### PR TITLE
Improve checkpoint artifact filtering

### DIFF
--- a/src/modules/checkpoints/domain/checkpoint.spec.ts
+++ b/src/modules/checkpoints/domain/checkpoint.spec.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "@/shared/api/openapi";
+import { checkpointFromApiToDomain } from "./checkpoint";
+
+type ArtifactSaveType = components["schemas"]["ArtifactSaveType"];
+type StepRunInputArtifactType =
+	components["schemas"]["StepRunInputArtifactType"];
+
+function makeArtifactBody(
+	overrides: {
+		artifactName?: string;
+		saveType?: ArtifactSaveType;
+	} = {}
+): Record<string, unknown> {
+	const body: Record<string, unknown> = {
+		created: "2024-06-01T10:00:00Z",
+		updated: "2024-06-01T10:00:00Z",
+		project_id: "project-1",
+		version: "1",
+		uri: "s3://bucket/path",
+		type: "DataArtifact",
+		materializer: { module: "builtins", type: "internal" },
+		data_type: { module: "builtins", attribute: "str", type: "builtin" },
+		artifact: {
+			id: "artifact-id-1",
+			name: overrides.artifactName ?? "plain-artifact",
+		},
+	};
+
+	if (overrides.saveType !== undefined) {
+		body.save_type = overrides.saveType;
+	}
+
+	return body;
+}
+
+function makeInputArtifact(
+	overrides: {
+		id?: string;
+		artifactName?: string;
+		inputType?: StepRunInputArtifactType;
+		saveType?: ArtifactSaveType;
+	} = {}
+): components["schemas"]["StepRunInputResponse"] {
+	const result: Record<string, unknown> = {
+		id: overrides.id ?? "input-id-1",
+		body: makeArtifactBody({
+			artifactName: overrides.artifactName,
+			saveType: overrides.saveType,
+		}),
+	};
+
+	if (overrides.inputType !== undefined) {
+		result.input_type = overrides.inputType;
+	}
+
+	return result as unknown as components["schemas"]["StepRunInputResponse"];
+}
+
+function makeOutputArtifact(
+	overrides: {
+		id?: string;
+		artifactName?: string;
+		saveType?: ArtifactSaveType;
+	} = {}
+): components["schemas"]["ArtifactVersionResponse"] {
+	return {
+		id: overrides.id ?? "output-id-1",
+		body: makeArtifactBody({
+			artifactName: overrides.artifactName,
+			saveType: overrides.saveType,
+		}),
+	} as unknown as components["schemas"]["ArtifactVersionResponse"];
+}
+
+function makeCheckpoint(
+	overrides: {
+		inputs?: Record<string, unknown>;
+		outputs?: Record<string, unknown>;
+	} = {}
+): components["schemas"]["StepRunResponse"] {
+	return {
+		id: "checkpoint-id-1",
+		name: "checkpoint-name",
+		body: {
+			status: "completed",
+			start_time: "2024-06-01T10:00:00Z",
+			end_time: "2024-06-01T10:00:05Z",
+		},
+		resources: {
+			inputs: overrides.inputs,
+			outputs: overrides.outputs,
+		},
+	} as unknown as components["schemas"]["StepRunResponse"];
+}
+
+describe("checkpointFromApiToDomain", () => {
+	it("filters input artifacts using input_type semantics", () => {
+		const checkpoint = makeCheckpoint({
+			inputs: {
+				stepOutput: [
+					makeInputArtifact({
+						id: "step-output-id",
+						inputType: "step_output",
+						artifactName: "upstream-result",
+					}),
+				],
+				manual: [
+					makeInputArtifact({
+						id: "manual-id",
+						inputType: "manual",
+						artifactName: "manual-reference",
+					}),
+				],
+				external: [
+					makeInputArtifact({
+						id: "external-id",
+						inputType: "external",
+						artifactName: "ordinary-name",
+					}),
+				],
+				lazy: [
+					makeInputArtifact({
+						id: "lazy-id",
+						inputType: "lazy",
+						artifactName: "lazy-name",
+					}),
+				],
+			},
+		});
+
+		expect(checkpointFromApiToDomain(checkpoint).inputs).toEqual([
+			{ id: "step-output-id", name: "stepOutput" },
+			{ id: "manual-id", name: "manual" },
+		]);
+	});
+
+	it("filters output artifacts using save_type semantics", () => {
+		const checkpoint = makeCheckpoint({
+			outputs: {
+				stepOutput: [
+					makeOutputArtifact({
+						id: "step-output-id",
+						saveType: "step_output",
+						artifactName: "output-result",
+					}),
+				],
+				manual: [
+					makeOutputArtifact({
+						id: "manual-id",
+						saveType: "manual",
+						artifactName: "manual-result",
+					}),
+				],
+				external: [
+					makeOutputArtifact({
+						id: "external-id",
+						saveType: "external",
+						artifactName: "ordinary-name",
+					}),
+				],
+				preexisting: [
+					makeOutputArtifact({
+						id: "preexisting-id",
+						saveType: "preexisting",
+						artifactName: "preexisting-name",
+					}),
+				],
+			},
+		});
+
+		expect(checkpointFromApiToDomain(checkpoint).outputs).toEqual([
+			{ id: "step-output-id", name: "stepOutput" },
+			{ id: "manual-id", name: "manual" },
+		]);
+	});
+
+	it("keeps memory artifacts out of generic checkpoint chips", () => {
+		const checkpoint = makeCheckpoint({
+			inputs: {
+				memoryInput: [
+					makeInputArtifact({
+						id: "memory-input-id",
+						inputType: "manual",
+						artifactName: "kitaru_mem:repo_memory_demo:summaries/latest",
+					}),
+				],
+			},
+			outputs: {
+				memoryOutput: [
+					makeOutputArtifact({
+						id: "memory-output-id",
+						saveType: "manual",
+						artifactName: "kitaru_mem:repo_docs:sessions/topic_count",
+					}),
+				],
+			},
+		});
+
+		const mapped = checkpointFromApiToDomain(checkpoint);
+		expect(mapped.inputs).toEqual([]);
+		expect(mapped.outputs).toEqual([]);
+	});
+
+	it("treats external_ as a fallback heuristic, not the primary rule", () => {
+		const checkpoint = makeCheckpoint({
+			inputs: {
+				manualNamedExternal: [
+					makeInputArtifact({
+						id: "manual-visible-id",
+						inputType: "manual",
+						saveType: "manual",
+						artifactName: "external_report",
+					}),
+				],
+				fallbackHidden: [
+					makeInputArtifact({
+						id: "fallback-hidden-id",
+						saveType: "manual",
+						artifactName: "external_fallback",
+					}),
+				],
+			},
+			outputs: {
+				manualNamedExternal: [
+					makeOutputArtifact({
+						id: "manual-output-id",
+						saveType: "manual",
+						artifactName: "external_summary",
+					}),
+				],
+				fallbackHidden: [
+					makeOutputArtifact({
+						id: "fallback-output-hidden-id",
+						artifactName: "external_blob",
+					}),
+				],
+			},
+		});
+
+		const mapped = checkpointFromApiToDomain(checkpoint);
+
+		expect(mapped.inputs).toEqual([
+			{ id: "manual-visible-id", name: "manualNamedExternal" },
+		]);
+		expect(mapped.outputs).toEqual([
+			{ id: "manual-output-id", name: "manualNamedExternal" },
+		]);
+	});
+
+	it("uses visible indexes after filtering when naming artifact chips", () => {
+		const singleVisibleCheckpoint = makeCheckpoint({
+			outputs: {
+				result: [
+					makeOutputArtifact({
+						id: "hidden-memory-id",
+						saveType: "manual",
+						artifactName: "kitaru_mem:repo_docs:sessions/topic_count",
+					}),
+					makeOutputArtifact({
+						id: "visible-output-id",
+						saveType: "step_output",
+						artifactName: "visible-output",
+					}),
+				],
+			},
+		});
+
+		expect(checkpointFromApiToDomain(singleVisibleCheckpoint).outputs).toEqual([
+			{ id: "visible-output-id", name: "result" },
+		]);
+
+		const multiVisibleCheckpoint = makeCheckpoint({
+			outputs: {
+				result: [
+					makeOutputArtifact({
+						id: "hidden-external-id",
+						saveType: "external",
+						artifactName: "ordinary-hidden-name",
+					}),
+					makeOutputArtifact({
+						id: "visible-output-id-1",
+						saveType: "step_output",
+						artifactName: "visible-one",
+					}),
+					makeOutputArtifact({
+						id: "visible-output-id-2",
+						saveType: "manual",
+						artifactName: "visible-two",
+					}),
+				],
+			},
+		});
+
+		expect(checkpointFromApiToDomain(multiVisibleCheckpoint).outputs).toEqual([
+			{ id: "visible-output-id-1", name: "result[0]" },
+			{ id: "visible-output-id-2", name: "result[1]" },
+		]);
+	});
+
+	it("ignores malformed input and output entries safely", () => {
+		const checkpoint = makeCheckpoint({
+			inputs: {
+				notAnArray: "oops",
+				malformed: [
+					{ id: "missing-name", body: { artifact: {} } },
+					{ body: { artifact: { name: "missing-id" } } },
+				],
+				good: [
+					makeInputArtifact({
+						id: "good-input-id",
+						inputType: "step_output",
+						artifactName: "good-input",
+					}),
+				],
+			},
+			outputs: {
+				bad: [{ id: "missing-body" }],
+				good: [
+					makeOutputArtifact({
+						id: "good-output-id",
+						saveType: "step_output",
+						artifactName: "good-output",
+					}),
+				],
+			},
+		});
+
+		expect(() => checkpointFromApiToDomain(checkpoint)).not.toThrow();
+		expect(checkpointFromApiToDomain(checkpoint).inputs).toEqual([
+			{ id: "good-input-id", name: "good" },
+		]);
+		expect(checkpointFromApiToDomain(checkpoint).outputs).toEqual([
+			{ id: "good-output-id", name: "good" },
+		]);
+	});
+});

--- a/src/modules/checkpoints/domain/checkpoint.ts
+++ b/src/modules/checkpoints/domain/checkpoint.ts
@@ -1,6 +1,7 @@
 import type { components } from "@/shared/api/openapi";
 import type { ExecutionStatus } from "@/modules/executions/domain/execution";
 import { parseMemoryArtifactName } from "@/modules/memory/domain/memory";
+import { isRecord } from "@/shared/utils/is-record";
 import { parseBackendTimestamp } from "@/shared/utils/time";
 
 export type ArtifactEntry = {
@@ -21,6 +22,27 @@ export type Checkpoint = {
 	outputs: ArtifactEntry[];
 };
 
+type ArtifactDirection = "input" | "output";
+type ArtifactSaveType = components["schemas"]["ArtifactSaveType"];
+type StepRunInputArtifactType =
+	components["schemas"]["StepRunInputArtifactType"];
+
+type ArtifactCandidate = {
+	id: string;
+	artifactName: string;
+	saveType?: ArtifactSaveType;
+	inputType?: StepRunInputArtifactType;
+};
+
+const visibleInputTypes = new Set<StepRunInputArtifactType>([
+	"manual",
+	"step_output",
+]);
+const visibleOutputSaveTypes = new Set<ArtifactSaveType>([
+	"manual",
+	"step_output",
+]);
+
 export function checkpointFromApiToDomain(
 	checkpoint: components["schemas"]["StepRunResponse"]
 ): Checkpoint {
@@ -28,8 +50,8 @@ export function checkpointFromApiToDomain(
 		id: checkpoint.id,
 		name: checkpoint.name,
 		status: checkpoint.body?.status || undefined,
-		inputs: extractArtifactEntries(checkpoint.resources?.inputs),
-		outputs: extractArtifactEntries(checkpoint.resources?.outputs),
+		inputs: extractInputArtifactEntries(checkpoint.resources?.inputs),
+		outputs: extractOutputArtifactEntries(checkpoint.resources?.outputs),
 		startTime: checkpoint.body?.start_time
 			? parseBackendTimestamp(checkpoint.body.start_time)
 			: undefined,
@@ -48,30 +70,109 @@ export function checkpointFromApiToDomain(
 	};
 }
 
-function isExternalArtifact(
-	v: components["schemas"]["ArtifactVersionResponse"]
-): boolean {
-	const name = v.body?.artifact?.name;
-	if (!name) return false;
-	return (
-		parseMemoryArtifactName(name) !== undefined || name.startsWith("external_")
-	);
+function extractInputArtifactEntries(
+	record: Record<string, unknown> | undefined
+): ArtifactEntry[] {
+	return extractArtifactEntries(record, "input");
+}
+
+function extractOutputArtifactEntries(
+	record: Record<string, unknown> | undefined
+): ArtifactEntry[] {
+	return extractArtifactEntries(record, "output");
 }
 
 function extractArtifactEntries(
-	record: Record<string, unknown> | undefined
+	record: Record<string, unknown> | undefined,
+	direction: ArtifactDirection
 ): ArtifactEntry[] {
 	if (!record) return [];
 	return Object.entries(record).flatMap(([name, value]) => {
-		const versions =
-			value as components["schemas"]["ArtifactVersionResponse"][];
-		if (!Array.isArray(versions)) return [];
-		return versions.flatMap((v, index) => {
-			if (!v.id || isExternalArtifact(v)) return [];
-			const entryName = versions.length > 1 ? `${name}[${index}]` : name;
-			return [{ name: entryName, id: v.id }];
+		if (!Array.isArray(value)) return [];
+
+		const visibleCandidates = value.flatMap((entry) => {
+			const candidate = toArtifactCandidate(entry, direction);
+			if (!candidate || !shouldIncludeArtifact(candidate, direction)) {
+				return [];
+			}
+			return [candidate];
 		});
+
+		return visibleCandidates.map((candidate, visibleIndex) => ({
+			name: visibleCandidates.length === 1 ? name : `${name}[${visibleIndex}]`,
+			id: candidate.id,
+		}));
 	});
+}
+
+function toArtifactCandidate(
+	value: unknown,
+	direction: ArtifactDirection
+): ArtifactCandidate | undefined {
+	if (!isRecord(value)) return undefined;
+
+	const id = getNonEmptyString(value.id);
+	const body = isRecord(value.body) ? value.body : undefined;
+	const artifact = body && isRecord(body.artifact) ? body.artifact : undefined;
+	const artifactName = artifact ? getNonEmptyString(artifact.name) : undefined;
+
+	if (!id || !artifactName) return undefined;
+
+	return {
+		id,
+		artifactName,
+		saveType: parseArtifactSaveType(body?.save_type),
+		inputType:
+			direction === "input"
+				? parseInputArtifactType(value.input_type)
+				: undefined,
+	};
+}
+
+function shouldIncludeArtifact(
+	candidate: ArtifactCandidate,
+	direction: ArtifactDirection
+): boolean {
+	if (parseMemoryArtifactName(candidate.artifactName) !== undefined) {
+		return false;
+	}
+
+	if (direction === "input") {
+		if (candidate.inputType !== undefined) {
+			return visibleInputTypes.has(candidate.inputType);
+		}
+		return !candidate.artifactName.startsWith("external_");
+	}
+
+	if (candidate.saveType !== undefined) {
+		return visibleOutputSaveTypes.has(candidate.saveType);
+	}
+
+	return !candidate.artifactName.startsWith("external_");
+}
+
+function parseArtifactSaveType(value: unknown): ArtifactSaveType | undefined {
+	return value === "external" ||
+		value === "manual" ||
+		value === "preexisting" ||
+		value === "step_output"
+		? value
+		: undefined;
+}
+
+function parseInputArtifactType(
+	value: unknown
+): StepRunInputArtifactType | undefined {
+	return value === "external" ||
+		value === "lazy" ||
+		value === "manual" ||
+		value === "step_output"
+		? value
+		: undefined;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 export type CheckpointEntry = {

--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useReducer, useState } from "react";
 import {
 	getCheckpointDetailsPollingInterval,
 	useCheckpointDetails,
@@ -18,6 +18,26 @@ import { CheckpointDetailsEmptyView } from "../ui/CheckpointDetailsEmptyView";
 type CheckpointDetailPanelContainerProps = {
 	checkpointId?: string;
 };
+
+type SelectedArtifact = {
+	artifact: ArtifactEntry;
+	direction: "input" | "output";
+};
+
+const emptyArtifactEntries: ArtifactEntry[] = [];
+
+type SelectedArtifactAction =
+	| {
+			type: "select";
+			artifact: ArtifactEntry;
+			direction: "input" | "output";
+	  }
+	| {
+			type: "sync";
+			activeTab: PanelTab;
+			inputs: ArtifactEntry[];
+			outputs: ArtifactEntry[];
+	  };
 
 export function CheckpointDetailPanelContainer({
 	checkpointId,
@@ -42,26 +62,26 @@ function CheckpointDetailPanelContentContainer({
 		refetchInterval: getCheckpointDetailsPollingInterval,
 	});
 
-	const inputs = detailsData?.inputs ?? [];
-	const outputs = detailsData?.outputs ?? [];
+	const inputs = detailsData?.inputs ?? emptyArtifactEntries;
+	const outputs = detailsData?.outputs ?? emptyArtifactEntries;
 
 	const [activeTab, setActiveTab] = useState<PanelTab>("checkpoint");
-	const [selectedArtifact, setSelectedArtifact] = useState<{
-		artifact: ArtifactEntry;
-		direction: "input" | "output";
-	} | null>(null);
+	const [selectedArtifact, dispatchSelectedArtifact] = useReducer(
+		selectedArtifactReducer,
+		null
+	);
+
+	useEffect(() => {
+		dispatchSelectedArtifact({
+			type: "sync",
+			activeTab,
+			inputs,
+			outputs,
+		});
+	}, [activeTab, inputs, outputs]);
 
 	function handleTabChange(tab: PanelTab) {
 		setActiveTab(tab);
-		if (tab === "artifacts" && !selectedArtifact) {
-			const first = outputs[0] ?? inputs[0];
-			if (first) {
-				setSelectedArtifact({
-					artifact: first,
-					direction: outputs[0] ? "output" : "input",
-				});
-			}
-		}
 	}
 
 	return (
@@ -81,7 +101,11 @@ function CheckpointDetailPanelContentContainer({
 						outputs={outputs}
 						selectedArtifact={selectedArtifact}
 						onSelectArtifact={(artifact, direction) =>
-							setSelectedArtifact({ artifact, direction })
+							dispatchSelectedArtifact({
+								type: "select",
+								artifact,
+								direction,
+							})
 						}
 					/>
 				)}
@@ -92,5 +116,64 @@ function CheckpointDetailPanelContentContainer({
 				)}
 			</div>
 		</div>
+	);
+}
+
+function getDefaultSelectedArtifact(
+	inputs: ArtifactEntry[],
+	outputs: ArtifactEntry[]
+): SelectedArtifact | null {
+	const firstOutput = outputs[0];
+	if (firstOutput) {
+		return {
+			artifact: firstOutput,
+			direction: "output",
+		};
+	}
+
+	const firstInput = inputs[0];
+	if (firstInput) {
+		return {
+			artifact: firstInput,
+			direction: "input",
+		};
+	}
+
+	return null;
+}
+
+function selectedArtifactReducer(
+	selectedArtifact: SelectedArtifact | null,
+	action: SelectedArtifactAction
+): SelectedArtifact | null {
+	if (action.type === "select") {
+		return {
+			artifact: action.artifact,
+			direction: action.direction,
+		};
+	}
+
+	if (
+		selectedArtifact &&
+		isArtifactVisible(selectedArtifact, action.inputs, action.outputs)
+	) {
+		return selectedArtifact;
+	}
+
+	if (action.activeTab === "artifacts") {
+		return getDefaultSelectedArtifact(action.inputs, action.outputs);
+	}
+
+	return null;
+}
+
+function isArtifactVisible(
+	selectedArtifact: SelectedArtifact,
+	inputs: ArtifactEntry[],
+	outputs: ArtifactEntry[]
+): boolean {
+	const candidates = selectedArtifact.direction === "output" ? outputs : inputs;
+	return candidates.some(
+		(artifact) => artifact.id === selectedArtifact.artifact.id
 	);
 }

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
@@ -31,15 +31,28 @@ export function CheckpointDetailPanelArtifacts({
 	selectedArtifact,
 	onSelectArtifact,
 }: CheckpointDetailPanelArtifactsProps) {
+	const hasVisibleArtifacts = inputs.length > 0 || outputs.length > 0;
+
 	return (
 		<div className="flex h-full flex-col">
-			<ArtifactsToolbar
-				inputs={inputs}
-				outputs={outputs}
-				selectedArtifact={selectedArtifact}
-				onSelectArtifact={onSelectArtifact}
-			/>
-			{selectedArtifact ? (
+			{hasVisibleArtifacts && (
+				<ArtifactsToolbar
+					inputs={inputs}
+					outputs={outputs}
+					selectedArtifact={selectedArtifact}
+					onSelectArtifact={onSelectArtifact}
+				/>
+			)}
+			{!hasVisibleArtifacts ? (
+				<div className="flex flex-1 flex-col items-center justify-center gap-1 p-4 text-center">
+					<p className="text-foreground text-xs font-medium">
+						No checkpoint artifacts to show here.
+					</p>
+					<p className="text-muted-foreground text-xs">
+						Memory artifacts are available in the Memory tab.
+					</p>
+				</div>
+			) : selectedArtifact ? (
 				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
 					<div className="bg-muted/50 flex items-center justify-between px-4 py-2">
 						<span className="text-foreground truncate text-xs font-semibold">


### PR DESCRIPTION
## Summary
- tighten checkpoint artifact filtering to use backend semantics instead of mostly relying on artifact-name prefixes
- filter checkpoint inputs by `StepRunInputResponse.input_type` and outputs by artifact `save_type`
- keep memory-storage artifacts out of generic checkpoint artifact chips so they continue to live in the Memory UI
- add focused mapper tests plus small artifact-panel cleanup for empty-state/selection behavior

## Why
Before this change, the checkpoint artifact mapper mainly filtered artifacts by name heuristics such as `external_*` and `kitaru_mem:*`.

That worked as a rough stopgap, but it was too blunt:
- semantically external artifacts with ordinary names could still leak into the generic checkpoint artifact UI
- non-external artifacts with names starting with `external_` could be hidden even when they were valid user-facing artifacts
- synthetic memory-step plumbing was not being filtered using the richer semantics already available from the API payload

This change keeps the scope narrow and focused on the checkpoint artifact mapper while making the filtering behavior match the backend model more closely.

## What changed
- split checkpoint artifact extraction into input/output-specific paths in `checkpoint.ts`
- use `input_type` as the primary signal for input visibility
- use `save_type` as the primary signal for output visibility
- retain `kitaru_mem:*` filtering so memory artifacts stay in the dedicated Memory tab
- keep `external_*` as a compatibility fallback only when semantic metadata is unavailable
- make artifact chip numbering reflect the visible artifacts after filtering
- add a clearer empty state when a checkpoint has no generic artifacts to show
- keep artifact selection coherent when the filtered artifact list changes

## Impact
This makes the checkpoint artifact panel more targeted: it hides runtime plumbing more reliably while preserving user-meaningful checkpoint artifacts. Memory artifacts remain available in the Memory tab rather than appearing in the generic checkpoint artifact chips.

## Validation
- `pnpm exec eslint src/modules/checkpoints/domain/checkpoint.ts src/modules/checkpoints/domain/checkpoint.spec.ts src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx`
- `pnpm test:unit -- --run src/modules/checkpoints/domain/checkpoint.spec.ts`
