### PR TITLE
Fix Nested Buttons

### DIFF
--- a/src/modules/checkpoints/feature/DownloadArtifactButtonContainer.tsx
+++ b/src/modules/checkpoints/feature/DownloadArtifactButtonContainer.tsx
@@ -1,6 +1,6 @@
-import { Download01 } from "@untitledui/icons";
 import { Button } from "@/shared/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { Download01 } from "@untitledui/icons";
 import { useDownloadArtifact } from "../business-logic/use-download-artifact";
 
 type Props = {
@@ -12,16 +12,18 @@ export function DownloadArtifactButtonContainer({ artifactVersionId }: Props) {
 
 	return (
 		<Tooltip>
-			<TooltipTrigger>
-				<Button
-					variant="ghost"
-					size="icon-sm"
-					disabled={isDownloading}
-					onClick={() => download(artifactVersionId)}
-				>
-					<Download01 className="text-foreground h-3.5 w-3.5" />
-					<span className="sr-only">Download artifact</span>
-				</Button>
+			<TooltipTrigger
+				render={
+					<Button
+						variant="ghost"
+						size="icon-sm"
+						disabled={isDownloading}
+						onClick={() => download(artifactVersionId)}
+					/>
+				}
+			>
+				<Download01 className="text-foreground h-3.5 w-3.5" />
+				<span className="sr-only">Download artifact</span>
 			</TooltipTrigger>
 			<TooltipContent>Download</TooltipContent>
 		</Tooltip>


### PR DESCRIPTION
tooltip trigger renders as a button, with a button as the child. This violates a11y for not nesting interactive elements