### PR TITLE
feat: Waiting timeline block

### DIFF
--- a/src/modules/executions/business-logic/executions-queries.ts
+++ b/src/modules/executions/business-logic/executions-queries.ts
@@ -35,6 +35,5 @@ export const executionsQueries = {
 		queryOptions({
 			queryKey: executionsQueryKeys.waitConditions(executionId),
 			queryFn: () => fetchWaitConditions(executionId),
-			staleTime: Infinity,
 		}),
 };

--- a/src/modules/executions/business-logic/executions-queries.ts
+++ b/src/modules/executions/business-logic/executions-queries.ts
@@ -2,6 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 import { fetchExecutions } from "../domain/fetch-executions";
 import { fetchExecution } from "../domain/fetch-execution";
 import { fetchWaitCondition } from "../domain/fetch-wait-condition";
+import { fetchWaitConditions } from "../domain/fetch-wait-conditions";
 
 export const executionsQueryKeys = {
 	base: ["executions"] as const,
@@ -10,6 +11,8 @@ export const executionsQueryKeys = {
 		[...executionsQueryKeys.base, "detail", executionId] as const,
 	waitCondition: (waitConditionId: string) =>
 		[...executionsQueryKeys.base, "waitCondition", waitConditionId] as const,
+	waitConditions: (executionId: string) =>
+		[...executionsQueryKeys.base, "waitConditions", executionId] as const,
 };
 
 export const executionsQueries = {
@@ -27,5 +30,11 @@ export const executionsQueries = {
 		queryOptions({
 			queryKey: executionsQueryKeys.waitCondition(waitConditionId),
 			queryFn: () => fetchWaitCondition(waitConditionId),
+		}),
+	waitConditions: (executionId: string) =>
+		queryOptions({
+			queryKey: executionsQueryKeys.waitConditions(executionId),
+			queryFn: () => fetchWaitConditions(executionId),
+			staleTime: Infinity,
 		}),
 };

--- a/src/modules/executions/business-logic/use-timeline-entries.ts
+++ b/src/modules/executions/business-logic/use-timeline-entries.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { TimelineEntry } from "../domain/waiting-block";
+import { buildTimelineEntries } from "../domain/build-timeline-entries";
+import { executionsQueries } from "./executions-queries";
+
+export function useTimelineEntries(
+	executionId: string,
+	checkpoints: CheckpointEntry[]
+) {
+	const { data: waitingBlocks } = useQuery({
+		...executionsQueries.waitConditions(executionId),
+	});
+
+	const timelineEntries = useMemo((): TimelineEntry[] => {
+		return buildTimelineEntries(checkpoints, waitingBlocks ?? []);
+	}, [checkpoints, waitingBlocks]);
+
+	return { timelineEntries };
+}

--- a/src/modules/executions/business-logic/use-timeline-entries.ts
+++ b/src/modules/executions/business-logic/use-timeline-entries.ts
@@ -1,7 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
 import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
-import type { TimelineEntry } from "../domain/waiting-block";
 import { buildTimelineEntries } from "../domain/build-timeline-entries";
 import { executionsQueries } from "./executions-queries";
 
@@ -13,9 +11,7 @@ export function useTimelineEntries(
 		...executionsQueries.waitConditions(executionId),
 	});
 
-	const timelineEntries = useMemo((): TimelineEntry[] => {
-		return buildTimelineEntries(checkpoints, waitingBlocks ?? []);
-	}, [checkpoints, waitingBlocks]);
-
-	return { timelineEntries };
+	return {
+		timelineEntries: buildTimelineEntries(checkpoints, waitingBlocks ?? []),
+	};
 }

--- a/src/modules/executions/domain/build-timeline-entries.spec.ts
+++ b/src/modules/executions/domain/build-timeline-entries.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { WaitingBlock } from "./waiting-block";
+import { buildTimelineEntries } from "./build-timeline-entries";
+
+function makeCheckpoint(id: string, startTime?: Date): CheckpointEntry {
+	return {
+		id,
+		name: `step_${id}`,
+		status: "completed",
+		startTime,
+	};
+}
+
+function makeWaitingBlock(id: string, createdAt?: Date): WaitingBlock {
+	return {
+		id,
+		question: `approve ${id}?`,
+		answer: "yes",
+		createdAt,
+	};
+}
+
+describe("buildTimelineEntries", () => {
+	it("returns checkpoints as-is when there are no waiting blocks", () => {
+		const checkpoints = [
+			makeCheckpoint("a", new Date("2024-01-01T10:00:00Z")),
+			makeCheckpoint("b", new Date("2024-01-01T11:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, []);
+
+		expect(result).toEqual([
+			{ kind: "checkpoint", data: checkpoints[0] },
+			{ kind: "checkpoint", data: checkpoints[1] },
+		]);
+	});
+
+	it("returns empty array when both inputs are empty", () => {
+		expect(buildTimelineEntries([], [])).toEqual([]);
+	});
+
+	it("inserts waiting block before the checkpoint it precedes", () => {
+		const checkpoints = [
+			makeCheckpoint("a", new Date("2024-01-01T10:00:00Z")),
+			makeCheckpoint("b", new Date("2024-01-01T12:00:00Z")),
+		];
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T11:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"waiting:w1",
+			"checkpoint:b",
+		]);
+	});
+
+	it("places multiple waiting blocks between checkpoints in order", () => {
+		const checkpoints = [
+			makeCheckpoint("a", new Date("2024-01-01T10:00:00Z")),
+			makeCheckpoint("b", new Date("2024-01-01T14:00:00Z")),
+		];
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T11:00:00Z")),
+			makeWaitingBlock("w2", new Date("2024-01-01T12:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"waiting:w1",
+			"waiting:w2",
+			"checkpoint:b",
+		]);
+	});
+
+	it("appends remaining waiting blocks after all checkpoints", () => {
+		const checkpoints = [makeCheckpoint("a", new Date("2024-01-01T10:00:00Z"))];
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T11:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"waiting:w1",
+		]);
+	});
+
+	it("handles waiting blocks without createdAt by keeping them after checkpoints", () => {
+		const checkpoints = [
+			makeCheckpoint("a", new Date("2024-01-01T10:00:00Z")),
+			makeCheckpoint("b", new Date("2024-01-01T12:00:00Z")),
+		];
+		const waitingBlocks = [makeWaitingBlock("w1")];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"checkpoint:b",
+			"waiting:w1",
+		]);
+	});
+
+	it("handles checkpoints without startTime by not interleaving waiting blocks before them", () => {
+		const checkpoints = [makeCheckpoint("a"), makeCheckpoint("b")];
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T11:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"checkpoint:b",
+			"waiting:w1",
+		]);
+	});
+
+	it("handles only waiting blocks with no checkpoints", () => {
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T10:00:00Z")),
+		];
+
+		const result = buildTimelineEntries([], waitingBlocks);
+
+		expect(result).toEqual([{ kind: "waiting", data: waitingBlocks[0] }]);
+	});
+
+	it("interleaves waiting blocks across multiple checkpoints", () => {
+		const checkpoints = [
+			makeCheckpoint("a", new Date("2024-01-01T10:00:00Z")),
+			makeCheckpoint("b", new Date("2024-01-01T12:00:00Z")),
+			makeCheckpoint("c", new Date("2024-01-01T14:00:00Z")),
+		];
+		const waitingBlocks = [
+			makeWaitingBlock("w1", new Date("2024-01-01T11:00:00Z")),
+			makeWaitingBlock("w2", new Date("2024-01-01T13:00:00Z")),
+			makeWaitingBlock("w3", new Date("2024-01-01T15:00:00Z")),
+		];
+
+		const result = buildTimelineEntries(checkpoints, waitingBlocks);
+
+		expect(result.map((e) => `${e.kind}:${e.data.id}`)).toEqual([
+			"checkpoint:a",
+			"waiting:w1",
+			"checkpoint:b",
+			"waiting:w2",
+			"checkpoint:c",
+			"waiting:w3",
+		]);
+	});
+});

--- a/src/modules/executions/domain/build-timeline-entries.ts
+++ b/src/modules/executions/domain/build-timeline-entries.ts
@@ -5,34 +5,23 @@ export function buildTimelineEntries(
 	checkpoints: CheckpointEntry[],
 	waitingBlocks: WaitingBlock[]
 ): TimelineEntry[] {
-	if (waitingBlocks.length === 0) {
-		return checkpoints.map((cp) => ({
-			kind: "checkpoint" as const,
-			data: cp,
-		}));
-	}
-
 	const entries: TimelineEntry[] = [];
-	const remainingBlocks = [...waitingBlocks];
+	let waitIdx = 0;
 
 	for (const checkpoint of checkpoints) {
-		while (remainingBlocks.length > 0) {
-			const block = remainingBlocks[0];
-			if (
-				block.createdAt &&
-				checkpoint.startTime &&
-				block.createdAt < checkpoint.startTime
-			) {
-				entries.push({ kind: "waiting", data: remainingBlocks.shift()! });
-			} else {
-				break;
-			}
+		while (
+			waitIdx < waitingBlocks.length &&
+			waitingBlocks[waitIdx].createdAt &&
+			checkpoint.startTime &&
+			waitingBlocks[waitIdx].createdAt! < checkpoint.startTime
+		) {
+			entries.push({ kind: "waiting", data: waitingBlocks[waitIdx++] });
 		}
 		entries.push({ kind: "checkpoint", data: checkpoint });
 	}
 
-	for (const block of remainingBlocks) {
-		entries.push({ kind: "waiting", data: block });
+	while (waitIdx < waitingBlocks.length) {
+		entries.push({ kind: "waiting", data: waitingBlocks[waitIdx++] });
 	}
 
 	return entries;

--- a/src/modules/executions/domain/build-timeline-entries.ts
+++ b/src/modules/executions/domain/build-timeline-entries.ts
@@ -1,0 +1,39 @@
+import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { TimelineEntry, WaitingBlock } from "./waiting-block";
+
+export function buildTimelineEntries(
+	checkpoints: CheckpointEntry[],
+	waitingBlocks: WaitingBlock[]
+): TimelineEntry[] {
+	if (waitingBlocks.length === 0) {
+		return checkpoints.map((cp) => ({
+			kind: "checkpoint" as const,
+			data: cp,
+		}));
+	}
+
+	const entries: TimelineEntry[] = [];
+	const remainingBlocks = [...waitingBlocks];
+
+	for (const checkpoint of checkpoints) {
+		while (remainingBlocks.length > 0) {
+			const block = remainingBlocks[0];
+			if (
+				block.createdAt &&
+				checkpoint.startTime &&
+				block.createdAt < checkpoint.startTime
+			) {
+				entries.push({ kind: "waiting", data: remainingBlocks.shift()! });
+			} else {
+				break;
+			}
+		}
+		entries.push({ kind: "checkpoint", data: checkpoint });
+	}
+
+	for (const block of remainingBlocks) {
+		entries.push({ kind: "waiting", data: block });
+	}
+
+	return entries;
+}

--- a/src/modules/executions/domain/fetch-wait-conditions.ts
+++ b/src/modules/executions/domain/fetch-wait-conditions.ts
@@ -45,6 +45,8 @@ export async function fetchWaitConditions(
 				id: item.id,
 				question: item.metadata?.question ?? "",
 				answer,
+				dataSchema: item.metadata?.data_schema ?? undefined,
+				result: item.metadata?.result ?? undefined,
 				waitDurationMs:
 					waitDurationMs && waitDurationMs > 0 ? waitDurationMs : undefined,
 				createdAt: created,

--- a/src/modules/executions/domain/fetch-wait-conditions.ts
+++ b/src/modules/executions/domain/fetch-wait-conditions.ts
@@ -1,0 +1,53 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+import { parseBackendTimestamp } from "@/shared/utils/time";
+import type { WaitingBlock } from "./waiting-block";
+
+export async function fetchWaitConditions(
+	executionId: string
+): Promise<WaitingBlock[]> {
+	const response = await apiClient.GET("/api/v1/run_wait_conditions", {
+		params: {
+			query: {
+				pipeline_run: `equals:${executionId}`,
+				status: `equals:resolved`,
+				sort_by: "asc:created",
+				hydrate: true,
+			},
+		},
+	});
+	const page = expectData(response);
+
+	return page.items
+		.filter((item) => item.body?.status === "resolved")
+		.map((item) => {
+			const created = item.body?.created
+				? parseBackendTimestamp(item.body.created)
+				: undefined;
+			const resolvedAt = item.body?.resolved_at
+				? parseBackendTimestamp(item.body.resolved_at)
+				: undefined;
+
+			const waitDurationMs =
+				created && resolvedAt
+					? resolvedAt.getTime() - created.getTime()
+					: undefined;
+
+			const result = item.metadata?.result;
+			const answer =
+				typeof result === "string"
+					? result
+					: result != null
+						? JSON.stringify(result)
+						: "";
+
+			return {
+				id: item.id,
+				question: item.metadata?.question ?? "",
+				answer,
+				waitDurationMs:
+					waitDurationMs && waitDurationMs > 0 ? waitDurationMs : undefined,
+				createdAt: created,
+			};
+		});
+}

--- a/src/modules/executions/domain/waiting-block.ts
+++ b/src/modules/executions/domain/waiting-block.ts
@@ -4,6 +4,8 @@ export type WaitingBlock = {
 	id: string;
 	question: string;
 	answer: string;
+	dataSchema?: Record<string, unknown>;
+	result?: unknown;
 	waitDurationMs?: number;
 	createdAt?: Date;
 };

--- a/src/modules/executions/domain/waiting-block.ts
+++ b/src/modules/executions/domain/waiting-block.ts
@@ -1,0 +1,13 @@
+import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+
+export type WaitingBlock = {
+	id: string;
+	question: string;
+	answer: string;
+	waitDurationMs?: number;
+	createdAt?: Date;
+};
+
+export type TimelineEntry =
+	| { kind: "checkpoint"; data: CheckpointEntry }
+	| { kind: "waiting"; data: WaitingBlock };

--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -3,6 +3,7 @@ import {
 	getCheckpointsPollingInterval,
 	useCheckpoints,
 } from "@/modules/checkpoints/business-logic/use-checkpoints";
+import { useTimelineEntries } from "../business-logic/use-timeline-entries";
 import { CheckpointDetailPanelContainer } from "@/modules/checkpoints/feature/CheckpointDetailPanelContainer";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import { CopyCommand } from "@/shared/ui/CopyCommand";
@@ -30,15 +31,24 @@ export function ExecutionContainer() {
 	const { flowId, executionId } = useParams({
 		from: "/_private/_navbar/flows/$flowId/executions/$executionId",
 	});
-	const { executionsData, refetch: refetchExecutions } = useExecutions(flowId, {refetchInterval: DEFAULT_EXECUTIONS_POLLING_INTERVAL});
+	const { executionsData, refetch: refetchExecutions } = useExecutions(flowId, {
+		refetchInterval: DEFAULT_EXECUTIONS_POLLING_INTERVAL,
+	});
 	const { executionData, refetch: refetchExecution } =
 		useExecution(executionId);
-	const { checkpointsData, refetch: refetchCheckpoints } =
-		useCheckpoints(executionId, {
+	const { checkpointsData, refetch: refetchCheckpoints } = useCheckpoints(
+		executionId,
+		{
 			refetchInterval: getCheckpointsPollingInterval,
-		});
+		}
+	);
 	const { waitConditionData } = useWaitCondition(
 		executionData?.activeWaitConditionEntry?.id
+	);
+
+	const { timelineEntries } = useTimelineEntries(
+		executionId,
+		checkpointsData.checkpoints
 	);
 
 	useSyncExecutionStatus(
@@ -53,6 +63,9 @@ export function ExecutionContainer() {
 		});
 		queryClient.invalidateQueries({
 			queryKey: executionsQueryKeys.detail(executionId),
+		});
+		queryClient.invalidateQueries({
+			queryKey: executionsQueryKeys.waitConditions(executionId),
 		});
 		queryClient.invalidateQueries({
 			queryKey: checkpointsQueryKeys.all(executionId),
@@ -134,7 +147,7 @@ export function ExecutionContainer() {
 				<ExecutionDetails
 					key={executionId}
 					execution={executionData}
-					checkpointsEntries={checkpointsData.checkpoints}
+					timelineEntries={timelineEntries}
 					onSelectCheckpoint={(id) => {
 						setSelectedCheckpointId(id);
 						layoutRef.current?.expandRight();

--- a/src/modules/executions/ui/ExecutionDetails.tsx
+++ b/src/modules/executions/ui/ExecutionDetails.tsx
@@ -9,13 +9,13 @@ import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
 import type { Execution } from "../domain/execution";
 import type { WaitCondition } from "../domain/wait-condition";
 import type { ResolveWaitConditionParams } from "../domain/resolve-wait-condition";
-import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { TimelineEntry } from "../domain/waiting-block";
 import { CheckpointThread } from "./traces/CheckpointThread";
 import { WaitInputSection } from "./WaitInputSection";
 
 type ExecutionDetailsProps = {
 	execution: Execution;
-	checkpointsEntries: CheckpointEntry[];
+	timelineEntries: TimelineEntry[];
 	onSelectCheckpoint: (id: string) => void;
 	waitCondition?: WaitCondition;
 	onResolveWaitCondition?: (params: ResolveWaitConditionParams) => void;
@@ -24,7 +24,7 @@ type ExecutionDetailsProps = {
 
 export function ExecutionDetails({
 	execution,
-	checkpointsEntries,
+	timelineEntries,
 	onSelectCheckpoint,
 	waitCondition,
 	onResolveWaitCondition,
@@ -60,7 +60,7 @@ export function ExecutionDetails({
 			</PageHeader>
 			<div className="flex-1 overflow-y-auto">
 				<CheckpointThread
-					checkpointsEntries={checkpointsEntries}
+					timelineEntries={timelineEntries}
 					onSelect={onSelectCheckpoint}
 				/>
 			</div>

--- a/src/modules/executions/ui/traces/CheckpointRow.tsx
+++ b/src/modules/executions/ui/traces/CheckpointRow.tsx
@@ -1,9 +1,7 @@
-import { useState } from "react";
 import { StatusDot } from "@/shared/ui/StatusDot";
 import { CheckpointTypeBadge } from "./CheckpointTypeBadge";
-import { ChevronRight } from "@untitledui/icons";
-import { cn } from "@/shared/utils/styles";
 import { CheckpointRowArtifacts } from "./CheckpointRowArtifacts";
+import { ExpandableRow } from "./ExpandableRow";
 import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
 import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
 
@@ -16,53 +14,29 @@ export function CheckpointRow({
 	checkpointEntry,
 	onSelect,
 }: CheckpointRowProps) {
-	const [isExpanded, setIsExpanded] = useState(false);
-
 	return (
-		<div
-			className={cn(
-				"bg-card relative overflow-hidden rounded-lg border transition-colors",
-				isExpanded
-					? "border-border bg-card"
-					: "border-border hover:bg-accent/30"
-			)}
-		>
-			<button
-				type="button"
-				className={cn(
-					"flex h-10 w-full cursor-pointer items-center gap-2 px-4 text-left",
-					isExpanded && "border-border border-b"
-				)}
-				onClick={() => {
-					onSelect(checkpointEntry.id);
-					setIsExpanded((prev) => !prev);
-				}}
-			>
-				<ChevronRight
-					className={cn(
-						"text-muted-foreground size-3.5 shrink-0 transition-transform",
-						isExpanded && "rotate-90"
+		<ExpandableRow
+			onToggle={() => onSelect(checkpointEntry.id)}
+			header={
+				<>
+					{checkpointEntry.type && (
+						<CheckpointTypeBadge type={checkpointEntry.type} />
 					)}
-				/>
-				{checkpointEntry.type && (
-					<CheckpointTypeBadge type={checkpointEntry.type} />
-				)}
-				<span className="text-foreground truncate font-mono text-xs font-semibold">
-					{checkpointEntry.name}
-				</span>
-				<span className="flex-1" />
-				<LiveDurationMs
-					status={checkpointEntry.status}
-					startTime={checkpointEntry.startTime}
-					durationMs={checkpointEntry.durationMs}
-					className="text-2xs text-muted-foreground font-mono tabular-nums"
-				/>
-				<StatusDot status={checkpointEntry.status} />
-			</button>
-
-			{isExpanded && (
-				<CheckpointRowArtifacts checkpointId={checkpointEntry.id} />
-			)}
-		</div>
+					<span className="text-foreground truncate font-mono text-xs font-semibold">
+						{checkpointEntry.name}
+					</span>
+					<span className="flex-1" />
+					<LiveDurationMs
+						status={checkpointEntry.status}
+						startTime={checkpointEntry.startTime}
+						durationMs={checkpointEntry.durationMs}
+						className="text-2xs text-muted-foreground font-mono tabular-nums"
+					/>
+					<StatusDot status={checkpointEntry.status} />
+				</>
+			}
+		>
+			<CheckpointRowArtifacts checkpointId={checkpointEntry.id} />
+		</ExpandableRow>
 	);
 }

--- a/src/modules/executions/ui/traces/CheckpointThread.tsx
+++ b/src/modules/executions/ui/traces/CheckpointThread.tsx
@@ -1,24 +1,29 @@
 import { CheckpointRow } from "./CheckpointRow";
-import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import { WaitingBlockRow } from "./WaitingBlockRow";
+import type { TimelineEntry } from "../../domain/waiting-block";
 
 interface CheckpointThreadProps {
-	checkpointsEntries: CheckpointEntry[];
+	timelineEntries: TimelineEntry[];
 	onSelect: (id: string) => void;
 }
 
 export function CheckpointThread({
-	checkpointsEntries,
+	timelineEntries,
 	onSelect,
 }: CheckpointThreadProps) {
 	return (
 		<div className="flex-1 space-y-3 overflow-y-auto p-6">
-			{checkpointsEntries.map((checkpointEntry) => (
-				<CheckpointRow
-					key={checkpointEntry.id}
-					checkpointEntry={checkpointEntry}
-					onSelect={onSelect}
-				/>
-			))}
+			{timelineEntries.map((entry) =>
+				entry.kind === "waiting" ? (
+					<WaitingBlockRow key={entry.data.id} waitingBlock={entry.data} />
+				) : (
+					<CheckpointRow
+						key={entry.data.id}
+						checkpointEntry={entry.data}
+						onSelect={onSelect}
+					/>
+				)
+			)}
 		</div>
 	);
 }

--- a/src/modules/executions/ui/traces/ContentCard.tsx
+++ b/src/modules/executions/ui/traces/ContentCard.tsx
@@ -1,0 +1,28 @@
+interface ContentCardProps {
+	title: string;
+	subtitle?: string;
+	action?: React.ReactNode;
+	children: React.ReactNode;
+}
+
+export function ContentCard({
+	title,
+	subtitle,
+	action,
+	children,
+}: ContentCardProps) {
+	return (
+		<div className="border-border overflow-hidden rounded-lg border">
+			<div className="bg-muted/50 border-border flex items-center gap-2 border-b px-4 py-2">
+				<span className="text-foreground truncate text-xs font-semibold">
+					{title}
+				</span>
+				{subtitle && (
+					<span className="text-2xs text-muted-foreground">{subtitle}</span>
+				)}
+				{action && <div className="ml-auto">{action}</div>}
+			</div>
+			<div className="bg-background">{children}</div>
+		</div>
+	);
+}

--- a/src/modules/executions/ui/traces/ExpandableRow.tsx
+++ b/src/modules/executions/ui/traces/ExpandableRow.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { cn } from "@/shared/utils/styles";
+import { ChevronRight } from "@untitledui/icons";
+
+type ExpandableRowProps = {
+	header: React.ReactNode;
+	children: React.ReactNode;
+	onToggle?: () => void;
+};
+
+export function ExpandableRow({
+	header,
+	children,
+	onToggle,
+}: ExpandableRowProps) {
+	const [isExpanded, setIsExpanded] = useState(false);
+
+	return (
+		<div
+			className={cn(
+				"bg-card relative overflow-hidden rounded-lg border transition-colors",
+				isExpanded
+					? "border-border bg-card"
+					: "border-border hover:bg-accent/30"
+			)}
+		>
+			<button
+				type="button"
+				className={cn(
+					"flex h-10 w-full cursor-pointer items-center gap-2 px-4 text-left",
+					isExpanded && "border-border border-b"
+				)}
+				onClick={() => {
+					setIsExpanded((prev) => !prev);
+					onToggle?.();
+				}}
+			>
+				<ChevronRight
+					className={cn(
+						"text-muted-foreground size-3.5 shrink-0 transition-transform",
+						isExpanded && "rotate-90"
+					)}
+				/>
+				{header}
+			</button>
+
+			{isExpanded && children}
+		</div>
+	);
+}

--- a/src/modules/executions/ui/traces/WaitingBlockRow.tsx
+++ b/src/modules/executions/ui/traces/WaitingBlockRow.tsx
@@ -1,6 +1,19 @@
+import { withTheme } from "@rjsf/core";
+import { Theme as shadcnTheme } from "@rjsf/shadcn";
+import validator from "@rjsf/validator-ajv8";
 import { CheckpointTypeBadge } from "./CheckpointTypeBadge";
+import { ContentCard } from "./ContentCard";
+import { ExpandableRow } from "./ExpandableRow";
 import { formatDurationShort } from "@/shared/utils/time";
 import type { WaitingBlock } from "../../domain/waiting-block";
+
+const Form = withTheme(shadcnTheme);
+
+const UI_SCHEMA = {
+	"ui:submitButtonOptions": { norender: true },
+	"ui:title": "",
+	"ui:description": "",
+};
 
 type WaitingBlockRowProps = {
 	waitingBlock: WaitingBlock;
@@ -8,11 +21,11 @@ type WaitingBlockRowProps = {
 
 export function WaitingBlockRow({ waitingBlock }: WaitingBlockRowProps) {
 	return (
-		<div className="border-warning/30 border-l-warning bg-card relative overflow-hidden rounded-lg border border-l-[3px]">
-			<div className="flex flex-col gap-1.5 px-4 py-2.5">
-				<div className="flex items-center gap-2">
+		<ExpandableRow
+			header={
+				<>
 					<CheckpointTypeBadge type="wait" />
-					<span className="text-foreground font-mono text-xs font-semibold">
+					<span className="text-foreground truncate font-mono text-xs font-semibold">
 						User Input
 					</span>
 					<span className="flex-1" />
@@ -21,17 +34,43 @@ export function WaitingBlockRow({ waitingBlock }: WaitingBlockRowProps) {
 							{formatDurationShort(waitingBlock.waitDurationMs)}
 						</span>
 					)}
-				</div>
+				</>
+			}
+		>
+			<div className="flex flex-col gap-3 px-4 py-4">
 				{waitingBlock.question && (
-					<p className="text-muted-foreground text-xs">
-						<span className="font-semibold">Q:</span> {waitingBlock.question}
-					</p>
+					<ContentCard title="Question">
+						<div className="px-5 py-4">
+							<p className="text-foreground text-sm leading-snug">
+								{waitingBlock.question}
+							</p>
+						</div>
+					</ContentCard>
 				)}
-				<p className="text-foreground truncate text-xs">
-					<span className="text-muted-foreground font-semibold">A:</span>{" "}
-					{waitingBlock.answer}
-				</p>
+				{waitingBlock.dataSchema ? (
+					<ContentCard title="Response">
+						<div className="px-5 py-4 text-xs [&_button]:text-xs [&_input]:text-xs [&_label]:text-xs">
+							<Form
+								schema={waitingBlock.dataSchema as object}
+								formData={waitingBlock.result}
+								validator={validator}
+								uiSchema={UI_SCHEMA}
+								readonly
+							/>
+						</div>
+					</ContentCard>
+				) : (
+					waitingBlock.answer && (
+						<ContentCard title="Response">
+							<div className="px-5 py-4">
+								<p className="text-foreground text-sm leading-snug">
+									{waitingBlock.answer}
+								</p>
+							</div>
+						</ContentCard>
+					)
+				)}
 			</div>
-		</div>
+		</ExpandableRow>
 	);
 }

--- a/src/modules/executions/ui/traces/WaitingBlockRow.tsx
+++ b/src/modules/executions/ui/traces/WaitingBlockRow.tsx
@@ -1,0 +1,37 @@
+import { CheckpointTypeBadge } from "./CheckpointTypeBadge";
+import { formatDurationShort } from "@/shared/utils/time";
+import type { WaitingBlock } from "../../domain/waiting-block";
+
+type WaitingBlockRowProps = {
+	waitingBlock: WaitingBlock;
+};
+
+export function WaitingBlockRow({ waitingBlock }: WaitingBlockRowProps) {
+	return (
+		<div className="border-warning/30 border-l-warning bg-card relative overflow-hidden rounded-lg border border-l-[3px]">
+			<div className="flex flex-col gap-1.5 px-4 py-2.5">
+				<div className="flex items-center gap-2">
+					<CheckpointTypeBadge type="wait" />
+					<span className="text-foreground font-mono text-xs font-semibold">
+						User Input
+					</span>
+					<span className="flex-1" />
+					{waitingBlock.waitDurationMs != null && (
+						<span className="text-2xs text-muted-foreground font-mono tabular-nums">
+							{formatDurationShort(waitingBlock.waitDurationMs)}
+						</span>
+					)}
+				</div>
+				{waitingBlock.question && (
+					<p className="text-muted-foreground text-xs">
+						<span className="font-semibold">Q:</span> {waitingBlock.question}
+					</p>
+				)}
+				<p className="text-foreground truncate text-xs">
+					<span className="text-muted-foreground font-semibold">A:</span>{" "}
+					{waitingBlock.answer}
+				</p>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

- Add waiting timeline blocks that show resolved wait condition interactions (question, response, wait duration) in the execution checkpoint timeline
- Fetch resolved wait conditions via the list API endpoint and merge them into the timeline by timestamp
- Response is rendered as a read-only `@rjsf/shadcn` form when a `dataSchema` is available, matching the active `WaitInputSection` form visually
- Extract shared `ExpandableRow` component used by both `CheckpointRow` and `WaitingBlockRow`

## New files

| File | Purpose |
|------|---------|
| `executions/domain/waiting-block.ts` | `WaitingBlock` + `TimelineEntry` types |
| `executions/domain/fetch-wait-conditions.ts` | Fetches resolved wait conditions for an execution |
| `executions/domain/build-timeline-entries.ts` | Merges checkpoints and waiting blocks by timestamp |
| `executions/business-logic/use-timeline-entries.ts` | Orchestration hook |
| `executions/ui/traces/ExpandableRow.tsx` | Shared expandable row shell |
| `executions/ui/traces/WaitingBlockRow.tsx` | Wait block UI with Question/Response cards |
| `executions/ui/traces/ContentCard.tsx` | Lightweight titled content section |

## Test plan

- [ ] Open an execution with resolved wait conditions — waiting blocks appear in timeline
- [ ] Expand a waiting block — shows Question card and Response card (read-only form if schema present, plain text otherwise)
- [ ] Checkpoint rows still expand/collapse and show detail panel
- [ ] Execution without wait conditions renders normally (no waiting blocks)