### PR TITLE
fix: Running filter includes all active statuses

### DIFF
--- a/src/modules/flows/business-logic/categorize-flow-status.ts
+++ b/src/modules/flows/business-logic/categorize-flow-status.ts
@@ -1,0 +1,32 @@
+import type { ExecutionStatus } from "@/modules/executions/domain/execution";
+import type { FlowStatusFilter } from "../domain/flow";
+
+const FLOW_ACTIVE_STATUSES: Set<ExecutionStatus> = new Set([
+	"initializing",
+	"provisioning",
+	"running",
+	"retrying",
+	"paused",
+	"resuming",
+	"stopping",
+]);
+
+const FLOW_FAILED_STATUSES: Set<ExecutionStatus> = new Set(["failed"]);
+
+const FLOW_COMPLETED_STATUSES: Set<ExecutionStatus> = new Set([
+	"completed",
+	"cached",
+	"skipped",
+	"stopped",
+	"retried",
+]);
+
+export function categorizeFlowStatus(
+	status: ExecutionStatus | undefined
+): FlowStatusFilter {
+	if (!status) return "all";
+	if (FLOW_ACTIVE_STATUSES.has(status)) return "running";
+	if (FLOW_FAILED_STATUSES.has(status)) return "failed";
+	if (FLOW_COMPLETED_STATUSES.has(status)) return "completed";
+	return "all";
+}

--- a/src/modules/flows/domain/flow.ts
+++ b/src/modules/flows/domain/flow.ts
@@ -22,18 +22,6 @@ export type Flow = {
 	createdAt?: Date;
 };
 
-export type FlowStatusFilterOption = {
-	label: string;
-	value: FlowStatusFilter;
-};
-
-export const flowStatusFilterOptions: FlowStatusFilterOption[] = [
-	{ label: "All", value: "all" },
-	{ label: "Running", value: "running" },
-	{ label: "Failed", value: "failed" },
-	{ label: "Completed", value: "completed" },
-];
-
 export function flowFromApiToDomain(
 	flow: components["schemas"]["PipelineResponse"]
 ): Flow {

--- a/src/modules/flows/feature/FlowsContainer.tsx
+++ b/src/modules/flows/feature/FlowsContainer.tsx
@@ -10,6 +10,7 @@ import {
 import { useRouter, useSearch } from "@tanstack/react-router";
 import { useMemo } from "react";
 import { useFlows } from "../business-logic/use-flows";
+import { categorizeFlowStatus } from "../business-logic/categorize-flow-status";
 import { FlowsToolbar } from "../ui/FlowsToolbar";
 import type { StatProps } from "../ui/Stat";
 import { Stats } from "../ui/Stats";
@@ -27,9 +28,10 @@ export function FlowsContainer() {
 
 	const statsCounts = flowsData.reduce(
 		(acc, flow) => {
-			if (flow.latestExecStatus === "running") acc.running++;
-			else if (flow.latestExecStatus === "failed") acc.failed++;
-			else if (flow.latestExecStatus === "completed") acc.completed++;
+			const category = categorizeFlowStatus(flow.latestExecStatus);
+			if (category === "running") acc.running++;
+			else if (category === "failed") acc.failed++;
+			else if (category === "completed") acc.completed++;
 			return acc;
 		},
 		{ running: 0, failed: 0, completed: 0 }
@@ -47,7 +49,9 @@ export function FlowsContainer() {
 
 		return flowsData.filter((flow) => {
 			const matchesStatus =
-				status === "all" ? true : flow.latestExecStatus === status;
+				status === "all"
+					? true
+					: categorizeFlowStatus(flow.latestExecStatus) === status;
 			const matchesSearch =
 				normalizedSearch.length === 0
 					? true


### PR DESCRIPTION
## Summary
- The "Running" filter on the Flows view now matches all active execution statuses (paused, initializing, provisioning, resuming, retrying, stopping) — not just the literal `"running"` status
- Both the stats counter and the filter use the new `categorizeFlowStatus` function
- Removed unused `FlowStatusFilterOption` type and `flowStatusFilterOptions` array

## Test plan
- [ ] Open Flows view with a flow whose latest execution is paused/initializing/resuming
- [ ] Verify the "Running" stat count includes it
- [ ] Verify the "Running" filter shows it