### PR TITLE
fix: render zero-duration checkpoints in TimelineBar

### DIFF
--- a/src/modules/executions/business-logic/timeline-entry-to-segment.spec.ts
+++ b/src/modules/executions/business-logic/timeline-entry-to-segment.spec.ts
@@ -113,10 +113,22 @@ describe("timelineEntryToSegment", () => {
 			});
 		});
 
-		it("drops waiting blocks with waitDurationMs === 0", () => {
+		it("keeps waiting blocks with waitDurationMs === 0 as a zero-duration segment", () => {
 			const entry = waitingEntry({ waitDurationMs: 0 });
 
-			expect(timelineEntryToSegment(entry)).toBeNull();
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment).not.toBeNull();
+			expect(segment?.durationMs).toBe(0);
+			expect(segment?.type).toBe("wait");
+		});
+
+		it("clamps negative wait durations to zero", () => {
+			const entry = waitingEntry({ waitDurationMs: -10 });
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment?.durationMs).toBe(0);
 		});
 
 		it("drops waiting blocks with no waitDurationMs", () => {

--- a/src/modules/executions/business-logic/timeline-entry-to-segment.spec.ts
+++ b/src/modules/executions/business-logic/timeline-entry-to-segment.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { TimelineEntry, WaitingBlock } from "../domain/waiting-block";
+import { timelineEntryToSegment } from "./timeline-entry-to-segment";
+
+function checkpointEntry(
+	overrides: Partial<CheckpointEntry> = {}
+): TimelineEntry {
+	return {
+		kind: "checkpoint",
+		data: {
+			id: "c1",
+			name: "step_one",
+			status: "completed",
+			...overrides,
+		},
+	};
+}
+
+function waitingEntry(overrides: Partial<WaitingBlock> = {}): TimelineEntry {
+	return {
+		kind: "waiting",
+		data: {
+			id: "w1",
+			question: "approve?",
+			answer: "yes",
+			...overrides,
+		},
+	};
+}
+
+describe("timelineEntryToSegment", () => {
+	describe("checkpoint entries", () => {
+		it("maps a checkpoint with a positive duration", () => {
+			const entry = checkpointEntry({
+				id: "c1",
+				name: "train",
+				type: "tool_call",
+				durationMs: 12_000,
+			});
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment).toEqual({
+				id: "c1",
+				name: "train",
+				type: "tool_call",
+				durationMs: 12_000,
+				entry,
+			});
+		});
+
+		it("keeps cached checkpoints with durationMs === 0 as a zero-duration segment", () => {
+			const entry = checkpointEntry({
+				id: "cached",
+				name: "load_data",
+				status: "cached",
+				durationMs: 0,
+			});
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment).not.toBeNull();
+			expect(segment?.id).toBe("cached");
+			expect(segment?.durationMs).toBe(0);
+			expect(segment?.entry).toBe(entry);
+		});
+
+		it("treats missing durationMs as zero instead of dropping the segment", () => {
+			const entry = checkpointEntry({
+				id: "unknown",
+				durationMs: undefined,
+			});
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment).not.toBeNull();
+			expect(segment?.durationMs).toBe(0);
+		});
+
+		it("clamps negative durations to zero", () => {
+			const entry = checkpointEntry({ durationMs: -5 });
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment?.durationMs).toBe(0);
+		});
+
+		it("falls back to an empty string when type is undefined", () => {
+			const entry = checkpointEntry({ type: undefined, durationMs: 1 });
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment?.type).toBe("");
+		});
+	});
+
+	describe("waiting entries", () => {
+		it("maps a waiting block with a positive wait duration", () => {
+			const entry = waitingEntry({
+				id: "w1",
+				waitDurationMs: 5_000,
+			});
+
+			const segment = timelineEntryToSegment(entry);
+
+			expect(segment).toEqual({
+				id: "w1",
+				name: "User Input",
+				type: "wait",
+				durationMs: 5_000,
+				entry,
+			});
+		});
+
+		it("drops waiting blocks with waitDurationMs === 0", () => {
+			const entry = waitingEntry({ waitDurationMs: 0 });
+
+			expect(timelineEntryToSegment(entry)).toBeNull();
+		});
+
+		it("drops waiting blocks with no waitDurationMs", () => {
+			const entry = waitingEntry({ waitDurationMs: undefined });
+
+			expect(timelineEntryToSegment(entry)).toBeNull();
+		});
+	});
+});

--- a/src/modules/executions/business-logic/timeline-entry-to-segment.ts
+++ b/src/modules/executions/business-logic/timeline-entry-to-segment.ts
@@ -14,13 +14,12 @@ export function timelineEntryToSegment(
 			entry,
 		};
 	}
-	const durationMs = entry.data.waitDurationMs ?? 0;
-	if (durationMs <= 0) return null;
+	if (entry.data.waitDurationMs === undefined) return null;
 	return {
 		id: entry.data.id,
 		name: "User Input",
 		type: "wait",
-		durationMs,
+		durationMs: Math.max(entry.data.waitDurationMs, 0),
 		entry,
 	};
 }

--- a/src/modules/executions/business-logic/timeline-entry-to-segment.ts
+++ b/src/modules/executions/business-logic/timeline-entry-to-segment.ts
@@ -5,8 +5,7 @@ export function timelineEntryToSegment(
 	entry: TimelineEntry
 ): TimelineSegment | null {
 	if (entry.kind === "checkpoint") {
-		const durationMs = entry.data.durationMs ?? 0;
-		if (durationMs <= 0) return null;
+		const durationMs = Math.max(entry.data.durationMs ?? 0, 0);
 		return {
 			id: entry.data.id,
 			name: entry.data.name,

--- a/src/modules/executions/ui/traces/CheckpointThread.tsx
+++ b/src/modules/executions/ui/traces/CheckpointThread.tsx
@@ -58,7 +58,7 @@ function RowHighlightedWrapper({
 		<div
 			ref={ref}
 			className={cn(
-				"rounded-lg",
+				"scroll-mt-6 rounded-lg",
 				highlighted &&
 					"animate-highlight-blink ring-primary/40 ring-offset-background ring-1 ring-offset-2"
 			)}

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -23,10 +23,8 @@ export function ExecutionTimelineBar({
 	const segments = timelineEntries
 		.map(timelineEntryToSegment)
 		.filter((s): s is TimelineSegment => s !== null);
-	const total = segments.reduce((sum, s) => sum + s.durationMs, 0);
+	if (segments.length === 0) return null;
 	const widths = computeTimelineWidths(segments.map((s) => s.durationMs));
-
-	if (total === 0) return null;
 
 	const handleSelect = (entry: TimelineEntry) => {
 		setSelectedSegmentId(entry.data.id);


### PR DESCRIPTION
## Summary
- Cached checkpoints (`durationMs === 0`) were dropped by `timelineEntryToSegment` and never appeared in `ExecutionTimelineBar`.
- Keep them as zero-duration segments; the existing `min-w-[6px]` constraint renders them as the smallest visible pill.
- Also swap the bar's `total === 0` early return for `segments.length === 0` so the bar still renders when every checkpoint is cached.
- Waiting blocks with `waitDurationMs <= 0` remain filtered (they represent un-triggered waits).

## Test plan
- [x] `pnpm vitest run` — 154/154 passing, including 8 new cases in `timeline-entry-to-segment.spec.ts`
- [x] `pnpm check:types` — clean
- [ ] Manual browser check: open an execution that contains at least one cached checkpoint and confirm it renders as a 6px segment with a working tooltip and selection ring