### PR TITLE
Add local testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,11 +216,10 @@ pnpm test:unit        # Run unit tests (Vitest)
 
 ### Local Integration Testing
 
-To test the UI against a real ZenML server locally:
+Two ways to test against a real server:
 
-1. Install the ZenML server from the `develop` branch: `./scripts/install-kitaru-branch.sh develop`
-2. Start the server: `zenml login --local`
-3. Start the UI: `pnpm dev` (proxies `/api` to `http://localhost:8237`)
+- **Dev server** (hot reload): `uv pip install "zenml[server]>=0.94.1"` → `zenml login --local` → `pnpm dev` (proxies `/api` to `http://localhost:8237`)
+- **Docker** (production-like): `pnpm build` → copy `dist/` to kitaru repo's `docker/kitaru-ui-dist/` → `just server-dev-image` → `docker run -p 8080:8080 kitaru-server-dev`
 
 See [TESTING.md](./TESTING.md) for the full step-by-step guide including troubleshooting.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ pnpm test:unit        # Run unit tests (Vitest)
 
 Two ways to test against a real server:
 
-- **Dev server** (hot reload): Clone kitaru repo → `uv sync --extra local` → `uv run kitaru login --local` → `pnpm dev` (proxies `/api` to `http://localhost:8237`)
+- **Dev server** (hot reload): Clone kitaru repo → `uv sync --extra local` → `uv run kitaru login` → `pnpm dev` (proxies `/api` to `http://localhost:8237`)
 - **Docker** (production-like): `pnpm build` → copy `dist/` to kitaru repo's `docker/kitaru-ui-dist/` → `just server-dev-image` → `docker run -p 8080:8080 kitaru-server-dev`
 
 See [TESTING.md](./TESTING.md) for the full step-by-step guide including troubleshooting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,24 @@ Keep both files accurate — stale docs erode trust faster than missing docs.
 - Good: "Add workflow to require release label on PRs"
 - Bad: "ci: add workflow to require release label on PRs"
 
+## Testing
+
+### Unit Tests
+
+```bash
+pnpm test:unit        # Run unit tests (Vitest)
+```
+
+### Local Integration Testing
+
+To test the UI against a real ZenML server locally:
+
+1. Install the ZenML server from the `develop` branch: `./scripts/install-kitaru-branch.sh develop`
+2. Start the server: `zenml login --local`
+3. Start the UI: `pnpm dev` (proxies `/api` to `http://localhost:8237`)
+
+See [TESTING.md](./TESTING.md) for the full step-by-step guide including troubleshooting.
+
 ## CI
 
 GitHub Actions (`.github/workflows/build-validation.yml`) runs on push to `main` and on all PRs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ pnpm test:unit        # Run unit tests (Vitest)
 
 Two ways to test against a real server:
 
-- **Dev server** (hot reload): `uv pip install "zenml[server]>=0.94.1"` → `zenml login --local` → `pnpm dev` (proxies `/api` to `http://localhost:8237`)
+- **Dev server** (hot reload): Clone kitaru repo → `uv sync --extra local` → `uv run kitaru login --local` → `pnpm dev` (proxies `/api` to `http://localhost:8237`)
 - **Docker** (production-like): `pnpm build` → copy `dist/` to kitaru repo's `docker/kitaru-ui-dist/` → `just server-dev-image` → `docker run -p 8080:8080 kitaru-server-dev`
 
 See [TESTING.md](./TESTING.md) for the full step-by-step guide including troubleshooting.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,44 +1,52 @@
 # Testing Kitaru UI Locally
 
-This guide walks you through testing the Kitaru UI against a local ZenML/Kitaru server. There are two approaches depending on what you need:
+This guide walks you through testing the Kitaru UI against a local Kitaru server. There are two approaches depending on what you need:
 
-- **Option A: Dev server** (hot reload, fastest iteration) — run `pnpm dev` and proxy to a local ZenML server
+- **Option A: Dev server** (hot reload, fastest iteration) — run `pnpm dev` and proxy to a local Kitaru server
 - **Option B: Docker** (production-like) — build the UI and bundle it into the Kitaru server image
 
 ## Prerequisites
 
 - Node.js (LTS)
 - [pnpm](https://pnpm.io/)
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for installing ZenML/Kitaru)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for installing Kitaru)
 - A Python virtual environment (recommended)
 
 ## Option A: Dev Server (Hot Reload)
 
-This is the fastest path for frontend development. The Vite dev server proxies `/api` requests to the ZenML backend.
+This is the fastest path for frontend development. The Vite dev server proxies `/api` requests to the Kitaru backend.
 
-### 1. Install the ZenML Server
+### 1. Install Kitaru with Server Extras
 
 ```bash
-# From any directory, with your Python venv active:
-uv pip install "zenml[server]>=0.94.1"
+# Clone the kitaru repo (if you haven't already)
+git clone https://github.com/zenml-io/kitaru.git
+cd kitaru
+
+# Install with server extras (pulls ZenML automatically)
+uv sync --extra local
 ```
 
-> **Testing against unreleased ZenML?** Use the helper script instead:
+> **Testing against a specific Kitaru branch?** Just check out that branch
+> before running `uv sync`:
 > ```bash
-> ./scripts/install-kitaru-branch.sh develop
+> git checkout feat/my-branch
+> uv sync --extra local
 > ```
 
-### 2. Start the ZenML Server
+### 2. Start the Kitaru Server
 
 ```bash
-zenml login --local
+uv run kitaru login --local
 ```
 
-This starts the ZenML server on `http://localhost:8237` by default.
+This starts the server on `http://localhost:8237` by default.
 
 ### 3. Start the Kitaru UI
 
 ```bash
+# From the kitaru-ui repo root
+
 # Install frontend dependencies (first time or after lockfile changes)
 pnpm install
 
@@ -49,13 +57,13 @@ cp .env.example .env
 pnpm dev
 ```
 
-The dev server starts at `http://localhost:5173` and proxies all `/api` requests to the ZenML backend at `VITE_BACKEND_URL` (defaults to `http://localhost:8237`).
+The dev server starts at `http://localhost:5173` and proxies all `/api` requests to the Kitaru backend at `VITE_BACKEND_URL` (defaults to `http://localhost:8237`).
 
-If your ZenML server is running on a different port, update `VITE_BACKEND_URL` in your `.env` file.
+If your server is running on a different port, update `VITE_BACKEND_URL` in your `.env` file.
 
 ### 4. Open the App
 
-Open `http://localhost:5173` in your browser. You should see the Kitaru UI connected to your local ZenML server.
+Open `http://localhost:5173` in your browser. You should see the Kitaru UI connected to your local server.
 
 ## Option B: Docker (Production-like)
 
@@ -108,7 +116,7 @@ When reporting a bug, include:
 
 | Problem | Fix |
 |---------|-----|
-| `ECONNREFUSED` on API calls | Make sure the ZenML server is running (`zenml login --local` for Option A, or check `docker ps` for Option B) |
+| `ECONNREFUSED` on API calls | Make sure the server is running (`uv run kitaru login --local` for Option A, or check `docker ps` for Option B) |
 | 401 errors / redirect to login | Your session may have expired — log in again through the UI |
 | Stale types or API mismatches | Regenerate types: `pnpm generate:types -- http://localhost:8237` |
 | UI not reflecting code changes | Hard-refresh the browser (`Cmd+Shift+R` / `Ctrl+Shift+R`) |

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,28 +1,34 @@
 # Testing Kitaru UI Locally
 
-This guide walks you through setting up the Kitaru UI against a local ZenML server so you can test features, log bugs, and give feedback.
+This guide walks you through testing the Kitaru UI against a local ZenML/Kitaru server. There are two approaches depending on what you need:
+
+- **Option A: Dev server** (hot reload, fastest iteration) — run `pnpm dev` and proxy to a local ZenML server
+- **Option B: Docker** (production-like) — build the UI and bundle it into the Kitaru server image
 
 ## Prerequisites
 
 - Node.js (LTS)
 - [pnpm](https://pnpm.io/)
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for installing the ZenML server)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for installing ZenML/Kitaru)
 - A Python virtual environment (recommended)
 
-## 1. Install the ZenML Server
+## Option A: Dev Server (Hot Reload)
 
-Install the ZenML server from the `develop` branch of the main ZenML repo. There is a helper script in this repository:
+This is the fastest path for frontend development. The Vite dev server proxies `/api` requests to the ZenML backend.
+
+### 1. Install the ZenML Server
 
 ```bash
-# From the kitaru-ui repo root
-./scripts/install-kitaru-branch.sh develop
+# From any directory, with your Python venv active:
+uv pip install "zenml[server]>=0.94.1"
 ```
 
-This runs `uv pip install` to install `zenml[dev,server,templates]` from the `develop` branch. Make sure you have a Python virtual environment active before running this.
+> **Testing against unreleased ZenML?** Use the helper script instead:
+> ```bash
+> ./scripts/install-kitaru-branch.sh develop
+> ```
 
-> **Note:** Use the `develop` branch — the older `kitaru` branch is outdated.
-
-## 2. Start the ZenML Server
+### 2. Start the ZenML Server
 
 ```bash
 zenml login --local
@@ -30,7 +36,7 @@ zenml login --local
 
 This starts the ZenML server on `http://localhost:8237` by default.
 
-## 3. Start the Kitaru UI
+### 3. Start the Kitaru UI
 
 ```bash
 # Install frontend dependencies (first time or after lockfile changes)
@@ -47,17 +53,49 @@ The dev server starts at `http://localhost:5173` and proxies all `/api` requests
 
 If your ZenML server is running on a different port, update `VITE_BACKEND_URL` in your `.env` file.
 
-## 4. Test the App
+### 4. Open the App
 
 Open `http://localhost:5173` in your browser. You should see the Kitaru UI connected to your local ZenML server.
 
-### What to look for
+## Option B: Docker (Production-like)
+
+This tests the UI as it would be served in production — bundled into the Kitaru server image, served by the ZenML FastAPI server on the same port as the API.
+
+### 1. Build the Kitaru UI
+
+```bash
+# From the kitaru-ui repo root
+pnpm install
+pnpm build
+```
+
+This creates a `dist/` directory with the production build.
+
+### 2. Copy the Build Output to the Kitaru Repo
+
+```bash
+cp -r dist/ /path/to/kitaru/docker/kitaru-ui-dist/
+```
+
+### 3. Build and Run the Dev Server Image
+
+```bash
+# From the kitaru repo root
+just server-dev-image
+docker run -p 8080:8080 kitaru-server-dev
+```
+
+### 4. Open the App
+
+Open `http://localhost:8080` in your browser. The UI and API are served on the same port, just like production.
+
+## What to Look For
 
 - **Bugs** — anything broken, unresponsive, or showing unexpected errors
 - **UX issues** — confusing flows, missing feedback, unclear labels
 - **Visual glitches** — layout problems, misaligned elements, theme issues
 
-### Reporting issues
+## Reporting Issues
 
 When reporting a bug, include:
 - Steps to reproduce
@@ -70,7 +108,8 @@ When reporting a bug, include:
 
 | Problem | Fix |
 |---------|-----|
-| `ECONNREFUSED` on API calls | Make sure the ZenML server is running (`zenml login --local`) |
+| `ECONNREFUSED` on API calls | Make sure the ZenML server is running (`zenml login --local` for Option A, or check `docker ps` for Option B) |
 | 401 errors / redirect to login | Your session may have expired — log in again through the UI |
 | Stale types or API mismatches | Regenerate types: `pnpm generate:types -- http://localhost:8237` |
 | UI not reflecting code changes | Hard-refresh the browser (`Cmd+Shift+R` / `Ctrl+Shift+R`) |
+| Docker build fails on missing `index.html` | Make sure you ran `pnpm build` and copied `dist/` to `docker/kitaru-ui-dist/` |

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,76 @@
+# Testing Kitaru UI Locally
+
+This guide walks you through setting up the Kitaru UI against a local ZenML server so you can test features, log bugs, and give feedback.
+
+## Prerequisites
+
+- Node.js (LTS)
+- [pnpm](https://pnpm.io/)
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) (for installing the ZenML server)
+- A Python virtual environment (recommended)
+
+## 1. Install the ZenML Server
+
+Install the ZenML server from the `develop` branch of the main ZenML repo. There is a helper script in this repository:
+
+```bash
+# From the kitaru-ui repo root
+./scripts/install-kitaru-branch.sh develop
+```
+
+This runs `uv pip install` to install `zenml[dev,server,templates]` from the `develop` branch. Make sure you have a Python virtual environment active before running this.
+
+> **Note:** Use the `develop` branch — the older `kitaru` branch is outdated.
+
+## 2. Start the ZenML Server
+
+```bash
+zenml login --local
+```
+
+This starts the ZenML server on `http://localhost:8237` by default.
+
+## 3. Start the Kitaru UI
+
+```bash
+# Install frontend dependencies (first time or after lockfile changes)
+pnpm install
+
+# Copy environment config (first time only)
+cp .env.example .env
+
+# Start the dev server
+pnpm dev
+```
+
+The dev server starts at `http://localhost:5173` and proxies all `/api` requests to the ZenML backend at `VITE_BACKEND_URL` (defaults to `http://localhost:8237`).
+
+If your ZenML server is running on a different port, update `VITE_BACKEND_URL` in your `.env` file.
+
+## 4. Test the App
+
+Open `http://localhost:5173` in your browser. You should see the Kitaru UI connected to your local ZenML server.
+
+### What to look for
+
+- **Bugs** — anything broken, unresponsive, or showing unexpected errors
+- **UX issues** — confusing flows, missing feedback, unclear labels
+- **Visual glitches** — layout problems, misaligned elements, theme issues
+
+### Reporting issues
+
+When reporting a bug, include:
+- Steps to reproduce
+- What you expected to happen
+- What actually happened
+- Browser and OS info
+- Screenshots or screen recordings if possible
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `ECONNREFUSED` on API calls | Make sure the ZenML server is running (`zenml login --local`) |
+| 401 errors / redirect to login | Your session may have expired — log in again through the UI |
+| Stale types or API mismatches | Regenerate types: `pnpm generate:types -- http://localhost:8237` |
+| UI not reflecting code changes | Hard-refresh the browser (`Cmd+Shift+R` / `Ctrl+Shift+R`) |

--- a/TESTING.md
+++ b/TESTING.md
@@ -37,7 +37,7 @@ uv sync --extra local
 ### 2. Start the Kitaru Server
 
 ```bash
-uv run kitaru login --local
+uv run kitaru login
 ```
 
 This starts the server on `http://localhost:8237` by default.
@@ -116,7 +116,7 @@ When reporting a bug, include:
 
 | Problem | Fix |
 |---------|-----|
-| `ECONNREFUSED` on API calls | Make sure the server is running (`uv run kitaru login --local` for Option A, or check `docker ps` for Option B) |
+| `ECONNREFUSED` on API calls | Make sure the server is running (`uv run kitaru login` for Option A, or check `docker ps` for Option B) |
 | 401 errors / redirect to login | Your session may have expired — log in again through the UI |
 | Stale types or API mismatches | Regenerate types: `pnpm generate:types -- http://localhost:8237` |
 | UI not reflecting code changes | Hard-refresh the browser (`Cmd+Shift+R` / `Ctrl+Shift+R`) |


### PR DESCRIPTION
## Summary

- Updates `TESTING.md` with two testing paths:
  - **Option A: Dev server** — install ZenML from PyPI (`zenml[server]>=0.94.1`), start server, run `pnpm dev` with hot reload
  - **Option B: Docker** — build UI, copy dist/ to kitaru repo, build `server-dev-image`, test production-like serving
- Updates `AGENTS.md` testing section with a compact summary of both paths
- Default install path now uses PyPI instead of git branch clone (ZenML 0.94.1 is released)
- Keeps `install-kitaru-branch.sh` as a fallback for testing against unreleased ZenML branches

## Test plan

- [ ] Verify Option A instructions work: `uv pip install "zenml[server]>=0.94.1"` → `zenml login --local` → `pnpm dev` → open `localhost:5173`
- [ ] Verify Option B instructions work: `pnpm build` → copy `dist/` → `just server-dev-image` → open `localhost:8080`
- [x] Confirm AGENTS.md renders correctly with the updated Testing section