### PR TITLE
reafctor: UI improvements #21

### DIFF
--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -66,11 +66,13 @@ function CheckpointDetailPanelContentContainer({
 
 	return (
 		<div className="flex h-full flex-col">
-			<CheckpointDetailPanelHeader checkpoint={detailsData} />
-			<CheckpointDetailPanelTabs
-				activeTab={activeTab}
-				onTabChange={handleTabChange}
-			/>
+			<div className="border-border bg-card shrink-0 border-b">
+				<CheckpointDetailPanelHeader checkpoint={detailsData} />
+				<CheckpointDetailPanelTabs
+					activeTab={activeTab}
+					onTabChange={handleTabChange}
+				/>
+			</div>
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				{activeTab === "checkpoint" && (
 					<CheckpointDetailPanelInfo checkpoint={detailsData} />

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelHeader.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelHeader.tsx
@@ -12,7 +12,7 @@ export function CheckpointDetailPanelHeader({
 	checkpoint,
 }: CheckpointDetailPanelHeaderProps) {
 	return (
-		<div className="border-border flex h-10 shrink-0 items-center gap-2 border-b px-4">
+		<div className="flex h-10 shrink-0 items-center gap-2 px-4">
 			{checkpoint.type && <CheckpointTypeBadge type={checkpoint.type} />}
 			{checkpoint.costUsd !== undefined && (
 				<Badge variant="secondary">{formatCost(checkpoint.costUsd)}</Badge>

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelSkeleton.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelSkeleton.tsx
@@ -3,13 +3,15 @@ import { Skeleton } from "@/shared/ui/skeleton";
 export function CheckpointDetailPanelSkeleton() {
 	return (
 		<div className="flex h-full flex-col">
-			<div className="border-border flex h-10 shrink-0 items-center gap-2 border-b px-4">
-				<Skeleton className="h-4 w-16" />
-				<Skeleton className="h-4 w-32" />
-			</div>
-			<div className="border-border flex h-9 shrink-0 items-center gap-4 border-b px-4">
-				<Skeleton className="h-3 w-16" />
-				<Skeleton className="h-3 w-16" />
+			<div className="border-border bg-card shrink-0 border-b">
+				<div className="flex h-10 shrink-0 items-center gap-2 px-4">
+					<Skeleton className="h-4 w-16" />
+					<Skeleton className="h-4 w-32" />
+				</div>
+				<div className="flex h-9 shrink-0 items-center gap-4 px-4">
+					<Skeleton className="h-3 w-16" />
+					<Skeleton className="h-3 w-16" />
+				</div>
 			</div>
 			<div className="space-y-3 p-4">
 				{Array.from({ length: 4 }).map((_, i) => (

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
@@ -12,7 +12,7 @@ export function CheckpointDetailPanelTabs({
 	onTabChange,
 }: CheckpointDetailPanelTabsProps) {
 	return (
-		<div className="border-border bg-background flex shrink-0 items-center border-b">
+		<div className="flex shrink-0 items-center">
 			{(["checkpoint", "artifacts", "memory"] as const).map((tab) => (
 				<button
 					key={tab}

--- a/src/modules/executions/ui/traces/ArtifactChip.tsx
+++ b/src/modules/executions/ui/traces/ArtifactChip.tsx
@@ -12,7 +12,7 @@ export function ArtifactChip({ name, isSelected, onClick }: ArtifactChipProps) {
 		<button
 			type="button"
 			className={cn(
-				"text-2xs inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full border px-2 py-0.5 font-mono font-normal transition-colors",
+				"inline-flex shrink-0 cursor-pointer items-center gap-1 rounded-full border px-3 py-1 font-mono text-xs font-normal transition-colors",
 				isSelected
 					? "bg-primary text-primary-foreground border-transparent"
 					: "border-border text-foreground hover:bg-accent"

--- a/src/modules/executions/ui/traces/CheckpointTypeBadge.tsx
+++ b/src/modules/executions/ui/traces/CheckpointTypeBadge.tsx
@@ -26,7 +26,7 @@ export function CheckpointTypeBadge({ type }: CheckpointTypeBadgeProps) {
 		<Badge
 			variant="secondary"
 			className={cn(
-				"text-2xs border-0 px-1.5 py-0 font-mono font-medium",
+				"text-2xs rounded-sm border-current/20 px-1.5 py-0 font-mono font-medium",
 				getCheckpointSurfaceClass(type),
 				getCheckpointTextClass(type)
 			)}

--- a/src/modules/executions/ui/traces/JsonArtifactViewer.tsx
+++ b/src/modules/executions/ui/traces/JsonArtifactViewer.tsx
@@ -125,7 +125,7 @@ export function JsonArtifactViewer({ data }: JsonArtifactViewerProps) {
 	}
 
 	return (
-		<pre className="text-2xs p-4 font-mono leading-relaxed break-words whitespace-pre-wrap">
+		<pre className="p-4 font-mono text-xs leading-relaxed break-words whitespace-pre-wrap">
 			<JsonValue value={data} depth={0} />
 		</pre>
 	);

--- a/src/modules/executions/ui/traces/VisualizationViewer.tsx
+++ b/src/modules/executions/ui/traces/VisualizationViewer.tsx
@@ -20,7 +20,7 @@ function InlineMarkdown({ text }: { text: string }) {
 					return (
 						<code
 							key={i}
-							className="bg-muted text-2xs text-foreground rounded px-1 py-0.5 font-mono"
+							className="bg-muted text-foreground rounded px-1 py-0.5 font-mono text-xs"
 						>
 							{part.slice(1, -1)}
 						</code>
@@ -76,7 +76,7 @@ export function VisualizationViewer({ artifact }: VisualizationViewerProps) {
 									>
 										{block.lang && (
 											<div className="border-border bg-muted/50 border-b px-4 py-1.5">
-												<span className="text-2xs text-muted-foreground font-mono">
+												<span className="text-muted-foreground font-mono text-xs">
 													{block.lang}
 												</span>
 											</div>
@@ -103,7 +103,7 @@ export function VisualizationViewer({ artifact }: VisualizationViewerProps) {
 										key={i}
 										className="border-border overflow-x-auto rounded-md border"
 									>
-										<table className="text-2xs w-full">
+										<table className="w-full text-xs">
 											<thead>
 												<tr className="bg-muted/50 border-border border-b">
 													{block.headers.map((h, j) => (

--- a/src/modules/memory/ui/MemoryChip.tsx
+++ b/src/modules/memory/ui/MemoryChip.tsx
@@ -29,8 +29,9 @@ export function MemoryChip({
 		<Badge
 			render={<button type="button" />}
 			variant={isSelected ? "default" : "outline"}
+			size="lg"
 			className={cn(
-				"text-2xs shrink-0 cursor-pointer gap-1 px-2 py-0.5 font-mono font-normal transition-colors",
+				"shrink-0 cursor-pointer gap-1 font-mono font-normal transition-colors",
 				isSelected && "bg-primary text-primary-foreground",
 				!isSelected && "hover:bg-accent",
 				isDeleted && "line-through opacity-60"

--- a/src/modules/memory/ui/MemoryChip.tsx
+++ b/src/modules/memory/ui/MemoryChip.tsx
@@ -1,12 +1,13 @@
+import { Database01 } from "@untitledui/icons";
 import { Badge } from "@/shared/ui/badge";
 import { cn } from "@/shared/utils/styles";
 import type { MemoryScopeType } from "../domain/memory";
 
 const SCOPE_COLOR: Record<MemoryScopeType, string> = {
-	namespace: "bg-info",
-	flow: "bg-primary",
-	execution: "bg-muted-foreground",
-	unknown: "bg-muted-foreground",
+	namespace: "text-info",
+	flow: "text-primary",
+	execution: "text-muted-foreground",
+	unknown: "text-muted-foreground",
 };
 
 type MemoryChipProps = {
@@ -38,10 +39,10 @@ export function MemoryChip({
 			onClick={onClick}
 			title={label}
 		>
-			<span
+			<Database01
 				className={cn(
-					"size-1.5 shrink-0 rounded-full",
-					isSelected ? "bg-primary-foreground/70" : SCOPE_COLOR[scopeType]
+					"size-3 shrink-0",
+					isSelected ? "text-primary-foreground/70" : SCOPE_COLOR[scopeType]
 				)}
 			/>
 			<span className="max-w-40 truncate">{label}</span>

--- a/src/shared/ui/CodeBlock.tsx
+++ b/src/shared/ui/CodeBlock.tsx
@@ -61,7 +61,7 @@ export function CodeBlock({
 		return (
 			<pre
 				className={cn(
-					"text-2xs text-foreground p-4 font-mono leading-relaxed",
+					"text-foreground p-4 font-mono text-xs leading-relaxed",
 					wrap
 						? "break-words whitespace-pre-wrap"
 						: "overflow-x-auto whitespace-pre",
@@ -76,7 +76,7 @@ export function CodeBlock({
 	return (
 		<div
 			className={cn(
-				"[&_pre]:text-2xs [&_pre]:m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:font-mono [&_pre]:leading-relaxed",
+				"[&_pre]:m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:font-mono [&_pre]:text-xs [&_pre]:leading-relaxed",
 				"[&_.shiki]:!bg-transparent",
 				wrap
 					? "[&_pre]:break-words [&_pre]:whitespace-pre-wrap"

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/shared/utils/styles";
 
 const badgeVariants = cva(
-	"group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+	"group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
 	{
 		variants: {
 			variant: {
@@ -21,9 +21,14 @@ const badgeVariants = cva(
 				link: "text-primary underline-offset-4 hover:underline",
 				success: "bg-success text-success-foreground [a]:hover:bg-success/80",
 			},
+			size: {
+				md: "h-5 px-2 py-0.5 text-xs",
+				lg: "h-6 px-3 py-1 text-xs",
+			},
 		},
 		defaultVariants: {
 			variant: "default",
+			size: "md",
 		},
 	}
 );
@@ -31,6 +36,7 @@ const badgeVariants = cva(
 function Badge({
 	className,
 	variant = "default",
+	size = "md",
 	render,
 	...props
 }: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
@@ -38,7 +44,7 @@ function Badge({
 		defaultTagName: "span",
 		props: mergeProps<"span">(
 			{
-				className: cn(badgeVariants({ variant }), className),
+				className: cn(badgeVariants({ variant, size }), className),
 			},
 			props
 		),


### PR DESCRIPTION
## Summary

Ports a set of visual refinements from [kitaru-test-prototypes#21](https://github.com/zenml-io/kitaru-test-prototypes/pull/21):

- **Point 5** — Combined checkpoint detail header + tabs inside a single `bg-card` container with one shared border.
- **Point 7** — `CheckpointTypeBadge` now uses `rounded-sm` with subtle `border-current/20` instead of a fully rounded pill.
- **Point 8** — `ArtifactChip` and `MemoryChip` bumped from `text-2xs px-2 py-0.5` to `text-xs px-3 py-1` for better clickability. `Badge` now exposes a `size` variant (`md` default, `lg`) so `MemoryChip` can drop its `h-auto` override.
- **Point 9** — `MemoryChip` replaces its inline color dot with a `Database01` icon (from `@untitledui/icons`) tinted to the scope color.
- **Point 10** — All artifact text bumped from `text-2xs` to `text-xs`: `CodeBlock` (fallback + shiki), `JsonArtifactViewer`, markdown tables, inline code, and markdown code-block lang labels.
