### PR TITLE
Use flow IDs for memory scopes in UI

### DIFF
--- a/src/modules/memory/business-logic/memory-operations.spec.ts
+++ b/src/modules/memory/business-logic/memory-operations.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { MemoryEntry } from "../domain/memory";
 import {
 	dedupeMemoryEntries,
+	deriveScopesFromEntries,
 	snapshotMemoryEntriesAtTime,
 } from "./memory-operations";
 
@@ -18,6 +19,48 @@ function makeEntry(overrides: Partial<MemoryEntry> = {}): MemoryEntry {
 		...overrides,
 	};
 }
+
+describe("deriveScopesFromEntries", () => {
+	it("keeps flow scope identity as the raw flow id while using flow name as label", () => {
+		const scopes = deriveScopesFromEntries(
+			[],
+			[
+				makeEntry({
+					scope: "flow-123",
+					scopeLabel: "My Flow",
+					artifactId: "av-flow-1",
+				}),
+			],
+			[],
+			"flow-123",
+			"My Flow"
+		);
+
+		expect(scopes).toContainEqual({
+			scope: "flow-123",
+			label: "My Flow",
+			scopeType: "flow",
+			entryCount: 1,
+		});
+	});
+
+	it("adds an empty synthetic flow scope keyed by flow id", () => {
+		const scopes = deriveScopesFromEntries(
+			[],
+			[],
+			[],
+			"flow-456",
+			"Empty Flow"
+		);
+
+		expect(scopes).toContainEqual({
+			scope: "flow-456",
+			label: "Empty Flow",
+			scopeType: "flow",
+			entryCount: 0,
+		});
+	});
+});
 
 describe("dedupeMemoryEntries", () => {
 	it("keeps the newest version per key (first in newest-first input)", () => {

--- a/src/modules/memory/business-logic/memory-operations.ts
+++ b/src/modules/memory/business-logic/memory-operations.ts
@@ -55,6 +55,16 @@ export function deriveScopesFromEntries(
 	});
 }
 
+export function decorateFlowEntries(
+	entries: MemoryEntry[],
+	flowName: string
+): MemoryEntry[] {
+	return entries.map((entry) => ({
+		...entry,
+		scopeLabel: entry.scopeLabel ?? flowName,
+	}));
+}
+
 export function dedupeMemoryEntries(entries: MemoryEntry[]): MemoryEntry[] {
 	const best = new Map<string, MemoryEntry>();
 

--- a/src/modules/memory/business-logic/memory-operations.ts
+++ b/src/modules/memory/business-logic/memory-operations.ts
@@ -2,7 +2,6 @@ import {
 	isCompactionKey,
 	SCOPE_TYPE_SORT_ORDER,
 	type MemoryEntry,
-	type MemoryScopeType,
 	type MemoryScopeInfo,
 } from "../domain/memory";
 
@@ -10,12 +9,10 @@ export function deriveScopesFromEntries(
 	namespaceEntries: MemoryEntry[],
 	flowEntries: MemoryEntry[],
 	executionEntries: MemoryEntry[],
+	flowId: string,
 	flowName: string
 ): MemoryScopeInfo[] {
-	const scopeMap = new Map<
-		string,
-		{ scope: string; scopeType: MemoryScopeType; entryCount: number }
-	>();
+	const scopeMap = new Map<string, MemoryScopeInfo>();
 
 	for (const entry of [
 		...namespaceEntries,
@@ -26,9 +23,13 @@ export function deriveScopesFromEntries(
 		const existing = scopeMap.get(compositeKey);
 		if (existing) {
 			existing.entryCount++;
+			if (!existing.label && entry.scopeLabel) {
+				existing.label = entry.scopeLabel;
+			}
 		} else {
 			scopeMap.set(compositeKey, {
 				scope: entry.scope,
+				label: entry.scopeLabel,
 				scopeType: entry.scopeType,
 				entryCount: 1,
 			});
@@ -37,8 +38,13 @@ export function deriveScopesFromEntries(
 
 	const scopes: MemoryScopeInfo[] = Array.from(scopeMap.values());
 
-	if (!scopes.some((s) => s.scope === flowName && s.scopeType === "flow")) {
-		scopes.push({ scope: flowName, scopeType: "flow", entryCount: 0 });
+	if (!scopes.some((s) => s.scope === flowId && s.scopeType === "flow")) {
+		scopes.push({
+			scope: flowId,
+			label: flowName,
+			scopeType: "flow",
+			entryCount: 0,
+		});
 	}
 
 	return scopes.sort((a, b) => {

--- a/src/modules/memory/business-logic/memory-queries.spec.ts
+++ b/src/modules/memory/business-logic/memory-queries.spec.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchFlowMemories } = vi.hoisted(() => ({
+	fetchFlowMemories: vi.fn(),
+}));
+
+vi.mock("../domain/fetch-flow-memories", () => ({
+	fetchFlowMemories,
+}));
+
+import { memoryQueries, memoryQueryKeys } from "./memory-queries";
+
+describe("memoryQueryKeys.flow", () => {
+	it("keys flow-scoped memory by raw flow id", () => {
+		expect(memoryQueryKeys.flow("flow-123")).toEqual([
+			"memory",
+			"flow",
+			"flow-123",
+		]);
+	});
+});
+
+describe("memoryQueries.flow", () => {
+	beforeEach(() => {
+		fetchFlowMemories.mockReset();
+		fetchFlowMemories.mockResolvedValue([]);
+	});
+
+	it("fetches flow-scoped memory by raw flow id", async () => {
+		await memoryQueries.flow("flow-123").queryFn();
+
+		expect(fetchFlowMemories).toHaveBeenCalledWith("flow-123");
+	});
+});

--- a/src/modules/memory/business-logic/memory-queries.ts
+++ b/src/modules/memory/business-logic/memory-queries.ts
@@ -9,8 +9,7 @@ import { fetchMemoryHistory } from "../domain/fetch-memory-history";
 export const memoryQueryKeys = {
 	base: ["memory"] as const,
 	namespaces: () => [...memoryQueryKeys.base, "namespaces"] as const,
-	flow: (flowName: string) =>
-		[...memoryQueryKeys.base, "flow", flowName] as const,
+	flow: (flowId: string) => [...memoryQueryKeys.base, "flow", flowId] as const,
 	executions: (flowId: string) =>
 		[...memoryQueryKeys.base, "executions", flowId] as const,
 	execution: (executionId: string) =>
@@ -25,10 +24,10 @@ export const memoryQueries = {
 			queryKey: memoryQueryKeys.namespaces(),
 			queryFn: fetchNamespaceMemories,
 		}),
-	flow: (flowName: string) =>
+	flow: (flowId: string) =>
 		queryOptions({
-			queryKey: memoryQueryKeys.flow(flowName),
-			queryFn: () => fetchFlowMemories(flowName),
+			queryKey: memoryQueryKeys.flow(flowId),
+			queryFn: () => fetchFlowMemories(flowId),
 		}),
 	executions: (flowId: string) =>
 		queryOptions({

--- a/src/modules/memory/business-logic/use-checkpoint-memories.ts
+++ b/src/modules/memory/business-logic/use-checkpoint-memories.ts
@@ -7,27 +7,42 @@ import {
 	snapshotMemoryEntriesAtTime,
 } from "./memory-operations";
 
+function decorateFlowEntries(
+	entries: MemoryEntry[],
+	flowName: string
+): MemoryEntry[] {
+	return entries.map((entry) => ({
+		...entry,
+		scopeLabel: flowName,
+	}));
+}
+
 export function useCheckpointMemories(
+	flowId: string,
 	flowName: string,
 	executionId: string,
 	checkpointStartTime?: Date
 ) {
 	const namespaces = useQuery(memoryQueries.namespaces());
-	const flow = useQuery(memoryQueries.flow(flowName));
+	const flow = useQuery(memoryQueries.flow(flowId));
 	const execution = useQuery(memoryQueries.execution(executionId));
 
-	const resolveEntries = checkpointStartTime
-		? (entries: MemoryEntry[]) =>
-				snapshotMemoryEntriesAtTime(entries, checkpointStartTime)
-		: dedupeMemoryEntries;
+	const resolveEntries = useMemo<
+		(entries: MemoryEntry[]) => MemoryEntry[]
+	>(() => {
+		return checkpointStartTime
+			? (entries: MemoryEntry[]) =>
+					snapshotMemoryEntriesAtTime(entries, checkpointStartTime)
+			: dedupeMemoryEntries;
+	}, [checkpointStartTime]);
 
 	const namespaceEntries = useMemo(
 		() => resolveEntries(namespaces.data ?? []),
 		[namespaces.data, resolveEntries]
 	);
 	const flowEntries = useMemo(
-		() => resolveEntries(flow.data ?? []),
-		[flow.data, resolveEntries]
+		() => decorateFlowEntries(resolveEntries(flow.data ?? []), flowName),
+		[flow.data, flowName, resolveEntries]
 	);
 	const executionEntries = useMemo(
 		() => resolveEntries(execution.data ?? []),

--- a/src/modules/memory/business-logic/use-checkpoint-memories.ts
+++ b/src/modules/memory/business-logic/use-checkpoint-memories.ts
@@ -3,19 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 import { memoryQueries } from "./memory-queries";
 import type { MemoryEntry } from "../domain/memory";
 import {
+	decorateFlowEntries,
 	dedupeMemoryEntries,
 	snapshotMemoryEntriesAtTime,
 } from "./memory-operations";
-
-function decorateFlowEntries(
-	entries: MemoryEntry[],
-	flowName: string
-): MemoryEntry[] {
-	return entries.map((entry) => ({
-		...entry,
-		scopeLabel: flowName,
-	}));
-}
 
 export function useCheckpointMemories(
 	flowId: string,
@@ -27,6 +18,7 @@ export function useCheckpointMemories(
 	const flow = useQuery(memoryQueries.flow(flowId));
 	const execution = useQuery(memoryQueries.execution(executionId));
 
+	const checkpointTimestamp = checkpointStartTime?.getTime();
 	const resolveEntries = useMemo<
 		(entries: MemoryEntry[]) => MemoryEntry[]
 	>(() => {
@@ -34,7 +26,8 @@ export function useCheckpointMemories(
 			? (entries: MemoryEntry[]) =>
 					snapshotMemoryEntriesAtTime(entries, checkpointStartTime)
 			: dedupeMemoryEntries;
-	}, [checkpointStartTime]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [checkpointTimestamp]);
 
 	const namespaceEntries = useMemo(
 		() => resolveEntries(namespaces.data ?? []),

--- a/src/modules/memory/business-logic/use-flow-memories.ts
+++ b/src/modules/memory/business-logic/use-flow-memories.ts
@@ -1,11 +1,22 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import type { MemoryEntry } from "../domain/memory";
 import { memoryQueries } from "./memory-queries";
 import { dedupeMemoryEntries } from "./memory-operations";
 
+function decorateFlowEntries(
+	entries: MemoryEntry[],
+	flowName: string
+): MemoryEntry[] {
+	return entries.map((entry) => ({
+		...entry,
+		scopeLabel: flowName,
+	}));
+}
+
 export function useFlowMemories(flowId: string, flowName: string) {
 	const namespaces = useQuery(memoryQueries.namespaces());
-	const flow = useQuery(memoryQueries.flow(flowName));
+	const flow = useQuery(memoryQueries.flow(flowId));
 	const executions = useQuery(memoryQueries.executions(flowId));
 
 	const namespaceEntries = useMemo(
@@ -13,8 +24,8 @@ export function useFlowMemories(flowId: string, flowName: string) {
 		[namespaces.data]
 	);
 	const flowEntries = useMemo(
-		() => dedupeMemoryEntries(flow.data ?? []),
-		[flow.data]
+		() => decorateFlowEntries(dedupeMemoryEntries(flow.data ?? []), flowName),
+		[flow.data, flowName]
 	);
 	const executionEntries = useMemo(
 		() => dedupeMemoryEntries(executions.data ?? []),

--- a/src/modules/memory/business-logic/use-flow-memories.ts
+++ b/src/modules/memory/business-logic/use-flow-memories.ts
@@ -1,18 +1,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { MemoryEntry } from "../domain/memory";
 import { memoryQueries } from "./memory-queries";
-import { dedupeMemoryEntries } from "./memory-operations";
-
-function decorateFlowEntries(
-	entries: MemoryEntry[],
-	flowName: string
-): MemoryEntry[] {
-	return entries.map((entry) => ({
-		...entry,
-		scopeLabel: flowName,
-	}));
-}
+import { decorateFlowEntries, dedupeMemoryEntries } from "./memory-operations";
 
 export function useFlowMemories(flowId: string, flowName: string) {
 	const namespaces = useQuery(memoryQueries.namespaces());

--- a/src/modules/memory/domain/fetch-flow-memories.ts
+++ b/src/modules/memory/domain/fetch-flow-memories.ts
@@ -8,13 +8,13 @@ import {
 import { fetchMemoryArtifactVersions } from "./fetch-memory-artifact-versions";
 
 export async function fetchFlowMemories(
-	flowName: string
+	flowId: string
 ): Promise<MemoryEntry[]> {
 	const versions = await fetchMemoryArtifactVersions({
 		tags: [
 			MEMORY_TAG_MARKER,
 			`${MEMORY_TAG_SCOPE_TYPE_PREFIX}flow`,
-			`${MEMORY_TAG_SCOPE_PREFIX}${flowName}`,
+			`${MEMORY_TAG_SCOPE_PREFIX}${flowId}`,
 		],
 		logical_operator: "and",
 		sort_by: "desc:version_number",

--- a/src/modules/memory/domain/memory.spec.ts
+++ b/src/modules/memory/domain/memory.spec.ts
@@ -105,6 +105,7 @@ function makeArtifactVersion(
 		created?: string;
 		deleted?: unknown;
 		executionId?: string | null;
+		flowName?: unknown;
 	} = {}
 ): components["schemas"]["ArtifactVersionResponse"] {
 	// Minimal fixture — only fields the mapper actually reads.
@@ -131,6 +132,9 @@ function makeArtifactVersion(
 				...(overrides.deleted !== undefined
 					? { kitaru_memory_deleted: overrides.deleted }
 					: {}),
+				...(overrides.flowName !== undefined
+					? { flow_name: overrides.flowName }
+					: {}),
 			},
 		},
 		resources: {
@@ -148,6 +152,7 @@ describe("mapArtifactVersionToMemoryEntry", () => {
 		expect(entry).toEqual({
 			key: "counter",
 			scope: "my-flow",
+			scopeLabel: undefined,
 			scopeType: "flow",
 			version: "1",
 			valueType: "dict",
@@ -182,6 +187,16 @@ describe("mapArtifactVersionToMemoryEntry", () => {
 	it("returns null for unknown scope type in the name", () => {
 		const av = makeArtifactVersion({ name: "kitaru_mem:bogus:scope:key" });
 		expect(mapArtifactVersionToMemoryEntry(av)).toBeNull();
+	});
+
+	it("reads flow_name into scopeLabel for flow-scoped entries", () => {
+		const av = makeArtifactVersion({ flowName: "My Flow" });
+		expect(mapArtifactVersionToMemoryEntry(av)?.scopeLabel).toBe("My Flow");
+	});
+
+	it("ignores non-string flow_name values", () => {
+		const av = makeArtifactVersion({ flowName: 123 });
+		expect(mapArtifactVersionToMemoryEntry(av)?.scopeLabel).toBeUndefined();
 	});
 
 	it("parses isDeleted from boolean true", () => {

--- a/src/modules/memory/domain/memory.ts
+++ b/src/modules/memory/domain/memory.ts
@@ -32,6 +32,7 @@ export type MemoryEntry = {
 	valueType: string;
 	version: string;
 	scope: string;
+	scopeLabel?: string;
 	scopeType: MemoryScopeType;
 	createdAt: Date;
 	isDeleted: boolean;
@@ -40,6 +41,7 @@ export type MemoryEntry = {
 
 export type MemoryScopeInfo = {
 	scope: string;
+	label?: string;
 	scopeType: MemoryScopeType;
 	entryCount: number;
 };
@@ -85,6 +87,15 @@ function parseIsDeleted(value: unknown): boolean {
 	return value === true || value === "true";
 }
 
+function parseFlowScopeLabel(
+	runMetadata: Record<string, unknown>
+): string | undefined {
+	const flowName = runMetadata.flow_name;
+	return typeof flowName === "string" && flowName.length > 0
+		? flowName
+		: undefined;
+}
+
 function inferValueType(dataType: components["schemas"]["Source"]): string {
 	const attr = dataType.attribute;
 	if (attr) return attr;
@@ -106,6 +117,10 @@ export function mapArtifactVersionToMemoryEntry(
 	return {
 		key: parsed.key,
 		scope: parsed.scope,
+		scopeLabel:
+			parsed.scopeType === "flow"
+				? parseFlowScopeLabel(runMetadata)
+				: undefined,
 		scopeType: parsed.scopeType,
 		version: body.version,
 		valueType: inferValueType(body.data_type),

--- a/src/modules/memory/feature/CheckpointMemoryTabContainer.tsx
+++ b/src/modules/memory/feature/CheckpointMemoryTabContainer.tsx
@@ -26,7 +26,12 @@ export function CheckpointMemoryTabContainer({
 		entries: memoryEntries,
 		isError,
 		error,
-	} = useCheckpointMemories(flowData.name, executionId, checkpointStartTime);
+	} = useCheckpointMemories(
+		flowId,
+		flowData.name,
+		executionId,
+		checkpointStartTime
+	);
 
 	const [userSelectedId, setUserSelectedId] = useState<string | undefined>();
 

--- a/src/modules/memory/feature/FlowMemoryContainer.tsx
+++ b/src/modules/memory/feature/FlowMemoryContainer.tsx
@@ -27,7 +27,8 @@ export function FlowMemoryContainer() {
 	const flowName = flowData.name;
 
 	const [activeScope, setActiveScope] = useState<MemoryScopeInfo>({
-		scope: flowName,
+		scope: flowId,
+		label: flowName,
 		scopeType: "flow",
 		entryCount: 0,
 	});
@@ -50,9 +51,10 @@ export function FlowMemoryContainer() {
 				namespaceEntries,
 				flowEntries,
 				executionEntries,
+				flowId,
 				flowName
 			),
-		[namespaceEntries, flowEntries, executionEntries, flowName]
+		[namespaceEntries, flowEntries, executionEntries, flowId, flowName]
 	);
 
 	const memoryEntriesData = useMemo(
@@ -81,6 +83,19 @@ export function FlowMemoryContainer() {
 		isPending: isHistoryPending,
 		refetch: refetchHistory,
 	} = useMemoryHistory(activeScope.scope, activeScope.scopeType, selectedKey);
+
+	const displayMemoryHistoryData = useMemo(
+		() =>
+			memoryHistoryData?.map((entry) => ({
+				...entry,
+				scopeLabel:
+					entry.scope === activeScope.scope &&
+					entry.scopeType === activeScope.scopeType
+						? (activeScope.label ?? entry.scopeLabel)
+						: entry.scopeLabel,
+			})),
+		[memoryHistoryData, activeScope]
+	);
 
 	// memoryScopesData already includes flow scope via deriveScopesFromEntries
 
@@ -114,21 +129,21 @@ export function FlowMemoryContainer() {
 		(e) => e.key === selectedKey
 	);
 	const selectedHistoryEntry = selectedVersion
-		? memoryHistoryData?.find((e) => e.version === selectedVersion)
-		: memoryHistoryData?.[0];
+		? displayMemoryHistoryData?.find((e) => e.version === selectedVersion)
+		: displayMemoryHistoryData?.[0];
 	const detailEntry: MemoryEntry | undefined =
 		selectedHistoryEntry ?? selectedListEntry;
 
 	// --- Panel content ---
 
 	const isFlowScope =
-		activeScope.scope === flowName && activeScope.scopeType === "flow";
+		activeScope.scope === flowId && activeScope.scopeType === "flow";
 
 	const leftPanel = (
 		<MemorySidebar
 			scopes={memoryScopesData}
 			activeScope={activeScope}
-			flowName={flowName}
+			flowId={flowId}
 			onScopeChange={handleScopeChange}
 			entries={memoryEntriesData}
 			selectedKey={selectedKey}
@@ -154,7 +169,7 @@ export function FlowMemoryContainer() {
 			return (
 				<MemoryEmptyState
 					variant={isFlowScope ? "no-memory" : "no-scope-memory"}
-					scopeName={activeScope.scope}
+					scopeName={activeScope.label ?? activeScope.scope}
 				/>
 			);
 		}
@@ -210,7 +225,7 @@ export function FlowMemoryContainer() {
 			);
 		}
 
-		if (!memoryHistoryData || memoryHistoryData.length === 0) {
+		if (!displayMemoryHistoryData || displayMemoryHistoryData.length === 0) {
 			return (
 				<div className="text-muted-foreground flex h-full items-center justify-center px-4 text-center text-xs">
 					No history available
@@ -220,7 +235,7 @@ export function FlowMemoryContainer() {
 
 		return (
 			<MemoryHistoryPanel
-				history={memoryHistoryData}
+				history={displayMemoryHistoryData}
 				selectedVersion={selectedVersion}
 				onSelectVersion={handleSelectVersion}
 			/>
@@ -232,7 +247,7 @@ export function FlowMemoryContainer() {
 			selectedKey={selectedKey}
 			selectedEntry={detailEntry}
 			selectedVersion={selectedVersion}
-			history={memoryHistoryData}
+			history={displayMemoryHistoryData}
 			onSelectVersion={handleSelectVersion}
 			isRefreshing={isRefreshing}
 			onRefresh={refresh}

--- a/src/modules/memory/feature/FlowMemoryContainer.tsx
+++ b/src/modules/memory/feature/FlowMemoryContainer.tsx
@@ -84,20 +84,15 @@ export function FlowMemoryContainer() {
 		refetch: refetchHistory,
 	} = useMemoryHistory(activeScope.scope, activeScope.scopeType, selectedKey);
 
-	const displayMemoryHistoryData = useMemo(
-		() =>
-			memoryHistoryData?.map((entry) => ({
-				...entry,
-				scopeLabel:
-					entry.scope === activeScope.scope &&
-					entry.scopeType === activeScope.scopeType
-						? (activeScope.label ?? entry.scopeLabel)
-						: entry.scopeLabel,
-			})),
-		[memoryHistoryData, activeScope]
-	);
-
-	// memoryScopesData already includes flow scope via deriveScopesFromEntries
+	const displayMemoryHistoryData = useMemo(() => {
+		if (!memoryHistoryData) return undefined;
+		const overrideLabel = activeScope.label;
+		if (!overrideLabel) return memoryHistoryData;
+		return memoryHistoryData.map((entry) => ({
+			...entry,
+			scopeLabel: entry.scopeLabel ?? overrideLabel,
+		}));
+	}, [memoryHistoryData, activeScope.label]);
 
 	const handleScopeChange = useCallback((scope: MemoryScopeInfo) => {
 		setActiveScope(scope);

--- a/src/modules/memory/ui/MemoryMetadata.tsx
+++ b/src/modules/memory/ui/MemoryMetadata.tsx
@@ -5,11 +5,15 @@ type MemoryMetadataProps = {
 	entry: MemoryEntry;
 };
 
+function getScopeDisplayLabel(entry: MemoryEntry): string {
+	return entry.scopeLabel ?? entry.scope;
+}
+
 export function MemoryMetadata({ entry }: MemoryMetadataProps) {
 	return (
 		<dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
 			<MetadataRow label="Scope">
-				<span>{entry.scope}</span>
+				<span>{getScopeDisplayLabel(entry)}</span>
 				<Badge variant="secondary" className="text-2xs ml-1.5">
 					{entry.scopeType}
 				</Badge>

--- a/src/modules/memory/ui/MemoryScopeSelector.tsx
+++ b/src/modules/memory/ui/MemoryScopeSelector.tsx
@@ -14,7 +14,7 @@ import { ChevronDown, Check } from "@untitledui/icons";
 type MemoryScopeSelectorProps = {
 	scopes: MemoryScopeInfo[];
 	activeScope: MemoryScopeInfo;
-	flowName: string;
+	flowId: string;
 	onScopeChange: (scope: MemoryScopeInfo) => void;
 };
 
@@ -32,10 +32,14 @@ const SCOPE_TYPE_LABELS: Record<MemoryScopeType, string> = {
 	unknown: "Other",
 };
 
+function getScopeDisplayLabel(scope: MemoryScopeInfo): string {
+	return scope.label ?? scope.scope;
+}
+
 export function MemoryScopeSelector({
 	scopes,
 	activeScope,
-	flowName,
+	flowId,
 	onScopeChange,
 }: MemoryScopeSelectorProps) {
 	const grouped = new Map<MemoryScopeType, MemoryScopeInfo[]>();
@@ -54,7 +58,9 @@ export function MemoryScopeSelector({
 						variant="outline"
 						className="w-full justify-between font-mono font-medium"
 					>
-						<span className="truncate">{activeScope.scope}</span>
+						<span className="truncate">
+							{getScopeDisplayLabel(activeScope)}
+						</span>
 						<ChevronDown className="ml-1 size-4 shrink-0 opacity-50" />
 					</Button>
 				}
@@ -78,9 +84,9 @@ export function MemoryScopeSelector({
 										)}
 								</span>
 								<span className="min-w-0 flex-1 truncate font-mono font-medium">
-									{s.scope}
+									{getScopeDisplayLabel(s)}
 								</span>
-								{s.scope === flowName && (
+								{s.scope === flowId && s.scopeType === "flow" && (
 									<Badge variant="secondary" className="text-2xs shrink-0">
 										this flow
 									</Badge>

--- a/src/modules/memory/ui/MemorySidebar.tsx
+++ b/src/modules/memory/ui/MemorySidebar.tsx
@@ -7,7 +7,7 @@ import { MemoryScopeSelector } from "./MemoryScopeSelector";
 type MemorySidebarProps = {
 	scopes: MemoryScopeInfo[];
 	activeScope: MemoryScopeInfo;
-	flowName: string;
+	flowId: string;
 	onScopeChange: (scope: MemoryScopeInfo) => void;
 	entries: MemoryEntry[];
 	selectedKey?: string;
@@ -18,7 +18,7 @@ type MemorySidebarProps = {
 export function MemorySidebar({
 	scopes,
 	activeScope,
-	flowName,
+	flowId,
 	onScopeChange,
 	entries,
 	selectedKey,
@@ -32,7 +32,7 @@ export function MemorySidebar({
 				<MemoryScopeSelector
 					scopes={scopes}
 					activeScope={activeScope}
-					flowName={flowName}
+					flowId={flowId}
 					onScopeChange={onScopeChange}
 				/>
 			</div>

--- a/src/routes/_private/_navbar/flows/$flowId/$tab.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/$tab.tsx
@@ -32,7 +32,7 @@ export const Route = createFileRoute("/_private/_navbar/flows/$flowId/$tab")({
 
 		if (params.tab === "memory") {
 			context.queryClient.ensureQueryData(memoryQueries.namespaces());
-			context.queryClient.ensureQueryData(memoryQueries.flow(flow.name));
+			context.queryClient.ensureQueryData(memoryQueries.flow(params.flowId));
 			context.queryClient.ensureQueryData(
 				memoryQueries.executions(params.flowId)
 			);

--- a/src/routes/_private/_navbar/flows/$flowId/executions/$executionId/route.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/executions/$executionId/route.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute(
 	pendingComponent: PageSpinner,
 
 	loader: async ({ context, params }) => {
-		const [flow, execution] = await Promise.all([
+		const [, execution] = await Promise.all([
 			context.queryClient.ensureQueryData(flowsQueries.detail(params.flowId)),
 			ensureQueryDataOr404(
 				context.queryClient.ensureQueryData(
@@ -30,7 +30,7 @@ export const Route = createFileRoute(
 		]);
 
 		context.queryClient.ensureQueryData(memoryQueries.namespaces());
-		context.queryClient.ensureQueryData(memoryQueries.flow(flow.name));
+		context.queryClient.ensureQueryData(memoryQueries.flow(params.flowId));
 		context.queryClient.ensureQueryData(
 			memoryQueries.execution(params.executionId)
 		);


### PR DESCRIPTION
## Summary

Switch flow-scoped memory from using **flow name** to **flow ID** as the scope identity, matching the updated backend contract (`scope_type="flow"` + `scope=<flowId>`).

### What changed

- **Query keys & fetching**: `memoryQueryKeys.flow()` and `fetchFlowMemories()` now key on `flowId` instead of `flowName`
- **Route prefetching**: both flow tab and execution loaders prefetch memory by `flowId`
- **Scope selector**: the "this flow" badge matches by `flowId` + `scopeType`, not just name
- **Display labels**: a new `scopeLabel` field on `MemoryEntry` and `label` field on `MemoryScopeInfo` carry the human-readable flow name for display, sourced from `flow_name` in artifact run metadata
- **Label decoration**: `decorateFlowEntries` (shared utility in `memory-operations.ts`) fills in `scopeLabel` as a fallback when domain-layer metadata doesn't provide it, using `??` to preserve upstream values
- **Efficiency**: `checkpointStartTime` `useMemo` dependency uses a stable numeric timestamp instead of Date reference identity (prevents cascading recomputation on every 3s poll)

### Files touched

| Area | Files |
|------|-------|
| Domain model | `memory.ts` (types + `parseFlowScopeLabel`) |
| Data fetching | `fetch-flow-memories.ts`, `memory-queries.ts` |
| Business logic | `memory-operations.ts`, `use-flow-memories.ts`, `use-checkpoint-memories.ts` |
| Feature containers | `FlowMemoryContainer.tsx`, `CheckpointMemoryTabContainer.tsx` |
| UI components | `MemoryScopeSelector.tsx`, `MemorySidebar.tsx`, `MemoryMetadata.tsx` |
| Route loaders | `flows/$flowId/$tab.tsx`, `executions/$executionId/route.tsx` |
| Tests | `memory.spec.ts`, `memory-operations.spec.ts`, `memory-queries.spec.ts` |

## Test plan

- [ ] `pnpm test:unit -- --run src/modules/memory/`
- [ ] `pnpm lint`
- [ ] Verify flow memory tab loads entries keyed by flow ID
- [ ] Verify scope selector displays flow name (not ID) with "this flow" badge
- [ ] Verify checkpoint memory panel shows correct scope labels
- [ ] Verify memory history panel shows human-readable scope labels