### PR TITLE
feat: Timeline Bar

### DIFF
--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -183,6 +183,10 @@
 	--color-info: var(--info);
 	--color-info-foreground: var(--info-foreground);
 
+	/* Span type colors (no shadcn equivalent) */
+	--color-span-tool: oklch(0.7 0.08 65);
+	--color-span-sleep: oklch(0.7 0.02 260);
+
 	--shadow-2xs: var(--shadow-2xs);
 	--shadow-xs: var(--shadow-xs);
 	--shadow-sm: var(--shadow-sm);
@@ -197,6 +201,7 @@
 	--animate-drift-2: drift-2 25s ease-in-out infinite;
 	--animate-drift-3: drift-3 30s ease-in-out infinite;
 	--animate-drift-4: drift-4 22s ease-in-out infinite;
+	--animate-highlight-blink: highlight-blink 1.5s ease-out both;
 
 	/* Text */
 	--text-2xs: 0.625rem;
@@ -211,5 +216,18 @@
 	}
 	html {
 		@apply font-sans;
+	}
+}
+
+@keyframes highlight-blink {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	33% {
+		opacity: 0.4;
+	}
+	66% {
+		opacity: 1;
 	}
 }

--- a/src/assets/styles/tailwind.css
+++ b/src/assets/styles/tailwind.css
@@ -201,7 +201,7 @@
 	--animate-drift-2: drift-2 25s ease-in-out infinite;
 	--animate-drift-3: drift-3 30s ease-in-out infinite;
 	--animate-drift-4: drift-4 22s ease-in-out infinite;
-	--animate-highlight-blink: highlight-blink 1.5s ease-out both;
+	--animate-highlight-blink: highlight-blink var(--highlight-duration, 1.5s) ease-out both;
 
 	/* Text */
 	--text-2xs: 0.625rem;

--- a/src/modules/executions/business-logic/timeline-entry-to-segment.ts
+++ b/src/modules/executions/business-logic/timeline-entry-to-segment.ts
@@ -1,0 +1,27 @@
+import type { TimelineSegment } from "../domain/timeline-segment";
+import type { TimelineEntry } from "../domain/waiting-block";
+
+export function timelineEntryToSegment(
+	entry: TimelineEntry
+): TimelineSegment | null {
+	if (entry.kind === "checkpoint") {
+		const durationMs = entry.data.durationMs ?? 0;
+		if (durationMs <= 0) return null;
+		return {
+			id: entry.data.id,
+			name: entry.data.name,
+			type: entry.data.type ?? "",
+			durationMs,
+			entry,
+		};
+	}
+	const durationMs = entry.data.waitDurationMs ?? 0;
+	if (durationMs <= 0) return null;
+	return {
+		id: entry.data.id,
+		name: "User Input",
+		type: "wait",
+		durationMs,
+		entry,
+	};
+}

--- a/src/modules/executions/domain/timeline-segment.ts
+++ b/src/modules/executions/domain/timeline-segment.ts
@@ -1,0 +1,9 @@
+import type { TimelineEntry } from "./waiting-block";
+
+export type TimelineSegment = {
+	id: string;
+	name: string;
+	type: string;
+	durationMs: number;
+	entry: TimelineEntry;
+};

--- a/src/modules/executions/ui/ExecutionDetails.tsx
+++ b/src/modules/executions/ui/ExecutionDetails.tsx
@@ -5,12 +5,14 @@ import {
 } from "@/shared/ui/PageHeader";
 import { Stat } from "@/modules/flows/ui/Stat";
 import { getCanShowDuration } from "@/shared/business-logic/duration";
+import { useScrollHighlight } from "@/shared/business-logic/use-scroll-highlight";
 import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
 import type { Execution } from "../domain/execution";
 import type { WaitCondition } from "../domain/wait-condition";
 import type { ResolveWaitConditionParams } from "../domain/resolve-wait-condition";
 import type { TimelineEntry } from "../domain/waiting-block";
 import { CheckpointThread } from "./traces/CheckpointThread";
+import { ExecutionTimelineBar } from "./traces/ExecutionTimelineBar";
 import { WaitInputSection } from "./WaitInputSection";
 
 type ExecutionDetailsProps = {
@@ -36,6 +38,16 @@ export function ExecutionDetails({
 		endTime: execution.endTime,
 	});
 
+	const scrollHighlight = useScrollHighlight();
+
+	const handleTimelineSelect = (entry: TimelineEntry) => {
+		scrollHighlight.focus(entry.data.id);
+
+		if (entry.kind === "checkpoint") {
+			onSelectCheckpoint(entry.data.id);
+		}
+	};
+
 	return (
 		<main className="flex min-h-0 flex-1 flex-col">
 			<PageHeader>
@@ -58,12 +70,15 @@ export function ExecutionDetails({
 					</PageHeaderBody>
 				</PageHeaderContent>
 			</PageHeader>
-			<div className="flex-1 overflow-y-auto">
-				<CheckpointThread
-					timelineEntries={timelineEntries}
-					onSelect={onSelectCheckpoint}
-				/>
-			</div>
+			<ExecutionTimelineBar
+				timelineEntries={timelineEntries}
+				onSelect={handleTimelineSelect}
+			/>
+			<CheckpointThread
+				timelineEntries={timelineEntries}
+				onSelect={onSelectCheckpoint}
+				highlightedId={scrollHighlight.highlightedId}
+			/>
 
 			{resumeHint && (
 				<>

--- a/src/modules/executions/ui/traces/CheckpointThread.tsx
+++ b/src/modules/executions/ui/traces/CheckpointThread.tsx
@@ -1,29 +1,65 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/shared/utils/styles";
 import { CheckpointRow } from "./CheckpointRow";
 import { WaitingBlockRow } from "./WaitingBlockRow";
 import type { TimelineEntry } from "../../domain/waiting-block";
 
-interface CheckpointThreadProps {
+type CheckpointThreadProps = {
 	timelineEntries: TimelineEntry[];
 	onSelect: (id: string) => void;
-}
+	highlightedId?: string;
+};
 
 export function CheckpointThread({
 	timelineEntries,
 	onSelect,
+	highlightedId,
 }: CheckpointThreadProps) {
 	return (
 		<div className="flex-1 space-y-3 overflow-y-auto p-6">
-			{timelineEntries.map((entry) =>
-				entry.kind === "waiting" ? (
-					<WaitingBlockRow key={entry.data.id} waitingBlock={entry.data} />
-				) : (
-					<CheckpointRow
-						key={entry.data.id}
-						checkpointEntry={entry.data}
-						onSelect={onSelect}
-					/>
-				)
+			{timelineEntries.map((entry) => (
+				<RowHighlightedWrapper
+					key={entry.data.id}
+					highlighted={highlightedId === entry.data.id}
+				>
+					{entry.kind === "waiting" ? (
+						<WaitingBlockRow waitingBlock={entry.data} />
+					) : (
+						<CheckpointRow checkpointEntry={entry.data} onSelect={onSelect} />
+					)}
+				</RowHighlightedWrapper>
+			))}
+		</div>
+	);
+}
+
+type RowHighlightedWrapperProps = {
+	highlighted?: boolean;
+	children: React.ReactNode;
+};
+
+function RowHighlightedWrapper({
+	highlighted,
+	children,
+}: RowHighlightedWrapperProps) {
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (highlighted) {
+			ref.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+		}
+	}, [highlighted]);
+
+	return (
+		<div
+			ref={ref}
+			className={cn(
+				"rounded-lg",
+				highlighted &&
+					"animate-highlight-blink ring-primary/40 ring-offset-background ring-1 ring-offset-2"
 			)}
+		>
+			{children}
 		</div>
 	);
 }

--- a/src/modules/executions/ui/traces/CheckpointThread.tsx
+++ b/src/modules/executions/ui/traces/CheckpointThread.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { cn } from "@/shared/utils/styles";
+import { HIGHLIGHT_MS } from "@/shared/business-logic/use-scroll-highlight";
 import { CheckpointRow } from "./CheckpointRow";
 import { WaitingBlockRow } from "./WaitingBlockRow";
 import type { TimelineEntry } from "../../domain/waiting-block";
@@ -16,7 +17,10 @@ export function CheckpointThread({
 	highlightedId,
 }: CheckpointThreadProps) {
 	return (
-		<div className="flex-1 space-y-3 overflow-y-auto p-6">
+		<div
+			className="flex-1 space-y-3 overflow-y-auto p-6"
+			style={{ "--highlight-duration": `${HIGHLIGHT_MS}ms` }}
+		>
 			{timelineEntries.map((entry) => (
 				<RowHighlightedWrapper
 					key={entry.data.id}

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { ColorDot } from "@/shared/ui/ColorDot";
+import { getCheckpointFillClass } from "./checkpoint-styles";
+import { formatDurationShort } from "@/shared/utils/time";
+import { cn } from "@/shared/utils/styles";
+import type { TimelineEntry } from "../../domain/waiting-block";
+
+type TimelineSegment = {
+	id: string;
+	name: string;
+	type: string;
+	durationMs: number;
+	entry: TimelineEntry;
+};
+
+function toSegment(entry: TimelineEntry): TimelineSegment | null {
+	if (entry.kind === "checkpoint") {
+		const durationMs = entry.data.durationMs ?? 0;
+		if (durationMs <= 0) return null;
+		return {
+			id: entry.data.id,
+			name: entry.data.name,
+			type: entry.data.type ?? "",
+			durationMs,
+			entry,
+		};
+	}
+	const durationMs = entry.data.waitDurationMs ?? 0;
+	if (durationMs <= 0) return null;
+	return {
+		id: entry.data.id,
+		name: "User Input",
+		type: "wait",
+		durationMs,
+		entry,
+	};
+}
+
+type ExecutionTimelineProps = {
+	timelineEntries: TimelineEntry[];
+	onSelect: (entry: TimelineEntry) => void;
+};
+
+export function ExecutionTimelineBar({
+	timelineEntries,
+	onSelect,
+}: ExecutionTimelineProps) {
+	const [selectedSegmentId, setSelectedSegmentId] = useState<string>();
+
+	const segments = timelineEntries
+		.map(toSegment)
+		.filter((s): s is TimelineSegment => s !== null);
+	const total = segments.reduce((sum, s) => sum + s.durationMs, 0);
+
+	if (total === 0) return null;
+
+	const handleSelect = (entry: TimelineEntry) => {
+		setSelectedSegmentId(entry.data.id);
+		onSelect(entry);
+	};
+
+	return (
+		<div className="border-border flex shrink-0 items-center border-b px-4 py-2.5">
+			<div
+				role="toolbar"
+				aria-label="Execution timeline"
+				className="flex h-7 w-full gap-0.5"
+			>
+				{segments.map((segment, index, arr) => {
+					const pct = (segment.durationMs / total) * 100;
+					const isSelected = segment.id === selectedSegmentId;
+					const isFirst = index === 0;
+					const isLast = index === arr.length - 1;
+					const fillClass = getCheckpointFillClass(segment.type);
+
+					return (
+						<Tooltip key={segment.id}>
+							<TooltipTrigger
+								render={
+									<button
+										type="button"
+										onClick={() => handleSelect(segment.entry)}
+										aria-label={`${segment.name}, duration ${formatDurationShort(segment.durationMs)}`}
+										aria-pressed={isSelected}
+										className={cn(
+											"relative h-full transition-opacity",
+											isFirst && "rounded-l-md",
+											isLast && "rounded-r-md",
+											fillClass,
+											isSelected
+												? "ring-foreground opacity-100 ring-2 ring-inset"
+												: "opacity-80 hover:opacity-100"
+										)}
+										style={{ width: `${Math.max(pct, 1.5)}%` }}
+									/>
+								}
+							/>
+							<TooltipContent
+								side="bottom"
+								className="block max-w-64 overflow-hidden p-0"
+							>
+								<div className="border-background/20 flex items-center gap-2 border-b px-3 py-2">
+									<ColorDot size="sm" className={cn("shrink-0", fillClass)} />
+									<span className="min-w-0 flex-1 truncate font-mono text-xs font-semibold">
+										{segment.name}
+									</span>
+									{segment.type && (
+										<span className="text-2xs shrink-0 font-medium opacity-70">
+											{segment.type}
+										</span>
+									)}
+								</div>
+								<div className="grid grid-cols-2 gap-x-4 gap-y-1 px-3 py-2 text-xs">
+									<span className="opacity-70">Duration</span>
+									<span className="text-right font-mono tabular-nums">
+										{formatDurationShort(segment.durationMs)}
+									</span>
+								</div>
+							</TooltipContent>
+						</Tooltip>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -4,6 +4,7 @@ import { ColorDot } from "@/shared/ui/ColorDot";
 import { getCheckpointFillClass } from "./checkpoint-styles";
 import { formatDurationShort } from "@/shared/utils/time";
 import { cn } from "@/shared/utils/styles";
+import { computeTimelineWidths } from "../../util/timeline-scale";
 import type { TimelineEntry } from "../../domain/waiting-block";
 
 type TimelineSegment = {
@@ -52,6 +53,7 @@ export function ExecutionTimelineBar({
 		.map(toSegment)
 		.filter((s): s is TimelineSegment => s !== null);
 	const total = segments.reduce((sum, s) => sum + s.durationMs, 0);
+	const widths = computeTimelineWidths(segments.map((s) => s.durationMs));
 
 	if (total === 0) return null;
 
@@ -68,7 +70,6 @@ export function ExecutionTimelineBar({
 				className="flex h-7 w-full gap-0.5"
 			>
 				{segments.map((segment, index, arr) => {
-					const pct = (segment.durationMs / total) * 100;
 					const isSelected = segment.id === selectedSegmentId;
 					const isFirst = index === 0;
 					const isLast = index === arr.length - 1;
@@ -92,7 +93,7 @@ export function ExecutionTimelineBar({
 												? "ring-foreground opacity-100 ring-2 ring-inset"
 												: "opacity-80 hover:opacity-100"
 										)}
-										style={{ width: `${Math.max(pct, 1.5)}%` }}
+										style={{ width: `${widths[index]}%`, minWidth: "6px" }}
 									/>
 								}
 							/>

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -56,7 +56,7 @@ export function ExecutionTimelineBar({
 										aria-label={`${segment.name}, duration ${formatDurationShort(segment.durationMs)}`}
 										aria-pressed={isSelected}
 										className={cn(
-											"relative h-full transition-opacity",
+											"relative h-full min-w-[6px] transition-opacity",
 											isFirst && "rounded-l-md",
 											isLast && "rounded-r-md",
 											fillClass,
@@ -64,7 +64,7 @@ export function ExecutionTimelineBar({
 												? "ring-foreground opacity-100 ring-2 ring-inset"
 												: "opacity-80 hover:opacity-100"
 										)}
-										style={{ width: `${widths[index]}%`, minWidth: "6px" }}
+										style={{ width: `${widths[index]}%` }}
 									/>
 								}
 							/>

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -6,39 +6,10 @@ import { formatDurationShort } from "@/shared/utils/time";
 import { cn } from "@/shared/utils/styles";
 import { computeTimelineWidths } from "../../util/timeline-scale";
 import type { TimelineEntry } from "../../domain/waiting-block";
+import type { TimelineSegment } from "../../domain/timeline-segment";
+import { timelineEntryToSegment } from "../../business-logic/timeline-entry-to-segment";
 
-type TimelineSegment = {
-	id: string;
-	name: string;
-	type: string;
-	durationMs: number;
-	entry: TimelineEntry;
-};
-
-function toSegment(entry: TimelineEntry): TimelineSegment | null {
-	if (entry.kind === "checkpoint") {
-		const durationMs = entry.data.durationMs ?? 0;
-		if (durationMs <= 0) return null;
-		return {
-			id: entry.data.id,
-			name: entry.data.name,
-			type: entry.data.type ?? "",
-			durationMs,
-			entry,
-		};
-	}
-	const durationMs = entry.data.waitDurationMs ?? 0;
-	if (durationMs <= 0) return null;
-	return {
-		id: entry.data.id,
-		name: "User Input",
-		type: "wait",
-		durationMs,
-		entry,
-	};
-}
-
-type ExecutionTimelineProps = {
+type ExecutionTimelineBarProps = {
 	timelineEntries: TimelineEntry[];
 	onSelect: (entry: TimelineEntry) => void;
 };
@@ -46,11 +17,11 @@ type ExecutionTimelineProps = {
 export function ExecutionTimelineBar({
 	timelineEntries,
 	onSelect,
-}: ExecutionTimelineProps) {
+}: ExecutionTimelineBarProps) {
 	const [selectedSegmentId, setSelectedSegmentId] = useState<string>();
 
 	const segments = timelineEntries
-		.map(toSegment)
+		.map(timelineEntryToSegment)
 		.filter((s): s is TimelineSegment => s !== null);
 	const total = segments.reduce((sum, s) => sum + s.durationMs, 0);
 	const widths = computeTimelineWidths(segments.map((s) => s.durationMs));

--- a/src/modules/executions/util/timeline-scale.spec.ts
+++ b/src/modules/executions/util/timeline-scale.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { computeTimelineWidths } from "./timeline-scale";
+
+describe("computeTimelineWidths", () => {
+	it("returns an empty array for empty input", () => {
+		expect(computeTimelineWidths([])).toEqual([]);
+	});
+
+	it("returns [100] for a single duration", () => {
+		expect(computeTimelineWidths([42])).toEqual([100]);
+	});
+
+	it("splits equal durations into equal widths summing to 100", () => {
+		const widths = computeTimelineWidths([5, 5, 5, 5]);
+		expect(widths).toHaveLength(4);
+		for (const w of widths) {
+			expect(w).toBeCloseTo(25, 9);
+		}
+		const sum = widths.reduce((a, b) => a + b, 0);
+		expect(sum).toBeCloseTo(100, 9);
+	});
+
+	it("returns all zeros when every duration is zero", () => {
+		expect(computeTimelineWidths([0, 0, 0])).toEqual([0, 0, 0]);
+	});
+
+	it("scales widths by sqrt of duration ratio", () => {
+		const [long, short] = computeTimelineWidths([300_000, 5_000]);
+		expect(long / short).toBeCloseTo(Math.sqrt(300_000 / 5_000), 9);
+	});
+
+	it("produces the expected distribution for a long-plus-shorts mix", () => {
+		const durations = [
+			300_000, 1_000, 2_000, 3_000, 4_000, 5_000, 6_000, 7_000, 8_000, 9_000,
+			10_000,
+		];
+		const widths = computeTimelineWidths(durations);
+
+		const sum = widths.reduce((a, b) => a + b, 0);
+		expect(sum).toBeCloseTo(100, 9);
+
+		expect(widths[0]).toBeCloseTo(43.51, 1);
+		expect(widths[10]).toBeCloseTo(7.95, 1);
+
+		for (let i = 1; i < widths.length - 1; i++) {
+			expect(widths[i + 1]).toBeGreaterThan(widths[i]);
+		}
+	});
+
+	it("assigns zero width to zero durations while normalizing positives to 100", () => {
+		const widths = computeTimelineWidths([0, 10_000, 0, 40_000]);
+		expect(widths[0]).toBe(0);
+		expect(widths[2]).toBe(0);
+		const sum = widths.reduce((a, b) => a + b, 0);
+		expect(sum).toBeCloseTo(100, 9);
+		expect(widths[3] / widths[1]).toBeCloseTo(Math.sqrt(40_000 / 10_000), 9);
+	});
+});

--- a/src/modules/executions/util/timeline-scale.ts
+++ b/src/modules/executions/util/timeline-scale.ts
@@ -1,0 +1,14 @@
+export const POWER_SCALE_EXPONENT = 0.5;
+
+export function computeTimelineWidths(durations: number[]): number[] {
+	if (durations.length === 0) return [];
+	if (durations.length === 1) return [100];
+
+	const scaled = durations.map((d) =>
+		d > 0 ? Math.pow(d, POWER_SCALE_EXPONENT) : 0
+	);
+	const total = scaled.reduce((sum, v) => sum + v, 0);
+	if (total === 0) return durations.map(() => 0);
+
+	return scaled.map((v) => (v / total) * 100);
+}

--- a/src/react-css.d.ts
+++ b/src/react-css.d.ts
@@ -1,0 +1,7 @@
+import "react";
+
+declare module "react" {
+	interface CSSProperties {
+		[key: `--${string}`]: string | number | undefined;
+	}
+}

--- a/src/shared/business-logic/use-scroll-highlight.ts
+++ b/src/shared/business-logic/use-scroll-highlight.ts
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-// Keep in sync with the `highlight-blink` keyframe duration in tailwind.css.
-const HIGHLIGHT_MS = 1500;
+export const HIGHLIGHT_MS = 1500;
 
 export function useScrollHighlight() {
 	const [highlightedId, setHighlightedId] = useState<string | undefined>();

--- a/src/shared/business-logic/use-scroll-highlight.ts
+++ b/src/shared/business-logic/use-scroll-highlight.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, useState } from "react";
+
+// Keep in sync with the `highlight-blink` keyframe duration in tailwind.css.
+const HIGHLIGHT_MS = 1500;
+
+export function useScrollHighlight() {
+	const [highlightedId, setHighlightedId] = useState<string | undefined>();
+	const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (timer.current) clearTimeout(timer.current);
+		};
+	}, []);
+
+	const focus = (id: string) => {
+		if (timer.current) clearTimeout(timer.current);
+		setHighlightedId(id);
+		timer.current = setTimeout(() => setHighlightedId(undefined), HIGHLIGHT_MS);
+	};
+
+	return { highlightedId, focus };
+}


### PR DESCRIPTION


Uploading Screen Recording 2026-04-13 at 17.12.48.mov…

## Summary

- Adds an interactive timeline bar above the checkpoint thread. Colored segments proportional to duration, hover tooltips with name / type / duration, and click-to-focus that scrolls the matching row in the thread and blinks a highlight ring around it for ~1.5s.
- Wait blocks appear as warning-colored segments alongside checkpoints. Clicking a wait segment scrolls to the row but does not open the checkpoint detail panel (wait ids aren't checkpoint ids).
- New `useScrollHighlight` hook in `shared/business-logic` — small reusable "scroll a row into view + blink a ring" primitive. The row wrapper owns its own ref + effect, so the hook stays registry-free.
