### PR TITLE
feat(ui): add TruncatedText with overflow-only tooltip

### DIFF
--- a/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
@@ -2,6 +2,7 @@ import { VisualizationErrorBoundary } from "@/modules/executions/ui/Visualizatio
 import { ArtifactChip } from "@/modules/executions/ui/traces/ArtifactChip";
 import { ChipBar } from "@/shared/ui/ChipBar";
 import { Separator } from "@/shared/ui/separator";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { ArtifactEntry } from "../domain/checkpoint";
@@ -55,9 +56,9 @@ export function CheckpointDetailPanelArtifacts({
 			{hasVisibleArtifacts && selectedArtifact && (
 				<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
 					<div className="bg-muted/50 flex items-center justify-between px-4 py-2">
-						<span className="text-foreground truncate text-xs font-semibold">
+						<TruncatedText className="text-foreground text-xs font-semibold">
 							{selectedArtifact.artifact.name}
-						</span>
+						</TruncatedText>
 						<div className="flex items-center gap-1">
 							<DownloadArtifactButtonContainer
 								artifactVersionId={selectedArtifact.artifact.id}

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelHeader.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelHeader.tsx
@@ -3,6 +3,7 @@ import type { Checkpoint } from "../domain/checkpoint";
 import { Badge } from "@/shared/ui/badge";
 import { formatCost } from "@/shared/utils/currency";
 import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 
 type CheckpointDetailPanelHeaderProps = {
 	checkpoint: Checkpoint;
@@ -17,9 +18,9 @@ export function CheckpointDetailPanelHeader({
 			{checkpoint.costUsd !== undefined && (
 				<Badge variant="secondary">{formatCost(checkpoint.costUsd)}</Badge>
 			)}
-			<span className="text-foreground truncate font-mono text-xs font-semibold">
+			<TruncatedText className="text-foreground font-mono text-xs font-semibold">
 				{checkpoint.name}
-			</span>
+			</TruncatedText>
 			<span className="flex-1" />
 			<LiveDurationMs
 				status={checkpoint.status}

--- a/src/modules/checkpoints/ui/FullscreenArtifactDialogContent.tsx
+++ b/src/modules/checkpoints/ui/FullscreenArtifactDialogContent.tsx
@@ -7,6 +7,7 @@ import {
 	DialogTitle,
 } from "@/shared/ui/dialog";
 import { Separator } from "@/shared/ui/separator";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { XClose } from "@untitledui/icons";
 
 type Props = {
@@ -26,8 +27,8 @@ export function FullscreenArtifactDialogContent({
 			className="flex h-[90vh] w-[90vw] flex-col gap-0 p-0 sm:max-w-[90vw]"
 		>
 			<DialogHeader className="bg-muted/50 flex-row items-center justify-between px-4 py-2">
-				<DialogTitle className="text-foreground truncate text-xs font-semibold">
-					{name}
+				<DialogTitle className="text-foreground text-xs font-semibold">
+					<TruncatedText>{name}</TruncatedText>
 				</DialogTitle>
 				<div className="flex items-center gap-1">
 					{actions}

--- a/src/modules/executions/ui/ExecutionsList.tsx
+++ b/src/modules/executions/ui/ExecutionsList.tsx
@@ -36,6 +36,7 @@ export function ExecutionsList({
 					<ExecutionName index={execution.index} />
 					<div className="flex shrink-0 items-center gap-1.5">
 						<StatusDot
+							showTooltip={false}
 							status={(execution.status ?? "unknown") as StatusDotVariant}
 						/>
 						<span className="text-muted-foreground text-xs capitalize">

--- a/src/modules/executions/ui/traces/ArtifactChip.tsx
+++ b/src/modules/executions/ui/traces/ArtifactChip.tsx
@@ -1,4 +1,5 @@
 import { File02 } from "@untitledui/icons";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { cn } from "@/shared/utils/styles";
 
 type ArtifactChipProps = {
@@ -21,7 +22,7 @@ export function ArtifactChip({ name, isSelected, onClick }: ArtifactChipProps) {
 			onClick={onClick}
 		>
 			<File02 className="size-3" />
-			<span className="max-w-[120px] truncate">{name}</span>
+			<TruncatedText className="max-w-[120px]">{name}</TruncatedText>
 		</button>
 	);
 }

--- a/src/modules/executions/ui/traces/CheckpointRow.tsx
+++ b/src/modules/executions/ui/traces/CheckpointRow.tsx
@@ -4,6 +4,7 @@ import { CheckpointRowArtifacts } from "./CheckpointRowArtifacts";
 import { ExpandableRow } from "./ExpandableRow";
 import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
 import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 
 type CheckpointRowProps = {
 	checkpointEntry: CheckpointEntry;
@@ -22,9 +23,9 @@ export function CheckpointRow({
 					{checkpointEntry.type && (
 						<CheckpointTypeBadge type={checkpointEntry.type} />
 					)}
-					<span className="text-foreground truncate font-mono text-xs font-semibold">
+					<TruncatedText className="text-foreground font-mono text-xs font-semibold">
 						{checkpointEntry.name}
-					</span>
+					</TruncatedText>
 					<span className="flex-1" />
 					<LiveDurationMs
 						status={checkpointEntry.status}

--- a/src/modules/executions/ui/traces/CheckpointRowArtifacts.tsx
+++ b/src/modules/executions/ui/traces/CheckpointRowArtifacts.tsx
@@ -12,6 +12,7 @@ import { Suspense, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { VisualizationErrorBoundary } from "../VisualizationErrorBoundary";
 import { NoArtifactsMessage } from "@/modules/checkpoints/ui/NoArtifactsMessage";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { ArtifactChip } from "./ArtifactChip";
 
 function CheckpointRowArtifactsContent({
@@ -89,9 +90,9 @@ function CheckpointRowArtifactsContent({
 			{selected && (
 				<div className="border-border overflow-hidden rounded-lg border">
 					<div className="bg-muted/50 border-border flex items-center justify-between border-b px-4 py-2">
-						<span className="text-foreground truncate text-xs font-semibold">
+						<TruncatedText className="text-foreground text-xs font-semibold">
 							{selected.entry.name}
-						</span>
+						</TruncatedText>
 						<div className="flex items-center gap-1">
 							<DownloadArtifactButtonContainer
 								artifactVersionId={selected.entry.id}

--- a/src/modules/memory/ui/MemoryChip.tsx
+++ b/src/modules/memory/ui/MemoryChip.tsx
@@ -1,5 +1,6 @@
 import { Database01 } from "@untitledui/icons";
 import { Badge } from "@/shared/ui/badge";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { cn } from "@/shared/utils/styles";
 import type { MemoryScopeType } from "../domain/memory";
 
@@ -38,7 +39,6 @@ export function MemoryChip({
 			)}
 			aria-pressed={isSelected}
 			onClick={onClick}
-			title={label}
 		>
 			<Database01
 				className={cn(
@@ -46,7 +46,7 @@ export function MemoryChip({
 					isSelected ? "text-primary-foreground/70" : SCOPE_COLOR[scopeType]
 				)}
 			/>
-			<span className="max-w-40 truncate">{label}</span>
+			<TruncatedText className="max-w-40">{label}</TruncatedText>
 		</Badge>
 	);
 }

--- a/src/modules/memory/ui/MemoryDetailPanel.tsx
+++ b/src/modules/memory/ui/MemoryDetailPanel.tsx
@@ -1,3 +1,4 @@
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import type { MemoryEntry } from "../domain/memory";
 import { MemoryMetadata } from "./MemoryMetadata";
 
@@ -16,7 +17,11 @@ export function MemoryDetailPanel({
 		<div className="flex h-full flex-col overflow-hidden">
 			{/* Header + metadata */}
 			<div className="border-border shrink-0 border-b px-4 py-3">
-				<h2 className="mb-2 truncate text-sm font-semibold">{entry.key}</h2>
+				<h2 className="mb-2">
+					<TruncatedText className="text-sm font-semibold">
+						{entry.key}
+					</TruncatedText>
+				</h2>
 				<MemoryMetadata entry={entry} />
 			</div>
 

--- a/src/modules/memory/ui/MemoryMetadata.tsx
+++ b/src/modules/memory/ui/MemoryMetadata.tsx
@@ -2,6 +2,7 @@ import type { MemoryEntry } from "../domain/memory";
 import { Badge } from "@/shared/ui/badge";
 import { DetailItem } from "@/shared/ui/detail-list/DetailItem";
 import { DetailList } from "@/shared/ui/detail-list/DetailList";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 
 type MemoryMetadataProps = {
 	entry: MemoryEntry;
@@ -31,9 +32,9 @@ export function MemoryMetadata({ entry }: MemoryMetadataProps) {
 				{entry.createdAt.toLocaleString()}
 			</DetailItem>
 			<DetailItem label="Artifact ID">
-				<code className="text-muted-foreground truncate font-mono">
+				<TruncatedText className="text-muted-foreground font-mono">
 					{entry.artifactId}
-				</code>
+				</TruncatedText>
 			</DetailItem>
 		</DetailList>
 	);

--- a/src/modules/memory/ui/MemorySidebar.tsx
+++ b/src/modules/memory/ui/MemorySidebar.tsx
@@ -1,5 +1,6 @@
 import type { MemoryEntry, MemoryScopeInfo } from "../domain/memory";
 import { Badge } from "@/shared/ui/badge";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import { cn } from "@/shared/utils/styles";
 import { formatRelativeTime } from "@/shared/utils/time";
 import { MemoryScopeSelector } from "./MemoryScopeSelector";
@@ -69,14 +70,14 @@ export function MemorySidebar({
 							)}
 						>
 							<div className="flex w-full items-center gap-1.5">
-								<span
+								<TruncatedText
 									className={cn(
-										"min-w-0 flex-1 truncate font-mono text-xs font-medium",
+										"min-w-0 flex-1 font-mono text-xs font-medium",
 										entry.isDeleted && "line-through opacity-60"
 									)}
 								>
 									{entry.key}
-								</span>
+								</TruncatedText>
 								<Badge
 									variant="secondary"
 									className="text-2xs shrink-0 font-mono"

--- a/src/modules/memory/ui/MemoryToolbar.tsx
+++ b/src/modules/memory/ui/MemoryToolbar.tsx
@@ -24,15 +24,18 @@ export function MemoryToolbar({
 }: MemoryToolbarProps) {
 	const prefix = selectedKey?.includes("/")
 		? selectedKey.slice(0, selectedKey.lastIndexOf("/") + 1)
-		: null;
+		: undefined;
 	const name = selectedKey?.includes("/")
 		? selectedKey.slice(selectedKey.lastIndexOf("/") + 1)
 		: selectedKey;
 
 	return (
-		<div className="flex flex-1 items-center gap-2">
+		<div className="flex flex-1 items-center gap-2 overflow-hidden">
 			{selectedKey && (
-				<TruncatedText className="font-mono text-sm font-semibold">
+				<TruncatedText
+					className="font-mono text-sm font-semibold"
+					tooltipLabel={`${prefix}${name}`}
+				>
 					{prefix && (
 						<span className="text-muted-foreground font-normal">{prefix}</span>
 					)}

--- a/src/modules/memory/ui/MemoryToolbar.tsx
+++ b/src/modules/memory/ui/MemoryToolbar.tsx
@@ -1,4 +1,5 @@
 import { RefreshButton } from "@/shared/ui/RefreshButton";
+import { TruncatedText } from "@/shared/ui/truncated-text";
 import type { MemoryEntry } from "../domain/memory";
 import { VersionSelector } from "./VersionSelector";
 
@@ -31,12 +32,12 @@ export function MemoryToolbar({
 	return (
 		<div className="flex flex-1 items-center gap-2">
 			{selectedKey && (
-				<span className="truncate font-mono text-sm font-semibold">
+				<TruncatedText className="font-mono text-sm font-semibold">
 					{prefix && (
 						<span className="text-muted-foreground font-normal">{prefix}</span>
 					)}
 					{name}
-				</span>
+				</TruncatedText>
 			)}
 
 			{selectedEntry && history && history.length > 0 && (

--- a/src/shared/ui/StatusDot.tsx
+++ b/src/shared/ui/StatusDot.tsx
@@ -1,5 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import { ColorDot } from "./ColorDot";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
 
 const statusDotVariants = cva("", {
 	variants: {
@@ -29,8 +30,14 @@ export type StatusDotVariant = NonNullable<
 	VariantProps<typeof statusDotVariants>["status"]
 >;
 
-function StatusDot({ status }: { status: StatusDotVariant }) {
-	return (
+function StatusDot({
+	status,
+	showTooltip = true,
+}: {
+	status: StatusDotVariant;
+	showTooltip?: boolean;
+}) {
+	const dot = (
 		<ColorDot
 			shape="round"
 			size="sm"
@@ -38,6 +45,17 @@ function StatusDot({ status }: { status: StatusDotVariant }) {
 			data-status={status}
 			className={statusDotVariants({ status })}
 		/>
+	);
+
+	if (!showTooltip) return dot;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger render={dot} />
+			<TooltipContent>
+				<span className="capitalize">{status}</span>
+			</TooltipContent>
+		</Tooltip>
 	);
 }
 

--- a/src/shared/ui/Table/CellRenderer.tsx
+++ b/src/shared/ui/Table/CellRenderer.tsx
@@ -31,7 +31,7 @@ function MetricValueRenderer({ children }: { children: React.ReactNode }) {
 function StatusRenderer({ status = "unknown" }: { status?: StatusDotVariant }) {
 	return (
 		<div className="flex items-center gap-2">
-			<StatusDot status={status} />
+			<StatusDot status={status} showTooltip={false} />
 			<span className="text-foreground text-sm capitalize">{status}</span>
 		</div>
 	);

--- a/src/shared/ui/truncated-text.tsx
+++ b/src/shared/ui/truncated-text.tsx
@@ -9,11 +9,16 @@ function isOverflowing(el: HTMLElement): boolean {
 	return range.getBoundingClientRect().width > el.getBoundingClientRect().width;
 }
 
+type TruncatedTextProps = React.ComponentProps<"span"> & {
+	tooltipLabel?: string;
+};
+
 function TruncatedText({
 	children,
 	className,
+	tooltipLabel,
 	...props
-}: React.ComponentProps<"span">) {
+}: TruncatedTextProps) {
 	const ref = React.useRef<HTMLSpanElement>(null);
 	const [open, setOpen] = React.useState(false);
 
@@ -36,7 +41,7 @@ function TruncatedText({
 					</span>
 				}
 			/>
-			<TooltipContent>{children}</TooltipContent>
+			<TooltipContent>{tooltipLabel ?? children}</TooltipContent>
 		</Tooltip>
 	);
 }

--- a/src/shared/ui/truncated-text.tsx
+++ b/src/shared/ui/truncated-text.tsx
@@ -1,0 +1,44 @@
+import * as React from "react";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { cn } from "@/shared/utils/styles";
+
+function isOverflowing(el: HTMLElement): boolean {
+	const range = document.createRange();
+	range.selectNodeContents(el);
+	return range.getBoundingClientRect().width > el.getBoundingClientRect().width;
+}
+
+function TruncatedText({
+	children,
+	className,
+	...props
+}: React.ComponentProps<"span">) {
+	const ref = React.useRef<HTMLSpanElement>(null);
+	const [open, setOpen] = React.useState(false);
+
+	return (
+		<Tooltip
+			open={open}
+			onOpenChange={(next) => {
+				setOpen(next && !!ref.current && isOverflowing(ref.current));
+			}}
+		>
+			<TooltipTrigger
+				render={
+					<span
+						ref={ref}
+						data-slot="truncated-text"
+						className={cn("block truncate", className)}
+						{...props}
+					>
+						{children}
+					</span>
+				}
+			/>
+			<TooltipContent>{children}</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export { TruncatedText };


### PR DESCRIPTION
## Summary
- New `<TruncatedText>` primitive in `src/shared/ui/` that wraps content in a Base UI tooltip which only opens when the text is actually clipped by its ellipsis. Uses a `Range`-based float measurement so sub-pixel overflows still register.
- Applied across the memory, checkpoints, and executions modules (and `FullscreenArtifactDialogContent`) so long keys, artifact names, and checkpoint names become discoverable on hover instead of silently truncating.

## Test plan
- [ ] Hover long memory keys in the sidebar / detail panel / toolbar — tooltip appears only when the key is clipped.
- [ ] Hover checkpoint and artifact names in the trace rows and detail panels — tooltip only on truncated entries.
- [ ] Widen the panel so the same text fits — no tooltip on hover.
- [ ] Keyboard focus on a truncated chip still opens + dismisses the tooltip correctly.