### PR TITLE
Use composite scope identity to prevent Flow Memory scope collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs/superpowers
 
 *storybook.log
 storybook-static
+
+design/

--- a/src/modules/memory/business-logic/memory-operations.spec.ts
+++ b/src/modules/memory/business-logic/memory-operations.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { MemoryEntry } from "../domain/memory";
 import {
+	deriveScopesFromEntries,
 	dedupeMemoryEntries,
 	snapshotMemoryEntriesAtTime,
 } from "./memory-operations";
@@ -18,6 +19,35 @@ function makeEntry(overrides: Partial<MemoryEntry> = {}): MemoryEntry {
 		...overrides,
 	};
 }
+
+describe("deriveScopesFromEntries", () => {
+	it("keeps flow and namespace scopes separate when they share the same name", () => {
+		const scopes = deriveScopesFromEntries(
+			[
+				makeEntry({ scope: "coding_agent", scopeType: "namespace" }),
+				makeEntry({ scope: "coding_agent", scopeType: "flow" }),
+			],
+			"coding_agent"
+		);
+
+		expect(scopes).toEqual([
+			{ scope: "coding_agent", scopeType: "flow", entryCount: 1 },
+			{ scope: "coding_agent", scopeType: "namespace", entryCount: 1 },
+		]);
+	});
+
+	it("still adds the flow scope when only a same-named namespace scope exists", () => {
+		const scopes = deriveScopesFromEntries(
+			[makeEntry({ scope: "coding_agent", scopeType: "namespace" })],
+			"coding_agent"
+		);
+
+		expect(scopes).toEqual([
+			{ scope: "coding_agent", scopeType: "flow", entryCount: 0 },
+			{ scope: "coding_agent", scopeType: "namespace", entryCount: 1 },
+		]);
+	});
+});
 
 describe("dedupeMemoryEntries", () => {
 	it("keeps the newest version per key (first in newest-first input)", () => {

--- a/src/modules/memory/business-logic/memory-operations.ts
+++ b/src/modules/memory/business-logic/memory-operations.ts
@@ -1,47 +1,38 @@
 import {
 	isCompactionKey,
+	memoryScopeIdentityKey,
 	SCOPE_TYPE_SORT_ORDER,
 	type MemoryEntry,
-	type MemoryScopeType,
 	type MemoryScopeInfo,
 } from "../domain/memory";
 
 export function deriveScopesFromEntries(
-	namespaceEntries: MemoryEntry[],
-	flowEntries: MemoryEntry[],
-	executionEntries: MemoryEntry[],
+	entries: MemoryEntry[],
 	flowName: string
 ): MemoryScopeInfo[] {
-	const scopeMap = new Map<
-		string,
-		{ scopeType: MemoryScopeType; entryCount: number }
-	>();
+	const scopeMap = new Map<string, MemoryScopeInfo>();
 
-	for (const entry of [
-		...namespaceEntries,
-		...flowEntries,
-		...executionEntries,
-	]) {
-		const existing = scopeMap.get(entry.scope);
+	for (const entry of entries) {
+		const scopeKey = memoryScopeIdentityKey(entry);
+		const existing = scopeMap.get(scopeKey);
 		if (existing) {
 			existing.entryCount++;
 		} else {
-			scopeMap.set(entry.scope, {
+			scopeMap.set(scopeKey, {
+				scope: entry.scope,
 				scopeType: entry.scopeType,
 				entryCount: 1,
 			});
 		}
 	}
 
-	const scopes: MemoryScopeInfo[] = Array.from(scopeMap.entries()).map(
-		([scope, info]) => ({
-			scope,
-			scopeType: info.scopeType,
-			entryCount: info.entryCount,
-		})
-	);
+	const scopes = Array.from(scopeMap.values());
 
-	if (!scopes.some((s) => s.scope === flowName)) {
+	if (
+		!scopeMap.has(
+			memoryScopeIdentityKey({ scope: flowName, scopeType: "flow" })
+		)
+	) {
 		scopes.push({ scope: flowName, scopeType: "flow", entryCount: 0 });
 	}
 

--- a/src/modules/memory/business-logic/memory-queries.spec.ts
+++ b/src/modules/memory/business-logic/memory-queries.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { memoryQueries, memoryQueryKeys } from "./memory-queries";
+
+vi.mock("../domain/fetch-namespace-memories", () => ({
+	fetchNamespaceMemories: vi.fn(),
+}));
+
+vi.mock("../domain/fetch-flow-memories", () => ({
+	fetchFlowMemories: vi.fn(),
+}));
+
+vi.mock("../domain/fetch-execution-memories", () => ({
+	fetchExecutionMemories: vi.fn(),
+}));
+
+vi.mock("../domain/fetch-single-execution-memories", () => ({
+	fetchSingleExecutionMemories: vi.fn(),
+}));
+
+vi.mock("../domain/fetch-memory-history", () => ({
+	fetchMemoryHistory: vi.fn(),
+}));
+
+describe("memoryQueryKeys.history", () => {
+	it("distinguishes scopes that share a name but not a scope type", () => {
+		expect(
+			memoryQueryKeys.history(
+				{ scope: "coding_agent", scopeType: "flow" },
+				"counter"
+			)
+		).not.toEqual(
+			memoryQueryKeys.history(
+				{ scope: "coding_agent", scopeType: "namespace" },
+				"counter"
+			)
+		);
+	});
+});
+
+describe("memoryQueries.history", () => {
+	it("includes the scope type in the query key", () => {
+		const query = memoryQueries.history(
+			{ scope: "coding_agent", scopeType: "flow" },
+			"counter"
+		);
+
+		expect(query.queryKey).toEqual([
+			"memory",
+			"history",
+			"flow",
+			"coding_agent",
+			"counter",
+		]);
+	});
+});

--- a/src/modules/memory/business-logic/memory-queries.ts
+++ b/src/modules/memory/business-logic/memory-queries.ts
@@ -4,6 +4,7 @@ import { fetchFlowMemories } from "../domain/fetch-flow-memories";
 import { fetchExecutionMemories } from "../domain/fetch-execution-memories";
 import { fetchSingleExecutionMemories } from "../domain/fetch-single-execution-memories";
 import { fetchMemoryHistory } from "../domain/fetch-memory-history";
+import type { MemoryScopeIdentity } from "../domain/memory";
 
 export const memoryQueryKeys = {
 	base: ["memory"] as const,
@@ -14,8 +15,14 @@ export const memoryQueryKeys = {
 		[...memoryQueryKeys.base, "executions", flowId] as const,
 	execution: (executionId: string) =>
 		[...memoryQueryKeys.base, "execution", executionId] as const,
-	history: (scope: string, key: string) =>
-		[...memoryQueryKeys.base, "history", scope, key] as const,
+	history: (scope: MemoryScopeIdentity, key: string) =>
+		[
+			...memoryQueryKeys.base,
+			"history",
+			scope.scopeType,
+			scope.scope,
+			key,
+		] as const,
 };
 
 export const memoryQueries = {
@@ -39,7 +46,7 @@ export const memoryQueries = {
 			queryKey: memoryQueryKeys.execution(executionId),
 			queryFn: () => fetchSingleExecutionMemories(executionId),
 		}),
-	history: (scope: string, key: string) =>
+	history: (scope: MemoryScopeIdentity, key: string) =>
 		queryOptions({
 			queryKey: memoryQueryKeys.history(scope, key),
 			queryFn: () => fetchMemoryHistory(scope, key),

--- a/src/modules/memory/business-logic/use-memory-history.ts
+++ b/src/modules/memory/business-logic/use-memory-history.ts
@@ -1,10 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { memoryQueries } from "./memory-queries";
+import type { MemoryScopeIdentity } from "../domain/memory";
 
-export function useMemoryHistory(scope: string, key?: string) {
+export function useMemoryHistory(
+	scope: MemoryScopeIdentity | undefined,
+	key?: string
+) {
 	const query = useQuery({
-		...memoryQueries.history(scope, key ?? ""),
-		enabled: !!key,
+		...memoryQueries.history(
+			scope ?? { scope: "", scopeType: "unknown" },
+			key ?? ""
+		),
+		enabled: !!scope && !!key,
 	});
 	return { ...query, memoryHistoryData: query.data };
 }

--- a/src/modules/memory/business-logic/use-memory-history.ts
+++ b/src/modules/memory/business-logic/use-memory-history.ts
@@ -1,17 +1,20 @@
-import { useQuery } from "@tanstack/react-query";
+import { skipToken, useQuery } from "@tanstack/react-query";
 import { memoryQueries } from "./memory-queries";
 import type { MemoryScopeIdentity } from "../domain/memory";
+
+const DISABLED_SCOPE: MemoryScopeIdentity = {
+	scope: "",
+	scopeType: "unknown",
+};
 
 export function useMemoryHistory(
 	scope: MemoryScopeIdentity | undefined,
 	key?: string
 ) {
+	const options = memoryQueries.history(scope ?? DISABLED_SCOPE, key ?? "");
 	const query = useQuery({
-		...memoryQueries.history(
-			scope ?? { scope: "", scopeType: "unknown" },
-			key ?? ""
-		),
-		enabled: !!scope && !!key,
+		...options,
+		queryFn: scope && key ? options.queryFn : skipToken,
 	});
 	return { ...query, memoryHistoryData: query.data };
 }

--- a/src/modules/memory/domain/fetch-flow-memories.ts
+++ b/src/modules/memory/domain/fetch-flow-memories.ts
@@ -1,4 +1,5 @@
 import {
+	buildMemoryArtifactPrefix,
 	MEMORY_TAG_MARKER,
 	MEMORY_TAG_SCOPE_TYPE_PREFIX,
 	type MemoryEntry,
@@ -11,7 +12,10 @@ export async function fetchFlowMemories(
 ): Promise<MemoryEntry[]> {
 	const versions = await fetchMemoryArtifactVersions({
 		tags: [MEMORY_TAG_MARKER, `${MEMORY_TAG_SCOPE_TYPE_PREFIX}flow`],
-		artifact: `startswith:kitaru_mem:${flowName}:`,
+		artifact: `startswith:${buildMemoryArtifactPrefix({
+			scope: flowName,
+			scopeType: "flow",
+		})}`,
 		logical_operator: "and",
 		sort_by: "desc:version_number",
 	});

--- a/src/modules/memory/domain/fetch-memory-history.spec.ts
+++ b/src/modules/memory/domain/fetch-memory-history.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { components } from "@/shared/api/openapi";
+import { fetchMemoryArtifactVersions } from "./fetch-memory-artifact-versions";
+import { fetchMemoryHistory } from "./fetch-memory-history";
+
+vi.mock("./fetch-memory-artifact-versions", () => ({
+	fetchMemoryArtifactVersions: vi.fn(),
+}));
+
+const mockedFetchMemoryArtifactVersions = vi.mocked(
+	fetchMemoryArtifactVersions
+);
+
+function makeArtifactVersion(): components["schemas"]["ArtifactVersionResponse"] {
+	return {
+		id: "artifact-version-id-1",
+		body: {
+			created: "2024-06-01T10:00:00Z",
+			updated: "2024-06-01T10:00:00Z",
+			project_id: "project-1",
+			version: "1",
+			uri: "s3://bucket/path",
+			type: "DataArtifact",
+			materializer: { module: "builtins", type: "internal" },
+			data_type: { module: "builtins", attribute: "dict", type: "builtin" },
+			save_type: "step_output",
+			artifact: {
+				id: "artifact-id-1",
+				name: "kitaru_mem:flow:coding_agent:counter",
+			},
+		},
+		metadata: {
+			run_metadata: {
+				kitaru_memory_scope_type: "flow",
+			},
+		},
+	} as unknown as components["schemas"]["ArtifactVersionResponse"];
+}
+
+describe("fetchMemoryHistory", () => {
+	beforeEach(() => {
+		mockedFetchMemoryArtifactVersions.mockReset();
+	});
+
+	it("filters history requests by scope type as well as scope name", async () => {
+		mockedFetchMemoryArtifactVersions.mockResolvedValue([
+			makeArtifactVersion(),
+		]);
+
+		await fetchMemoryHistory(
+			{ scope: "coding_agent", scopeType: "flow" },
+			"counter"
+		);
+
+		expect(mockedFetchMemoryArtifactVersions).toHaveBeenCalledWith({
+			artifact: "kitaru_mem:flow:coding_agent:counter",
+			tags: ["kitaru:memory", "kitaru:memory:scope_type:flow"],
+			logical_operator: "and",
+			sort_by: "desc:version_number",
+		});
+	});
+});

--- a/src/modules/memory/domain/fetch-memory-history.ts
+++ b/src/modules/memory/domain/fetch-memory-history.ts
@@ -1,18 +1,23 @@
 import {
 	MEMORY_TAG_MARKER,
+	MEMORY_TAG_SCOPE_TYPE_PREFIX,
 	type MemoryEntry,
+	type MemoryScopeIdentity,
 	buildMemoryArtifactName,
 	mapArtifactVersionToMemoryEntry,
 } from "./memory";
 import { fetchMemoryArtifactVersions } from "./fetch-memory-artifact-versions";
 
 export async function fetchMemoryHistory(
-	scope: string,
+	scope: MemoryScopeIdentity,
 	key: string
 ): Promise<MemoryEntry[]> {
 	const artifactVersions = await fetchMemoryArtifactVersions({
 		artifact: buildMemoryArtifactName(scope, key),
-		tags: [MEMORY_TAG_MARKER],
+		tags: [
+			MEMORY_TAG_MARKER,
+			`${MEMORY_TAG_SCOPE_TYPE_PREFIX}${scope.scopeType}`,
+		],
 		logical_operator: "and",
 		sort_by: "desc:version_number",
 	});

--- a/src/modules/memory/domain/fetch-single-execution-memories.ts
+++ b/src/modules/memory/domain/fetch-single-execution-memories.ts
@@ -1,6 +1,7 @@
 import {
 	MEMORY_TAG_MARKER,
 	MEMORY_TAG_SCOPE_PREFIX,
+	MEMORY_TAG_SCOPE_TYPE_PREFIX,
 	type MemoryEntry,
 	mapArtifactVersionToMemoryEntry,
 } from "./memory";
@@ -10,7 +11,11 @@ export async function fetchSingleExecutionMemories(
 	executionId: string
 ): Promise<MemoryEntry[]> {
 	const versions = await fetchMemoryArtifactVersions({
-		tags: [MEMORY_TAG_MARKER, `${MEMORY_TAG_SCOPE_PREFIX}${executionId}`],
+		tags: [
+			MEMORY_TAG_MARKER,
+			`${MEMORY_TAG_SCOPE_PREFIX}${executionId}`,
+			`${MEMORY_TAG_SCOPE_TYPE_PREFIX}execution`,
+		],
 		logical_operator: "and",
 		sort_by: "desc:version_number",
 	});

--- a/src/modules/memory/domain/memory.spec.ts
+++ b/src/modules/memory/domain/memory.spec.ts
@@ -34,6 +34,19 @@ describe("parseMemoryArtifactName", () => {
 		});
 	});
 
+	it("falls back to legacy when scope name matches a scope type value", () => {
+		expect(parseMemoryArtifactName("kitaru_mem:flow:counter")).toEqual({
+			scope: "flow",
+			scopeType: "unknown",
+			key: "counter",
+		});
+		expect(parseMemoryArtifactName("kitaru_mem:namespace:my_key")).toEqual({
+			scope: "namespace",
+			scopeType: "unknown",
+			key: "my_key",
+		});
+	});
+
 	it("returns null for wrong prefix", () => {
 		expect(parseMemoryArtifactName("other_mem:scope:key")).toBeUndefined();
 	});

--- a/src/modules/memory/domain/memory.spec.ts
+++ b/src/modules/memory/domain/memory.spec.ts
@@ -1,25 +1,36 @@
 import { describe, expect, it } from "vitest";
 import type { components } from "@/shared/api/openapi";
 import {
+	buildMemoryArtifactName,
 	parseMemoryArtifactName,
 	isCompactionKey,
 	mapArtifactVersionToMemoryEntry,
 } from "./memory";
 
 describe("parseMemoryArtifactName", () => {
-	it("parses a valid artifact name", () => {
-		expect(parseMemoryArtifactName("kitaru_mem:my-flow:counter")).toEqual({
+	it("parses a valid typed artifact name", () => {
+		expect(parseMemoryArtifactName("kitaru_mem:flow:my-flow:counter")).toEqual({
 			scope: "my-flow",
+			scopeType: "flow",
 			key: "counter",
 		});
 	});
 
 	it("handles keys containing colons", () => {
 		expect(
-			parseMemoryArtifactName("kitaru_mem:my-flow:nested:key:value")
+			parseMemoryArtifactName("kitaru_mem:flow:my-flow:nested:key:value")
 		).toEqual({
 			scope: "my-flow",
+			scopeType: "flow",
 			key: "nested:key:value",
+		});
+	});
+
+	it("falls back to legacy untyped artifact names", () => {
+		expect(parseMemoryArtifactName("kitaru_mem:my-flow:counter")).toEqual({
+			scope: "my-flow",
+			scopeType: "unknown",
+			key: "counter",
 		});
 	});
 
@@ -28,11 +39,11 @@ describe("parseMemoryArtifactName", () => {
 	});
 
 	it("returns null for missing scope", () => {
-		expect(parseMemoryArtifactName("kitaru_mem::key")).toBeUndefined();
+		expect(parseMemoryArtifactName("kitaru_mem:flow::key")).toBeUndefined();
 	});
 
 	it("returns null for missing key", () => {
-		expect(parseMemoryArtifactName("kitaru_mem:scope:")).toBeUndefined();
+		expect(parseMemoryArtifactName("kitaru_mem:flow:scope:")).toBeUndefined();
 	});
 
 	it("returns null for missing scope and key", () => {
@@ -45,6 +56,17 @@ describe("parseMemoryArtifactName", () => {
 
 	it("returns null for prefix only with no colon after scope", () => {
 		expect(parseMemoryArtifactName("kitaru_mem:scopeonly")).toBeUndefined();
+	});
+});
+
+describe("buildMemoryArtifactName", () => {
+	it("builds a typed artifact name", () => {
+		expect(
+			buildMemoryArtifactName(
+				{ scope: "my-flow", scopeType: "flow" },
+				"counter"
+			)
+		).toBe("kitaru_mem:flow:my-flow:counter");
 	});
 });
 
@@ -88,7 +110,7 @@ function makeArtifactVersion(
 			save_type: "step_output",
 			artifact: {
 				id: "artifact-id-1",
-				name: overrides.name ?? "kitaru_mem:my-flow:counter",
+				name: overrides.name ?? "kitaru_mem:flow:my-flow:counter",
 			},
 		},
 		metadata: {
@@ -138,9 +160,18 @@ describe("mapArtifactVersionToMemoryEntry", () => {
 	});
 
 	it("defaults scopeType to unknown when metadata is missing", () => {
-		const av = makeArtifactVersion({ scopeType: "bogus" });
+		const av = makeArtifactVersion({
+			name: "kitaru_mem:legacy-flow:counter",
+			scopeType: "bogus",
+		});
 		const entry = mapArtifactVersionToMemoryEntry(av);
 		expect(entry?.scopeType).toBe("unknown");
+	});
+
+	it("prefers the scope type encoded in the typed artifact name", () => {
+		const av = makeArtifactVersion({ scopeType: "namespace" });
+		const entry = mapArtifactVersionToMemoryEntry(av);
+		expect(entry?.scopeType).toBe("flow");
 	});
 
 	it("parses isDeleted from boolean true", () => {

--- a/src/modules/memory/domain/memory.ts
+++ b/src/modules/memory/domain/memory.ts
@@ -39,30 +39,73 @@ export type MemoryEntry = {
 	artifactId: string;
 };
 
-export type MemoryScopeInfo = {
+export type MemoryScopeIdentity = {
 	scope: string;
 	scopeType: MemoryScopeType;
+};
+
+export type MemoryScopeInfo = MemoryScopeIdentity & {
 	entryCount: number;
 };
 
-export function buildMemoryArtifactName(scope: string, key: string): string {
-	return `${ARTIFACT_NAME_PREFIX}${scope}:${key}`;
+export function memoryScopeIdentityKey({
+	scope,
+	scopeType,
+}: MemoryScopeIdentity): string {
+	return `${scopeType}:${scope}`;
+}
+
+export function isSameMemoryScopeIdentity(
+	left: MemoryScopeIdentity,
+	right: MemoryScopeIdentity
+): boolean {
+	return left.scope === right.scope && left.scopeType === right.scopeType;
+}
+
+export function buildMemoryArtifactName(
+	scope: MemoryScopeIdentity,
+	key: string
+): string {
+	return `${ARTIFACT_NAME_PREFIX}${scope.scopeType}:${scope.scope}:${key}`;
+}
+
+export function buildMemoryArtifactPrefix(scope: MemoryScopeIdentity): string {
+	return `${ARTIFACT_NAME_PREFIX}${scope.scopeType}:${scope.scope}:`;
 }
 
 export function parseMemoryArtifactName(
 	name: string
-): { scope: string; key: string } | undefined {
+): (MemoryScopeIdentity & { key: string }) | undefined {
 	if (!name.startsWith(ARTIFACT_NAME_PREFIX)) return undefined;
 
 	const rest = name.slice(ARTIFACT_NAME_PREFIX.length);
-	const colonIndex = rest.indexOf(":");
-	if (colonIndex <= 0) return undefined;
+	const firstColonIndex = rest.indexOf(":");
+	if (firstColonIndex <= 0) return undefined;
 
-	const scope = rest.slice(0, colonIndex);
-	const key = rest.slice(colonIndex + 1);
-	if (!key) return undefined;
+	const maybeScopeType = rest.slice(0, firstColonIndex);
+	const remainder = rest.slice(firstColonIndex + 1);
 
-	return { scope, key };
+	if (memoryScopeTypeValues.includes(maybeScopeType as MemoryScopeType)) {
+		const secondColonIndex = remainder.indexOf(":");
+		if (secondColonIndex <= 0) return undefined;
+
+		const scope = remainder.slice(0, secondColonIndex);
+		const key = remainder.slice(secondColonIndex + 1);
+		if (!scope || !key) return undefined;
+		return {
+			scope,
+			scopeType: maybeScopeType as MemoryScopeType,
+			key,
+		};
+	}
+
+	if (!remainder) return undefined;
+
+	return {
+		scope: maybeScopeType,
+		scopeType: "unknown",
+		key: remainder,
+	};
 }
 
 export function isCompactionKey(key: string): boolean {
@@ -106,7 +149,10 @@ export function mapArtifactVersionToMemoryEntry(
 		scope: parsed.scope,
 		version: body.version,
 		valueType: inferValueType(body.data_type),
-		scopeType: parseScopeType(runMetadata[MEMORY_SCOPE_TYPE_METADATA_KEY]),
+		scopeType:
+			parsed.scopeType === "unknown"
+				? parseScopeType(runMetadata[MEMORY_SCOPE_TYPE_METADATA_KEY])
+				: parsed.scopeType,
 		createdAt: parseBackendTimestamp(body.created),
 		isDeleted: parseIsDeleted(runMetadata[MEMORY_DELETED_METADATA_KEY]),
 		artifactId: artifact.id,

--- a/src/modules/memory/domain/memory.ts
+++ b/src/modules/memory/domain/memory.ts
@@ -87,16 +87,19 @@ export function parseMemoryArtifactName(
 
 	if (memoryScopeTypeValues.includes(maybeScopeType as MemoryScopeType)) {
 		const secondColonIndex = remainder.indexOf(":");
-		if (secondColonIndex <= 0) return undefined;
-
-		const scope = remainder.slice(0, secondColonIndex);
-		const key = remainder.slice(secondColonIndex + 1);
-		if (!scope || !key) return undefined;
-		return {
-			scope,
-			scopeType: maybeScopeType as MemoryScopeType,
-			key,
-		};
+		if (secondColonIndex >= 0) {
+			// Has a colon — typed format. Validate strictly.
+			const scope = remainder.slice(0, secondColonIndex);
+			const key = remainder.slice(secondColonIndex + 1);
+			if (!scope || !key) return undefined;
+			return {
+				scope,
+				scopeType: maybeScopeType as MemoryScopeType,
+				key,
+			};
+		}
+		// No colon in remainder — ambiguous: could be legacy with a scope name
+		// matching a type value (e.g. kitaru_mem:flow:counter). Fall through.
 	}
 
 	if (!remainder) return undefined;

--- a/src/modules/memory/feature/FlowMemoryContainer.tsx
+++ b/src/modules/memory/feature/FlowMemoryContainer.tsx
@@ -10,7 +10,11 @@ import { ArtifactVisualizationContainer } from "@/modules/checkpoints/feature/Ar
 import { DownloadArtifactButtonContainer } from "@/modules/checkpoints/feature/DownloadArtifactButtonContainer";
 import { VisualizationSkeleton } from "@/modules/checkpoints/ui/VisualizationSkeleton";
 import { deriveScopesFromEntries } from "../business-logic/memory-operations";
-import type { MemoryEntry } from "../domain/memory";
+import {
+	isSameMemoryScopeIdentity,
+	type MemoryEntry,
+	type MemoryScopeIdentity,
+} from "../domain/memory";
 import { MemorySidebar } from "../ui/MemorySidebar";
 import { MemoryDetailPanel } from "../ui/MemoryDetailPanel";
 import { MemoryHistoryPanel } from "../ui/MemoryHistoryPanel";
@@ -24,8 +28,15 @@ export function FlowMemoryContainer() {
 
 	const { flowData } = useFlow(flowId);
 	const flowName = flowData.name;
+	const flowScope = useMemo<MemoryScopeIdentity>(
+		() => ({ scope: flowName, scopeType: "flow" }),
+		[flowName]
+	);
 
-	const [activeScope, setActiveScope] = useState(flowName);
+	const [activeScope, setActiveScope] = useState<MemoryScopeIdentity>(() => ({
+		scope: flowName,
+		scopeType: "flow",
+	}));
 	const [userSelectedKey, setUserSelectedKey] = useState<string | undefined>();
 	const [selectedVersion, setSelectedVersion] = useState<string | undefined>();
 
@@ -37,23 +48,22 @@ export function FlowMemoryContainer() {
 		refetch: refetchEntries,
 	} = useFlowMemories(flowId, flowName);
 
+	const allEntries = useMemo(
+		() => [...namespaceEntries, ...flowEntries, ...executionEntries],
+		[namespaceEntries, flowEntries, executionEntries]
+	);
+
 	const memoryScopesData = useMemo(
-		() =>
-			deriveScopesFromEntries(
-				namespaceEntries,
-				flowEntries,
-				executionEntries,
-				flowName
-			),
-		[namespaceEntries, flowEntries, executionEntries, flowName]
+		() => deriveScopesFromEntries(allEntries, flowName),
+		[allEntries, flowName]
 	);
 
 	const memoryEntriesData = useMemo(
 		() =>
-			[...namespaceEntries, ...flowEntries, ...executionEntries].filter(
-				(e) => e.scope === activeScope
+			allEntries.filter((entry) =>
+				isSameMemoryScopeIdentity(entry, activeScope)
 			),
-		[namespaceEntries, flowEntries, executionEntries, activeScope]
+		[allEntries, activeScope]
 	);
 
 	// Derive effective selected key: use user's choice if valid, else first entry
@@ -74,9 +84,7 @@ export function FlowMemoryContainer() {
 		refetch: refetchHistory,
 	} = useMemoryHistory(activeScope, selectedKey);
 
-	// memoryScopesData already includes flow scope via deriveScopesFromEntries
-
-	const handleScopeChange = useCallback((scope: string) => {
+	const handleScopeChange = useCallback((scope: MemoryScopeIdentity) => {
 		setActiveScope(scope);
 		setUserSelectedKey(undefined);
 		setSelectedVersion(undefined);
@@ -117,7 +125,7 @@ export function FlowMemoryContainer() {
 		<MemorySidebar
 			scopes={memoryScopesData}
 			activeScope={activeScope}
-			flowName={flowName}
+			flowScope={flowScope}
 			onScopeChange={handleScopeChange}
 			entries={memoryEntriesData}
 			selectedKey={selectedKey}
@@ -138,8 +146,12 @@ export function FlowMemoryContainer() {
 		if (memoryEntriesData.length === 0) {
 			return (
 				<MemoryEmptyState
-					variant={activeScope === flowName ? "no-memory" : "no-scope-memory"}
-					scopeName={activeScope}
+					variant={
+						isSameMemoryScopeIdentity(activeScope, flowScope)
+							? "no-memory"
+							: "no-scope-memory"
+					}
+					scope={activeScope}
 				/>
 			);
 		}

--- a/src/modules/memory/ui/MemoryEmptyState.tsx
+++ b/src/modules/memory/ui/MemoryEmptyState.tsx
@@ -7,10 +7,11 @@ import {
 	EmptyTitle,
 } from "@/shared/ui/empty";
 import { cn } from "@/shared/utils/styles";
+import type { MemoryScopeIdentity } from "../domain/memory";
 
 type MemoryEmptyStateProps = {
 	variant: "no-memory" | "no-scope-memory" | "no-preview";
-	scopeName?: string;
+	scope?: MemoryScopeIdentity;
 	className?: string;
 };
 
@@ -36,15 +37,15 @@ const CONFIG = {
 
 export function MemoryEmptyState({
 	variant,
-	scopeName,
+	scope,
 	className,
 }: MemoryEmptyStateProps) {
 	const config = CONFIG[variant];
 	const Icon = config.icon;
 
 	const description =
-		variant === "no-scope-memory" && scopeName
-			? `No memory entries found for scope "${scopeName}".`
+		variant === "no-scope-memory" && scope
+			? `No memory entries found for ${scope.scopeType} scope "${scope.scope}".`
 			: config.description;
 
 	return (

--- a/src/modules/memory/ui/MemoryEmptyState.tsx
+++ b/src/modules/memory/ui/MemoryEmptyState.tsx
@@ -45,7 +45,9 @@ export function MemoryEmptyState({
 
 	const description =
 		variant === "no-scope-memory" && scope
-			? `No memory entries found for ${scope.scopeType} scope "${scope.scope}".`
+			? scope.scopeType === "unknown"
+				? `No memory entries found for scope "${scope.scope}".`
+				: `No memory entries found for ${scope.scopeType} scope "${scope.scope}".`
 			: config.description;
 
 	return (

--- a/src/modules/memory/ui/MemoryScopeSelector.tsx
+++ b/src/modules/memory/ui/MemoryScopeSelector.tsx
@@ -1,10 +1,8 @@
 import { useMemo } from "react";
-import {
-	isSameMemoryScopeIdentity,
-	memoryScopeIdentityKey,
-	type MemoryScopeIdentity,
-	type MemoryScopeInfo,
-	type MemoryScopeType,
+import type {
+	MemoryScopeIdentity,
+	MemoryScopeInfo,
+	MemoryScopeType,
 } from "../domain/memory";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
@@ -38,6 +36,10 @@ const SCOPE_TYPE_LABELS: Record<MemoryScopeType, string> = {
 	execution: "Executions",
 	unknown: "Other",
 };
+
+function isSameScope(a: MemoryScopeIdentity, b: MemoryScopeIdentity) {
+	return a.scope === b.scope && a.scopeType === b.scopeType;
+}
 
 export function MemoryScopeSelector({
 	scopes,
@@ -82,19 +84,17 @@ export function MemoryScopeSelector({
 						</DropdownMenuLabel>
 						{grouped.get(scopeType)!.map((s) => (
 							<DropdownMenuItem
-								key={memoryScopeIdentityKey(s)}
+								key={`${s.scopeType}:${s.scope}`}
 								onClick={() => onScopeChange(s)}
 								className="flex items-center gap-2"
 							>
 								<span className="w-4 shrink-0">
-									{isSameMemoryScopeIdentity(s, activeScope) && (
-										<Check className="size-4" />
-									)}
+									{isSameScope(s, activeScope) && <Check className="size-4" />}
 								</span>
 								<span className="min-w-0 flex-1 truncate font-mono font-medium">
 									{s.scope}
 								</span>
-								{isSameMemoryScopeIdentity(s, flowScope) && (
+								{isSameScope(s, flowScope) && (
 									<Badge variant="secondary" className="text-2xs shrink-0">
 										this flow
 									</Badge>

--- a/src/modules/memory/ui/MemoryScopeSelector.tsx
+++ b/src/modules/memory/ui/MemoryScopeSelector.tsx
@@ -1,4 +1,11 @@
-import type { MemoryScopeInfo, MemoryScopeType } from "../domain/memory";
+import { useMemo } from "react";
+import {
+	isSameMemoryScopeIdentity,
+	memoryScopeIdentityKey,
+	type MemoryScopeIdentity,
+	type MemoryScopeInfo,
+	type MemoryScopeType,
+} from "../domain/memory";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import {
@@ -13,9 +20,9 @@ import { ChevronDown, Check } from "@untitledui/icons";
 
 type MemoryScopeSelectorProps = {
 	scopes: MemoryScopeInfo[];
-	activeScope: string;
-	flowName: string;
-	onScopeChange: (scope: string) => void;
+	activeScope: MemoryScopeIdentity;
+	flowScope: MemoryScopeIdentity;
+	onScopeChange: (scope: MemoryScopeIdentity) => void;
 };
 
 const SCOPE_TYPE_ORDER: MemoryScopeType[] = [
@@ -35,16 +42,21 @@ const SCOPE_TYPE_LABELS: Record<MemoryScopeType, string> = {
 export function MemoryScopeSelector({
 	scopes,
 	activeScope,
-	flowName,
+	flowScope,
 	onScopeChange,
 }: MemoryScopeSelectorProps) {
-	const grouped = new Map<MemoryScopeType, MemoryScopeInfo[]>();
-	for (const scope of scopes) {
-		const list = grouped.get(scope.scopeType) ?? [];
-		list.push(scope);
-		grouped.set(scope.scopeType, list);
-	}
-	const orderedGroups = SCOPE_TYPE_ORDER.filter((t) => grouped.has(t));
+	const { grouped, orderedGroups } = useMemo(() => {
+		const g = new Map<MemoryScopeType, MemoryScopeInfo[]>();
+		for (const scope of scopes) {
+			const list = g.get(scope.scopeType) ?? [];
+			list.push(scope);
+			g.set(scope.scopeType, list);
+		}
+		return {
+			grouped: g,
+			orderedGroups: SCOPE_TYPE_ORDER.filter((t) => g.has(t)),
+		};
+	}, [scopes]);
 
 	return (
 		<DropdownMenu>
@@ -52,9 +64,12 @@ export function MemoryScopeSelector({
 				render={
 					<Button
 						variant="outline"
-						className="w-full justify-between font-mono font-medium"
+						className="w-full justify-between gap-2 font-mono font-medium"
 					>
-						<span className="truncate">{activeScope}</span>
+						<span className="min-w-0 flex-1 truncate">{activeScope.scope}</span>
+						<Badge variant="secondary" className="text-2xs shrink-0">
+							{activeScope.scopeType}
+						</Badge>
 						<ChevronDown className="ml-1 size-4 shrink-0 opacity-50" />
 					</Button>
 				}
@@ -67,17 +82,19 @@ export function MemoryScopeSelector({
 						</DropdownMenuLabel>
 						{grouped.get(scopeType)!.map((s) => (
 							<DropdownMenuItem
-								key={s.scope}
-								onClick={() => onScopeChange(s.scope)}
+								key={memoryScopeIdentityKey(s)}
+								onClick={() => onScopeChange(s)}
 								className="flex items-center gap-2"
 							>
 								<span className="w-4 shrink-0">
-									{s.scope === activeScope && <Check className="size-4" />}
+									{isSameMemoryScopeIdentity(s, activeScope) && (
+										<Check className="size-4" />
+									)}
 								</span>
 								<span className="min-w-0 flex-1 truncate font-mono font-medium">
 									{s.scope}
 								</span>
-								{s.scope === flowName && (
+								{isSameMemoryScopeIdentity(s, flowScope) && (
 									<Badge variant="secondary" className="text-2xs shrink-0">
 										this flow
 									</Badge>

--- a/src/modules/memory/ui/MemorySidebar.tsx
+++ b/src/modules/memory/ui/MemorySidebar.tsx
@@ -1,4 +1,8 @@
-import type { MemoryEntry, MemoryScopeInfo } from "../domain/memory";
+import type {
+	MemoryEntry,
+	MemoryScopeIdentity,
+	MemoryScopeInfo,
+} from "../domain/memory";
 import { Badge } from "@/shared/ui/badge";
 import { cn } from "@/shared/utils/styles";
 import { formatRelativeTime } from "@/shared/utils/time";
@@ -6,9 +10,9 @@ import { MemoryScopeSelector } from "./MemoryScopeSelector";
 
 type MemorySidebarProps = {
 	scopes: MemoryScopeInfo[];
-	activeScope: string;
-	flowName: string;
-	onScopeChange: (scope: string) => void;
+	activeScope: MemoryScopeIdentity;
+	flowScope: MemoryScopeIdentity;
+	onScopeChange: (scope: MemoryScopeIdentity) => void;
 	entries: MemoryEntry[];
 	selectedKey?: string;
 	onSelectKey: (key: string) => void;
@@ -18,7 +22,7 @@ type MemorySidebarProps = {
 export function MemorySidebar({
 	scopes,
 	activeScope,
-	flowName,
+	flowScope,
 	onScopeChange,
 	entries,
 	selectedKey,
@@ -32,7 +36,7 @@ export function MemorySidebar({
 				<MemoryScopeSelector
 					scopes={scopes}
 					activeScope={activeScope}
-					flowName={flowName}
+					flowScope={flowScope}
 					onScopeChange={onScopeChange}
 				/>
 			</div>


### PR DESCRIPTION
## Summary

- The Flow Memory page identified scopes by plain `scope` string, so when the same name (e.g. `coding_agent`) existed as both a namespace and a flow scope, they merged into one selector item
- Switches the entire read path — from artifact name parsing through query cache keys to UI component props — to use a composite `(scope, scopeType)` identity via a new `MemoryScopeIdentity` type
- Artifact name format updated to `kitaru_mem:<scopeType>:<scope>:<key>` with backward-compatible fallback for legacy untyped names
- Simplifies `FlowMemoryContainer` state management and memoization

Paired with backend changes: https://github.com/zenml-io/kitaru/pull/123

### Follow-up fixes (post-review)

- **Parser hardening**: `parseMemoryArtifactName` now falls through to legacy parse when a scope name matches a scope type value (e.g. `kitaru_mem:flow:counter` where "flow" is the scope name, not a type prefix). Previously these artifacts were silently dropped.
- **Layer violation fix**: `MemoryScopeSelector` (ui/) no longer imports runtime functions from domain/ — uses a file-local `isSameScope` helper instead (types-only import preserved)
- **UX polish**: Empty state no longer shows "unknown" as a scope type label to users
- **skipToken**: `useMemoryHistory` now uses TanStack Query v5's `skipToken` instead of `enabled: false` with a sentinel value

## Test plan

- [x] All 129 tests pass (including new edge-case test for scope-name/type-value collision)
- [x] TypeScript compiles cleanly
- [x] ESLint + Prettier pass
- [ ] Manually verify Flow Memory page with a flow that has same-named namespace and flow scopes (e.g. `coding_agent`) — should show them as separate selector items
- [ ] Verify legacy artifact names (without scope type in the name) still parse and display correctly
- [ ] Verify memory history loads correctly for each scope type