### PR TITLE
fix: White artifact content

### DIFF
--- a/src/modules/checkpoints/feature/ArtifactVisualizationContainer.tsx
+++ b/src/modules/checkpoints/feature/ArtifactVisualizationContainer.tsx
@@ -10,5 +10,7 @@ export function ArtifactVisualizationContainer({
 }: ArtifactVisualizationContainerProps) {
 	const { visualizationData } = useArtifactVisualization(artifactVersionId);
 
-	return <VisualizationViewer artifact={visualizationData} />;
+	return (
+		<VisualizationViewer key={artifactVersionId} artifact={visualizationData} />
+	);
 }


### PR DESCRIPTION
## Summary

- Adds `key={artifactVersionId}` to `VisualizationViewer` inside `ArtifactVisualizationContainer` to force a remount when the artifact version changes
- Fixes a bug where switching between artifact versions would leave stale (white/blank) visualization content displayed

## Test plan

- [ ] Navigate to a run with multiple artifact versions
- [ ] Switch between artifact versions and verify the visualization updates correctly without showing blank/white content