### PR TITLE
Add Action for Releases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
+# The URL of the Devserver for the vite proxy during development
 VITE_BACKEND_URL=http://localhost:8237
+
+# The version of the UI to be displayed in the UI
+VITE_UI_VERSION=0.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release-pipeline
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Get the version from the github tag ref
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Install dependencies and build
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+        env:
+          VITE_UI_VERSION: ${{ steps.get_version.outputs.VERSION }}
+
+      - name: Create release archive
+        run: |
+          tar -zcf kitaru-ui.tar.gz -C dist --transform="s#\.\/##" .
+          sha256sum -b kitaru-ui.tar.gz > kitaru-ui.tar.gz.sha256
+
+      - name: Release to GitHub
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            kitaru-ui.tar.gz
+            kitaru-ui.tar.gz.sha256
+          body_path: ./CHANGELOG.md
+          prerelease: "true"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a action that publishes a GH-Release with the name of the tag that was pushed.

Also extends the Env by the `VITE_UI_VERSION` that gets created during the build of the artifact, to trace down which UI Version is used.