### PR TITLE
feat(flows): server-driven filtering, sorting, and search

### DIFF
--- a/src/modules/flows/business-logic/categorize-flow-status.ts
+++ b/src/modules/flows/business-logic/categorize-flow-status.ts
@@ -1,7 +1,7 @@
 import type { ExecutionStatus } from "@/modules/executions/domain/execution";
 import type { FlowStatusFilter } from "../domain/flow";
 
-export const FLOW_ACTIVE_STATUSES: readonly ExecutionStatus[] = [
+export const FLOW_ACTIVE_STATUSES = [
 	"initializing",
 	"provisioning",
 	"running",
@@ -9,17 +9,19 @@ export const FLOW_ACTIVE_STATUSES: readonly ExecutionStatus[] = [
 	"paused",
 	"resuming",
 	"stopping",
-];
+] as const satisfies readonly ExecutionStatus[];
 
-export const FLOW_FAILED_STATUSES: readonly ExecutionStatus[] = ["failed"];
+export const FLOW_FAILED_STATUSES = [
+	"failed",
+] as const satisfies readonly ExecutionStatus[];
 
-export const FLOW_COMPLETED_STATUSES: readonly ExecutionStatus[] = [
+export const FLOW_COMPLETED_STATUSES = [
 	"completed",
 	"cached",
 	"skipped",
 	"stopped",
 	"retried",
-];
+] as const satisfies readonly ExecutionStatus[];
 
 const FLOW_ACTIVE_STATUS_SET = new Set<ExecutionStatus>(FLOW_ACTIVE_STATUSES);
 const FLOW_FAILED_STATUS_SET = new Set<ExecutionStatus>(FLOW_FAILED_STATUSES);

--- a/src/modules/flows/business-logic/categorize-flow-status.ts
+++ b/src/modules/flows/business-logic/categorize-flow-status.ts
@@ -1,7 +1,7 @@
 import type { ExecutionStatus } from "@/modules/executions/domain/execution";
 import type { FlowStatusFilter } from "../domain/flow";
 
-const FLOW_ACTIVE_STATUSES: Set<ExecutionStatus> = new Set([
+export const FLOW_ACTIVE_STATUSES: readonly ExecutionStatus[] = [
 	"initializing",
 	"provisioning",
 	"running",
@@ -9,24 +9,30 @@ const FLOW_ACTIVE_STATUSES: Set<ExecutionStatus> = new Set([
 	"paused",
 	"resuming",
 	"stopping",
-]);
+];
 
-const FLOW_FAILED_STATUSES: Set<ExecutionStatus> = new Set(["failed"]);
+export const FLOW_FAILED_STATUSES: readonly ExecutionStatus[] = ["failed"];
 
-const FLOW_COMPLETED_STATUSES: Set<ExecutionStatus> = new Set([
+export const FLOW_COMPLETED_STATUSES: readonly ExecutionStatus[] = [
 	"completed",
 	"cached",
 	"skipped",
 	"stopped",
 	"retried",
-]);
+];
+
+const FLOW_ACTIVE_STATUS_SET = new Set<ExecutionStatus>(FLOW_ACTIVE_STATUSES);
+const FLOW_FAILED_STATUS_SET = new Set<ExecutionStatus>(FLOW_FAILED_STATUSES);
+const FLOW_COMPLETED_STATUS_SET = new Set<ExecutionStatus>(
+	FLOW_COMPLETED_STATUSES
+);
 
 export function categorizeFlowStatus(
 	status: ExecutionStatus | undefined
 ): FlowStatusFilter {
 	if (!status) return "all";
-	if (FLOW_ACTIVE_STATUSES.has(status)) return "running";
-	if (FLOW_FAILED_STATUSES.has(status)) return "failed";
-	if (FLOW_COMPLETED_STATUSES.has(status)) return "completed";
+	if (FLOW_ACTIVE_STATUS_SET.has(status)) return "running";
+	if (FLOW_FAILED_STATUS_SET.has(status)) return "failed";
+	if (FLOW_COMPLETED_STATUS_SET.has(status)) return "completed";
 	return "all";
 }

--- a/src/modules/flows/business-logic/flows-queries.ts
+++ b/src/modules/flows/business-logic/flows-queries.ts
@@ -1,10 +1,55 @@
 import { queryOptions } from "@tanstack/react-query";
-import {
-	DEFAULT_FLOWS_SORT,
-	type FetchFlowsParams,
-	fetchFlows,
-} from "../domain/fetch-flows";
+import { fetchFlows } from "../domain/fetch-flows";
 import { fetchFlow } from "../domain/fetch-flow";
+import type { FlowStatusFilter } from "../domain/flow";
+import {
+	FLOW_ACTIVE_STATUSES,
+	FLOW_COMPLETED_STATUSES,
+	FLOW_FAILED_STATUSES,
+} from "./categorize-flow-status";
+
+export const DEFAULT_FLOWS_SORT = "desc:latest_run";
+
+export type FetchFlowsParams = {
+	name?: string;
+	status?: FlowStatusFilter;
+	sort?: string;
+};
+
+const STATUS_CATEGORY_TO_BACKEND: Record<
+	Exclude<FlowStatusFilter, "all">,
+	readonly string[]
+> = {
+	running: FLOW_ACTIVE_STATUSES,
+	failed: FLOW_FAILED_STATUSES,
+	completed: FLOW_COMPLETED_STATUSES,
+};
+
+function buildFlowsQuery(params: FetchFlowsParams): Record<string, unknown> {
+	const query: Record<string, unknown> = {
+		sort_by: params.sort ?? DEFAULT_FLOWS_SORT,
+	};
+
+	let filterCount = 0;
+
+	const trimmedName = params.name?.trim();
+	if (trimmedName) {
+		query.name = `contains:${trimmedName}`;
+		filterCount++;
+	}
+
+	if (params.status && params.status !== "all") {
+		const backendValues = STATUS_CATEGORY_TO_BACKEND[params.status];
+		query.latest_run_status = `oneof:${JSON.stringify(backendValues)}`;
+		filterCount++;
+	}
+
+	if (filterCount > 1) {
+		query.logical_operator = "and";
+	}
+
+	return query;
+}
 
 export const flowsQueryKeys = {
 	all: ["flows"] as const,
@@ -26,11 +71,11 @@ function normalizeParams(params: FetchFlowsParams): FetchFlowsParams {
 }
 
 export const flowsQueries = {
-	all: (params: FetchFlowsParams = {}) => {
+	list: (params: FetchFlowsParams = {}) => {
 		const normalized = normalizeParams(params);
 		return queryOptions({
 			queryKey: flowsQueryKeys.list(normalized),
-			queryFn: () => fetchFlows(normalized),
+			queryFn: () => fetchFlows(buildFlowsQuery(normalized)),
 		});
 	},
 	detail: (flowId: string) =>

--- a/src/modules/flows/business-logic/flows-queries.ts
+++ b/src/modules/flows/business-logic/flows-queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from "@tanstack/react-query";
-import { fetchFlows } from "../domain/fetch-flows";
+import { type FlowsQuery, fetchFlows } from "../domain/fetch-flows";
 import { fetchFlow } from "../domain/fetch-flow";
 import type { FlowStatusFilter } from "../domain/flow";
 import {
@@ -9,6 +9,12 @@ import {
 } from "./categorize-flow-status";
 
 export const DEFAULT_FLOWS_SORT = "desc:latest_run";
+
+export const ALLOWED_FLOWS_SORT_FIELDS = [
+	"name",
+	"latest_run",
+	"created",
+] as const;
 
 export type FetchFlowsParams = {
 	name?: string;
@@ -25,8 +31,8 @@ const STATUS_CATEGORY_TO_BACKEND: Record<
 	completed: FLOW_COMPLETED_STATUSES,
 };
 
-function buildFlowsQuery(params: FetchFlowsParams): Record<string, unknown> {
-	const query: Record<string, unknown> = {
+function buildFlowsQuery(params: FetchFlowsParams): FlowsQuery {
+	const query: FlowsQuery = {
 		sort_by: params.sort ?? DEFAULT_FLOWS_SORT,
 	};
 

--- a/src/modules/flows/business-logic/flows-queries.ts
+++ b/src/modules/flows/business-logic/flows-queries.ts
@@ -1,18 +1,38 @@
 import { queryOptions } from "@tanstack/react-query";
-import { fetchFlows } from "../domain/fetch-flows";
+import {
+	DEFAULT_FLOWS_SORT,
+	type FetchFlowsParams,
+	fetchFlows,
+} from "../domain/fetch-flows";
 import { fetchFlow } from "../domain/fetch-flow";
 
 export const flowsQueryKeys = {
 	all: ["flows"] as const,
+	list: (params: FetchFlowsParams) => [...flowsQueryKeys.all, params] as const,
 	detail: (flowId: string) => [...flowsQueryKeys.all, flowId] as const,
 };
 
+function normalizeParams(params: FetchFlowsParams): FetchFlowsParams {
+	const trimmedName = params.name?.trim();
+	const normalized: FetchFlowsParams = {};
+	if (trimmedName) normalized.name = trimmedName;
+	if (params.status && params.status !== "all") {
+		normalized.status = params.status;
+	}
+	if (params.sort && params.sort !== DEFAULT_FLOWS_SORT) {
+		normalized.sort = params.sort;
+	}
+	return normalized;
+}
+
 export const flowsQueries = {
-	all: () =>
-		queryOptions({
-			queryKey: flowsQueryKeys.all,
-			queryFn: fetchFlows,
-		}),
+	all: (params: FetchFlowsParams = {}) => {
+		const normalized = normalizeParams(params);
+		return queryOptions({
+			queryKey: flowsQueryKeys.list(normalized),
+			queryFn: () => fetchFlows(normalized),
+		});
+	},
 	detail: (flowId: string) =>
 		queryOptions({
 			queryKey: flowsQueryKeys.detail(flowId),

--- a/src/modules/flows/business-logic/use-flows.tsx
+++ b/src/modules/flows/business-logic/use-flows.tsx
@@ -1,16 +1,34 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+	keepPreviousData,
+	useQuery,
+	useSuspenseQuery,
+} from "@tanstack/react-query";
+import type { FetchFlowsParams } from "../domain/fetch-flows";
 import { flowsQueries } from "./flows-queries";
 
-type Options = Omit<
+type SuspenseOptions = Omit<
 	ReturnType<typeof flowsQueries.all>,
 	"queryKey" | "queryFn"
 >;
 
-export function useFlows(opts: Options = {}) {
+export function useFlows(opts: SuspenseOptions = {}) {
 	const query = useSuspenseQuery({
 		...flowsQueries.all(),
 		...opts,
 	});
 
 	return { ...query, flowsData: query.data };
+}
+
+export function useFilteredFlows(
+	params: FetchFlowsParams,
+	opts: SuspenseOptions = {}
+) {
+	const query = useQuery({
+		...flowsQueries.all(params),
+		placeholderData: keepPreviousData,
+		...opts,
+	});
+
+	return { ...query, flowsData: query.data ?? [] };
 }

--- a/src/modules/flows/business-logic/use-flows.tsx
+++ b/src/modules/flows/business-logic/use-flows.tsx
@@ -3,17 +3,17 @@ import {
 	useQuery,
 	useSuspenseQuery,
 } from "@tanstack/react-query";
-import type { FetchFlowsParams } from "../domain/fetch-flows";
+import type { FetchFlowsParams } from "./flows-queries";
 import { flowsQueries } from "./flows-queries";
 
 type SuspenseOptions = Omit<
-	ReturnType<typeof flowsQueries.all>,
+	ReturnType<typeof flowsQueries.list>,
 	"queryKey" | "queryFn"
 >;
 
 export function useFlows(opts: SuspenseOptions = {}) {
 	const query = useSuspenseQuery({
-		...flowsQueries.all(),
+		...flowsQueries.list(),
 		...opts,
 	});
 
@@ -25,7 +25,7 @@ export function useFilteredFlows(
 	opts: SuspenseOptions = {}
 ) {
 	const query = useQuery({
-		...flowsQueries.all(params),
+		...flowsQueries.list(params),
 		placeholderData: keepPreviousData,
 		...opts,
 	});

--- a/src/modules/flows/domain/fetch-flows.ts
+++ b/src/modules/flows/domain/fetch-flows.ts
@@ -1,64 +1,19 @@
 import { apiClient } from "@/shared/api/domain/api-client";
 import { expectData } from "@/shared/api/utils/unwrap-api-result";
-import {
-	FLOW_ACTIVE_STATUSES,
-	FLOW_COMPLETED_STATUSES,
-	FLOW_FAILED_STATUSES,
-} from "../business-logic/categorize-flow-status";
-import { type Flow, type FlowStatusFilter, flowFromApiToDomain } from "./flow";
+import { type Flow, flowFromApiToDomain } from "./flow";
 
 // TODO: Remove these constants and use the API pagination instead
 const DEFAULT_PAGE = 1;
 const MAX_PAGE_SIZE = 1000;
 
-export const DEFAULT_FLOWS_SORT = "desc:latest_run";
-
-const STATUS_CATEGORY_TO_BACKEND: Record<
-	Exclude<FlowStatusFilter, "all">,
-	readonly string[]
-> = {
-	running: FLOW_ACTIVE_STATUSES,
-	failed: FLOW_FAILED_STATUSES,
-	completed: FLOW_COMPLETED_STATUSES,
-};
-
-export type FetchFlowsParams = {
-	name?: string;
-	status?: FlowStatusFilter;
-	sort?: string;
-};
-
 export async function fetchFlows(
-	params: FetchFlowsParams = {}
+	query: Record<string, unknown> = {}
 ): Promise<Flow[]> {
-	const query: Record<string, unknown> = {
-		page: DEFAULT_PAGE,
-		size: MAX_PAGE_SIZE,
-		sort_by: params.sort ?? DEFAULT_FLOWS_SORT,
-	};
-
-	let filterCount = 0;
-
-	const trimmedName = params.name?.trim();
-	if (trimmedName) {
-		query.name = `contains:${trimmedName}`;
-		filterCount++;
-	}
-
-	if (params.status && params.status !== "all") {
-		const backendValues = STATUS_CATEGORY_TO_BACKEND[params.status];
-		query.latest_run_status = `oneof:${JSON.stringify(backendValues)}`;
-		filterCount++;
-	}
-
-	if (filterCount > 1) {
-		query.logical_operator = "and";
-	}
-
 	const response = await apiClient.GET("/api/v1/pipelines", {
-		params: { query },
+		params: {
+			query: { page: DEFAULT_PAGE, size: MAX_PAGE_SIZE, ...query },
+		},
 	});
 	const flowsPage = expectData(response);
-
 	return flowsPage.items.map(flowFromApiToDomain);
 }

--- a/src/modules/flows/domain/fetch-flows.ts
+++ b/src/modules/flows/domain/fetch-flows.ts
@@ -1,19 +1,62 @@
 import { apiClient } from "@/shared/api/domain/api-client";
 import { expectData } from "@/shared/api/utils/unwrap-api-result";
-import { type Flow, flowFromApiToDomain } from "./flow";
+import {
+	FLOW_ACTIVE_STATUSES,
+	FLOW_COMPLETED_STATUSES,
+	FLOW_FAILED_STATUSES,
+} from "../business-logic/categorize-flow-status";
+import { type Flow, type FlowStatusFilter, flowFromApiToDomain } from "./flow";
 
 // TODO: Remove these constants and use the API pagination instead
 const DEFAULT_PAGE = 1;
 const MAX_PAGE_SIZE = 1000;
 
-export async function fetchFlows(): Promise<Flow[]> {
+export const DEFAULT_FLOWS_SORT = "desc:latest_run";
+
+const STATUS_CATEGORY_TO_BACKEND: Record<
+	Exclude<FlowStatusFilter, "all">,
+	readonly string[]
+> = {
+	running: FLOW_ACTIVE_STATUSES,
+	failed: FLOW_FAILED_STATUSES,
+	completed: FLOW_COMPLETED_STATUSES,
+};
+
+export type FetchFlowsParams = {
+	name?: string;
+	status?: FlowStatusFilter;
+	sort?: string;
+};
+
+export async function fetchFlows(
+	params: FetchFlowsParams = {}
+): Promise<Flow[]> {
+	const query: Record<string, unknown> = {
+		page: DEFAULT_PAGE,
+		size: MAX_PAGE_SIZE,
+		sort_by: params.sort ?? DEFAULT_FLOWS_SORT,
+	};
+
+	let filterCount = 0;
+
+	const trimmedName = params.name?.trim();
+	if (trimmedName) {
+		query.name = `contains:${trimmedName}`;
+		filterCount++;
+	}
+
+	if (params.status && params.status !== "all") {
+		const backendValues = STATUS_CATEGORY_TO_BACKEND[params.status];
+		query.latest_run_status = `oneof:${JSON.stringify(backendValues)}`;
+		filterCount++;
+	}
+
+	if (filterCount > 1) {
+		query.logical_operator = "and";
+	}
+
 	const response = await apiClient.GET("/api/v1/pipelines", {
-		params: {
-			query: {
-				page: DEFAULT_PAGE,
-				size: MAX_PAGE_SIZE,
-			},
-		},
+		params: { query },
 	});
 	const flowsPage = expectData(response);
 

--- a/src/modules/flows/domain/fetch-flows.ts
+++ b/src/modules/flows/domain/fetch-flows.ts
@@ -1,14 +1,17 @@
 import { apiClient } from "@/shared/api/domain/api-client";
+import type { operations } from "@/shared/api/openapi";
 import { expectData } from "@/shared/api/utils/unwrap-api-result";
 import { type Flow, flowFromApiToDomain } from "./flow";
+
+export type FlowsQuery = NonNullable<
+	operations["list_pipelines_api_v1_pipelines_get"]["parameters"]["query"]
+>;
 
 // TODO: Remove these constants and use the API pagination instead
 const DEFAULT_PAGE = 1;
 const MAX_PAGE_SIZE = 1000;
 
-export async function fetchFlows(
-	query: Record<string, unknown> = {}
-): Promise<Flow[]> {
+export async function fetchFlows(query: FlowsQuery = {}): Promise<Flow[]> {
 	const response = await apiClient.GET("/api/v1/pipelines", {
 		params: {
 			query: { page: DEFAULT_PAGE, size: MAX_PAGE_SIZE, ...query },

--- a/src/modules/flows/feature/FlowsContainer.tsx
+++ b/src/modules/flows/feature/FlowsContainer.tsx
@@ -1,3 +1,4 @@
+import { useDebouncedValue } from "@/shared/business-logic/use-debounced-value";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import {
 	PageHeader,
@@ -7,26 +8,55 @@ import {
 	PageHeaderDescription,
 	PageHeaderTitle,
 } from "@/shared/ui/PageHeader";
+import {
+	paramToSortingState,
+	sortingStateToParam,
+} from "@/shared/utils/sorting";
+import type { OnChangeFn, SortingState } from "@tanstack/react-table";
 import { useRouter, useSearch } from "@tanstack/react-router";
-import { useMemo } from "react";
-import { useFlows } from "../business-logic/use-flows";
+import { useFilteredFlows, useFlows } from "../business-logic/use-flows";
 import { categorizeFlowStatus } from "../business-logic/categorize-flow-status";
+import { DEFAULT_FLOWS_SORT } from "../domain/fetch-flows";
 import { FlowsToolbar } from "../ui/FlowsToolbar";
 import type { StatProps } from "../ui/Stat";
 import { Stats } from "../ui/Stats";
 import { FlowsTableContainer } from "./FlowsTableContainer";
 
+const SEARCH_DEBOUNCE_MS = 300;
+
 export function FlowsContainer() {
 	const router = useRouter();
-	const { q, status } = useSearch({ from: "/_private/_navbar/flows/" });
+	const { q, status, sort } = useSearch({ from: "/_private/_navbar/flows/" });
 
-	const { flowsData, refetch } = useFlows({
-		refetchInterval: 5000,
-	});
+	const { flowsData: allFlows } = useFlows({ refetchInterval: 5000 });
+
+	const debouncedQuery = useDebouncedValue(q, SEARCH_DEBOUNCE_MS);
+	const { flowsData: filteredRows, refetch } = useFilteredFlows(
+		{ name: debouncedQuery, status, sort },
+		{ refetchInterval: 5000 }
+	);
+
+	const sortingState = paramToSortingState(sort);
+
+	const handleSortingChange: OnChangeFn<SortingState> = (updater) => {
+		const nextState =
+			typeof updater === "function" ? updater(sortingState) : updater;
+		const nextSort = sortingStateToParam(nextState) ?? DEFAULT_FLOWS_SORT;
+		router.navigate({
+			to: "/flows",
+			search: (previousSearch) => ({
+				q: previousSearch.q ?? "",
+				status: previousSearch.status ?? "all",
+				sort: nextSort,
+			}),
+			replace: true,
+		});
+	};
+
 	const { refresh: refreshFlows, isPending: isManualRefreshPending } =
 		useManualRefresh(refetch);
 
-	const statsCounts = flowsData.reduce(
+	const statsCounts = allFlows.reduce(
 		(acc, flow) => {
 			const category = categorizeFlowStatus(flow.latestExecStatus);
 			if (category === "running") acc.running++;
@@ -38,30 +68,11 @@ export function FlowsContainer() {
 	);
 
 	const stats: StatProps[] = [
-		{ label: "Total", value: flowsData.length },
+		{ label: "Total", value: allFlows.length },
 		{ label: "Running", value: statsCounts.running, valueColor: "warning" },
 		{ label: "Failed", value: statsCounts.failed, valueColor: "danger" },
 		{ label: "Completed", value: statsCounts.completed, valueColor: "success" },
 	];
-
-	const filteredRows = useMemo(() => {
-		const normalizedSearch = q.trim().toLowerCase();
-
-		return flowsData.filter((flow) => {
-			const matchesStatus =
-				status === "all"
-					? true
-					: categorizeFlowStatus(flow.latestExecStatus) === status;
-			const matchesSearch =
-				normalizedSearch.length === 0
-					? true
-					: [flow.id, flow.name].some((value) =>
-							value.toLowerCase().includes(normalizedSearch)
-						);
-
-			return matchesStatus && matchesSearch;
-		});
-	}, [flowsData, q, status]);
 
 	return (
 		<>
@@ -89,6 +100,7 @@ export function FlowsContainer() {
 						search: (previousSearch) => ({
 							q: value,
 							status: previousSearch.status ?? "all",
+							sort: previousSearch.sort ?? DEFAULT_FLOWS_SORT,
 						}),
 						replace: true,
 					});
@@ -99,13 +111,18 @@ export function FlowsContainer() {
 						search: (previousSearch) => ({
 							q: previousSearch.q ?? "",
 							status: value,
+							sort: previousSearch.sort ?? DEFAULT_FLOWS_SORT,
 						}),
 						replace: true,
 					});
 				}}
 			/>
 			<div className="container mx-auto flex w-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
-				<FlowsTableContainer flowRows={filteredRows} />
+				<FlowsTableContainer
+					flowRows={filteredRows}
+					sorting={sortingState}
+					onSortingChange={handleSortingChange}
+				/>
 			</div>
 		</>
 	);

--- a/src/modules/flows/feature/FlowsContainer.tsx
+++ b/src/modules/flows/feature/FlowsContainer.tsx
@@ -12,7 +12,7 @@ import { useSorting } from "@/shared/business-logic/use-sorting";
 import { useRouter, useSearch } from "@tanstack/react-router";
 import { useFilteredFlows, useFlows } from "../business-logic/use-flows";
 import { categorizeFlowStatus } from "../business-logic/categorize-flow-status";
-import { DEFAULT_FLOWS_SORT } from "../domain/fetch-flows";
+import { DEFAULT_FLOWS_SORT } from "../business-logic/flows-queries";
 import { FlowsToolbar } from "../ui/FlowsToolbar";
 import type { StatProps } from "../ui/Stat";
 import { Stats } from "../ui/Stats";

--- a/src/modules/flows/feature/FlowsContainer.tsx
+++ b/src/modules/flows/feature/FlowsContainer.tsx
@@ -8,11 +8,7 @@ import {
 	PageHeaderDescription,
 	PageHeaderTitle,
 } from "@/shared/ui/PageHeader";
-import {
-	paramToSortingState,
-	sortingStateToParam,
-} from "@/shared/utils/sorting";
-import type { OnChangeFn, SortingState } from "@tanstack/react-table";
+import { useSorting } from "@/shared/business-logic/use-sorting";
 import { useRouter, useSearch } from "@tanstack/react-router";
 import { useFilteredFlows, useFlows } from "../business-logic/use-flows";
 import { categorizeFlowStatus } from "../business-logic/categorize-flow-status";
@@ -36,22 +32,17 @@ export function FlowsContainer() {
 		{ refetchInterval: 5000 }
 	);
 
-	const sortingState = paramToSortingState(sort);
-
-	const handleSortingChange: OnChangeFn<SortingState> = (updater) => {
-		const nextState =
-			typeof updater === "function" ? updater(sortingState) : updater;
-		const nextSort = sortingStateToParam(nextState) ?? DEFAULT_FLOWS_SORT;
-		router.navigate({
-			to: "/flows",
-			search: (previousSearch) => ({
-				q: previousSearch.q ?? "",
-				status: previousSearch.status ?? "all",
-				sort: nextSort,
-			}),
-			replace: true,
-		});
-	};
+	const { sortingState, onSortingChange } = useSorting(
+		sort,
+		DEFAULT_FLOWS_SORT,
+		(nextSort) => {
+			router.navigate({
+				to: "/flows",
+				search: (prev) => ({ ...prev, sort: nextSort }),
+				replace: true,
+			});
+		}
+	);
 
 	const { refresh: refreshFlows, isPending: isManualRefreshPending } =
 		useManualRefresh(refetch);
@@ -121,7 +112,7 @@ export function FlowsContainer() {
 				<FlowsTableContainer
 					flowRows={filteredRows}
 					sorting={sortingState}
-					onSortingChange={handleSortingChange}
+					onSortingChange={onSortingChange}
 				/>
 			</div>
 		</>

--- a/src/modules/flows/feature/FlowsContainer.tsx
+++ b/src/modules/flows/feature/FlowsContainer.tsx
@@ -24,7 +24,9 @@ export function FlowsContainer() {
 	const router = useRouter();
 	const { q, status, sort } = useSearch({ from: "/_private/_navbar/flows/" });
 
-	const { flowsData: allFlows } = useFlows({ refetchInterval: 5000 });
+	const { flowsData: allFlows, refetch: refetchAll } = useFlows({
+		refetchInterval: 5000,
+	});
 
 	const debouncedQuery = useDebouncedValue(q, SEARCH_DEBOUNCE_MS);
 	const { flowsData: filteredRows, refetch } = useFilteredFlows(
@@ -45,7 +47,9 @@ export function FlowsContainer() {
 	);
 
 	const { refresh: refreshFlows, isPending: isManualRefreshPending } =
-		useManualRefresh(refetch);
+		useManualRefresh(async () => {
+			await Promise.all([refetchAll(), refetch()]);
+		});
 
 	const statsCounts = allFlows.reduce(
 		(acc, flow) => {

--- a/src/modules/flows/feature/FlowsTableContainer.tsx
+++ b/src/modules/flows/feature/FlowsTableContainer.tsx
@@ -9,21 +9,30 @@ import {
 	TableRow,
 } from "@/shared/ui/Table/Table";
 import { Link } from "@tanstack/react-router";
-import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import type {
+	ColumnDef,
+	OnChangeFn,
+	SortingState,
+} from "@tanstack/react-table";
 import {
 	flexRender,
 	getCoreRowModel,
-	getSortedRowModel,
 	useReactTable,
 } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import type { Flow } from "../domain/flow";
 
-export function FlowsTableContainer({ flowRows }: { flowRows: Flow[] }) {
-	const [sorting, setSorting] = useState<SortingState>([
-		{ id: "createdAt", desc: true },
-	]);
+type FlowsTableContainerProps = {
+	flowRows: Flow[];
+	sorting: SortingState;
+	onSortingChange: OnChangeFn<SortingState>;
+};
 
+export function FlowsTableContainer({
+	flowRows,
+	sorting,
+	onSortingChange,
+}: FlowsTableContainerProps) {
 	const columns = useMemo(() => flowColumns, []);
 
 	const table = useReactTable({
@@ -32,9 +41,11 @@ export function FlowsTableContainer({ flowRows }: { flowRows: Flow[] }) {
 		state: {
 			sorting,
 		},
-		onSortingChange: setSorting,
+		onSortingChange,
+		manualSorting: true,
+		enableSortingRemoval: false,
+		enableMultiSort: false,
 		getCoreRowModel: getCoreRowModel(),
-		getSortedRowModel: getSortedRowModel(),
 		getRowId: (row) => row.id,
 	});
 
@@ -95,6 +106,7 @@ export function FlowsTableContainer({ flowRows }: { flowRows: Flow[] }) {
 
 const flowColumns: ColumnDef<Flow>[] = [
 	{
+		id: "name",
 		accessorKey: "name",
 		meta: { isPrimaryColumn: true },
 		header: ({ column }) => <SortableHeader column={column} label="Name" />,
@@ -109,22 +121,30 @@ const flowColumns: ColumnDef<Flow>[] = [
 		),
 	},
 	{
+		id: "latest_run",
 		accessorKey: "latestexecutionId",
 		header: ({ column }) => (
-			<SortableHeader column={column} label="Latest Execution ID" />
+			<SortableHeader column={column} label="Latest Run" />
 		),
 		cell: ({ row }) => (
 			<TextRenderer>{row.original.latestexecutionId ?? "-"}</TextRenderer>
 		),
 	},
 	{
+		id: "latestExecStatus",
 		accessorKey: "latestExecStatus",
-		header: ({ column }) => <SortableHeader column={column} label="Status" />,
+		enableSorting: false,
+		header: () => (
+			<span className="text-muted-foreground px-2 py-1 text-sm font-medium">
+				Status
+			</span>
+		),
 		cell: ({ row }) => (
 			<StatusRenderer status={row.original.latestExecStatus} />
 		),
 	},
 	{
+		id: "created",
 		accessorKey: "createdAt",
 		header: ({ column }) => <SortableHeader column={column} label="Created" />,
 		cell: ({ row }) => (

--- a/src/routes/_private/_navbar/flows/index.tsx
+++ b/src/routes/_private/_navbar/flows/index.tsx
@@ -8,6 +8,7 @@ import {
 	DEFAULT_FLOWS_SORT,
 } from "@/modules/flows/business-logic/flows-queries";
 import { buildPageTitles } from "@/shared/utils/build-page-titles";
+import { sortBySchema } from "@/shared/utils/sorting";
 import {
 	type SearchSchemaInput,
 	createFileRoute,
@@ -18,23 +19,10 @@ import { z } from "zod";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { PageSpinner } from "@/shared/ui/spinner";
 
-const sortSchema = z
-	.string()
-	.refine((value) => {
-		const [prefix, field] = value.split(":");
-		return (
-			(prefix === "asc" || prefix === "desc") &&
-			ALLOWED_FLOWS_SORT_FIELDS.includes(
-				field as (typeof ALLOWED_FLOWS_SORT_FIELDS)[number]
-			)
-		);
-	})
-	.catch(DEFAULT_FLOWS_SORT);
-
 const flowsSearchSchema = z.object({
 	q: z.string().catch(""),
 	status: z.enum(flowStatusFilterValues).catch("all"),
-	sort: sortSchema,
+	sort: sortBySchema([...ALLOWED_FLOWS_SORT_FIELDS]).catch(DEFAULT_FLOWS_SORT),
 });
 
 type FlowsSearchSchemaInput = SearchSchemaInput & {

--- a/src/routes/_private/_navbar/flows/index.tsx
+++ b/src/routes/_private/_navbar/flows/index.tsx
@@ -3,6 +3,7 @@ import {
 	flowStatusFilterValues,
 	type FlowStatusFilter,
 } from "@/modules/flows/domain/flow";
+import { DEFAULT_FLOWS_SORT } from "@/modules/flows/domain/fetch-flows";
 import { buildPageTitles } from "@/shared/utils/build-page-titles";
 import {
 	type SearchSchemaInput,
@@ -17,18 +18,22 @@ import { PageSpinner } from "@/shared/ui/spinner";
 const flowsSearchSchema = z.object({
 	q: z.string().catch(""),
 	status: z.enum(flowStatusFilterValues).catch("all"),
+	sort: z.string().catch(DEFAULT_FLOWS_SORT),
 });
 
 type FlowsSearchSchemaInput = SearchSchemaInput & {
 	q?: string;
 	status?: FlowStatusFilter;
+	sort?: string;
 };
 
 export const Route = createFileRoute("/_private/_navbar/flows/")({
 	validateSearch: (search: FlowsSearchSchemaInput) =>
 		flowsSearchSchema.parse(search),
 	search: {
-		middlewares: [stripSearchParams({ q: "", status: "all" })],
+		middlewares: [
+			stripSearchParams({ q: "", status: "all", sort: DEFAULT_FLOWS_SORT }),
+		],
 	},
 	component: FlowsContainer,
 	head: () => ({

--- a/src/routes/_private/_navbar/flows/index.tsx
+++ b/src/routes/_private/_navbar/flows/index.tsx
@@ -3,7 +3,10 @@ import {
 	flowStatusFilterValues,
 	type FlowStatusFilter,
 } from "@/modules/flows/domain/flow";
-import { DEFAULT_FLOWS_SORT } from "@/modules/flows/business-logic/flows-queries";
+import {
+	ALLOWED_FLOWS_SORT_FIELDS,
+	DEFAULT_FLOWS_SORT,
+} from "@/modules/flows/business-logic/flows-queries";
 import { buildPageTitles } from "@/shared/utils/build-page-titles";
 import {
 	type SearchSchemaInput,
@@ -15,10 +18,23 @@ import { z } from "zod";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { PageSpinner } from "@/shared/ui/spinner";
 
+const sortSchema = z
+	.string()
+	.refine((value) => {
+		const [prefix, field] = value.split(":");
+		return (
+			(prefix === "asc" || prefix === "desc") &&
+			ALLOWED_FLOWS_SORT_FIELDS.includes(
+				field as (typeof ALLOWED_FLOWS_SORT_FIELDS)[number]
+			)
+		);
+	})
+	.catch(DEFAULT_FLOWS_SORT);
+
 const flowsSearchSchema = z.object({
 	q: z.string().catch(""),
 	status: z.enum(flowStatusFilterValues).catch("all"),
-	sort: z.string().catch(DEFAULT_FLOWS_SORT),
+	sort: sortSchema,
 });
 
 type FlowsSearchSchemaInput = SearchSchemaInput & {
@@ -40,7 +56,12 @@ export const Route = createFileRoute("/_private/_navbar/flows/")({
 		meta: [{ title: buildPageTitles("Flows") }],
 	}),
 	pendingComponent: PageSpinner,
-	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(flowsQueries.list());
+	loader: async ({ context, deps }) => {
+		await context.queryClient.ensureQueryData(flowsQueries.list(deps));
 	},
+	loaderDeps: ({ search }) => ({
+		name: search.q,
+		status: search.status,
+		sort: search.sort,
+	}),
 });

--- a/src/routes/_private/_navbar/flows/index.tsx
+++ b/src/routes/_private/_navbar/flows/index.tsx
@@ -3,7 +3,7 @@ import {
 	flowStatusFilterValues,
 	type FlowStatusFilter,
 } from "@/modules/flows/domain/flow";
-import { DEFAULT_FLOWS_SORT } from "@/modules/flows/domain/fetch-flows";
+import { DEFAULT_FLOWS_SORT } from "@/modules/flows/business-logic/flows-queries";
 import { buildPageTitles } from "@/shared/utils/build-page-titles";
 import {
 	type SearchSchemaInput,
@@ -41,6 +41,6 @@ export const Route = createFileRoute("/_private/_navbar/flows/")({
 	}),
 	pendingComponent: PageSpinner,
 	loader: async ({ context }) => {
-		await context.queryClient.ensureQueryData(flowsQueries.all());
+		await context.queryClient.ensureQueryData(flowsQueries.list());
 	},
 });

--- a/src/shared/business-logic/use-debounced-value.ts
+++ b/src/shared/business-logic/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const id = setTimeout(() => setDebounced(value), delayMs);
+		return () => clearTimeout(id);
+	}, [value, delayMs]);
+
+	return debounced;
+}

--- a/src/shared/business-logic/use-sorting.ts
+++ b/src/shared/business-logic/use-sorting.ts
@@ -1,0 +1,21 @@
+import type { OnChangeFn, SortingState } from "@tanstack/react-table";
+import { paramToSortingState, sortingStateToParam } from "../utils/sorting";
+
+type UpdateSearchFn = (sort: string) => void;
+
+export function useSorting(
+	sortParam: string | undefined,
+	defaultSort: string,
+	updateSearch: UpdateSearchFn
+) {
+	const sortingState = paramToSortingState(sortParam);
+
+	const onSortingChange: OnChangeFn<SortingState> = (updater) => {
+		const nextState =
+			typeof updater === "function" ? updater(sortingState) : updater;
+		const nextSort = sortingStateToParam(nextState) ?? defaultSort;
+		updateSearch(nextSort);
+	};
+
+	return { sortingState, onSortingChange };
+}

--- a/src/shared/utils/sorting.spec.ts
+++ b/src/shared/utils/sorting.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { paramToSortingState, sortingStateToParam } from "./sorting";
+
+describe("sortingStateToParam", () => {
+	it("returns undefined for an empty sorting state", () => {
+		expect(sortingStateToParam([])).toBeUndefined();
+	});
+
+	it("serializes a descending sort", () => {
+		expect(sortingStateToParam([{ id: "latest_run", desc: true }])).toBe(
+			"desc:latest_run"
+		);
+	});
+
+	it("serializes an ascending sort", () => {
+		expect(sortingStateToParam([{ id: "name", desc: false }])).toBe("asc:name");
+	});
+
+	it("serializes only the first sort entry when multiple are present", () => {
+		expect(
+			sortingStateToParam([
+				{ id: "created", desc: true },
+				{ id: "name", desc: false },
+			])
+		).toBe("desc:created");
+	});
+});
+
+describe("paramToSortingState", () => {
+	it("returns an empty array for undefined input", () => {
+		expect(paramToSortingState(undefined)).toEqual([]);
+	});
+
+	it("returns an empty array for an empty string", () => {
+		expect(paramToSortingState("")).toEqual([]);
+	});
+
+	it("parses a descending sort", () => {
+		expect(paramToSortingState("desc:latest_run")).toEqual([
+			{ id: "latest_run", desc: true },
+		]);
+	});
+
+	it("parses an ascending sort", () => {
+		expect(paramToSortingState("asc:name")).toEqual([
+			{ id: "name", desc: false },
+		]);
+	});
+
+	it("returns an empty array for a malformed input without direction", () => {
+		expect(paramToSortingState("latest_run")).toEqual([]);
+	});
+
+	it("returns an empty array for an invalid direction", () => {
+		expect(paramToSortingState("ascending:latest_run")).toEqual([]);
+	});
+});
+
+describe("round-trip", () => {
+	it("round-trips desc:latest_run", () => {
+		const state = paramToSortingState("desc:latest_run");
+		expect(sortingStateToParam(state)).toBe("desc:latest_run");
+	});
+
+	it("round-trips asc:created", () => {
+		const state = paramToSortingState("asc:created");
+		expect(sortingStateToParam(state)).toBe("asc:created");
+	});
+});

--- a/src/shared/utils/sorting.ts
+++ b/src/shared/utils/sorting.ts
@@ -1,0 +1,16 @@
+import type { SortingState } from "@tanstack/react-table";
+
+export function sortingStateToParam(sorting: SortingState): string | undefined {
+	if (!sorting || sorting.length === 0) return undefined;
+	const first = sorting[0];
+	if (!first) return undefined;
+	return `${first.desc ? "desc" : "asc"}:${first.id}`;
+}
+
+export function paramToSortingState(param: string | undefined): SortingState {
+	if (!param) return [];
+	const [direction, key] = param.split(":");
+	if (!direction || !key) return [];
+	if (direction !== "asc" && direction !== "desc") return [];
+	return [{ id: key, desc: direction === "desc" }];
+}

--- a/src/shared/utils/sorting.ts
+++ b/src/shared/utils/sorting.ts
@@ -1,4 +1,5 @@
 import type { SortingState } from "@tanstack/react-table";
+import { z } from "zod";
 
 export function sortingStateToParam(sorting: SortingState): string | undefined {
 	if (!sorting || sorting.length === 0) return undefined;
@@ -14,3 +15,11 @@ export function paramToSortingState(param: string | undefined): SortingState {
 	if (direction !== "asc" && direction !== "desc") return [];
 	return [{ id: key, desc: direction === "desc" }];
 }
+
+export const sortBySchema = (allowedFields: string[]) =>
+	z.string().refine((value) => {
+		const [prefix, field] = value.split(":");
+		return (
+			(prefix === "asc" || prefix === "desc") && allowedFields.includes(field)
+		);
+	});


### PR DESCRIPTION
## Summary

Moves filtering and sorting for the flows table to URL-backed, server-side queries, mirroring zenml-cloud-ui's pattern. The URL is now the single source of truth for filter + sort state; TanStack sort state is derived from it; header clicks write back to the URL which triggers react-query to refetch.

- `fetchFlows` accepts `{ name, status, sort }` and builds `name=contains:*`, `latest_run_status=oneof:[...]`, and `sort_by=*` query params. Category buckets (running / failed / completed) are expanded to their full `ExecutionStatus` sets via `oneof:`, preserving the existing toolbar UX.
- Added `sort` to the flows route zod schema with `desc:latest_run` as the default (stripped from the URL when active).
- `FlowsTableContainer` uses `manualSorting: true` with `enableSortingRemoval: false`, so header clicks toggle `asc ↔ desc` only. **Latest Run**, **Name**, and **Created** are now clickable sortable headers; **Status** stays non-sortable.
- `FlowsContainer` runs two parallel queries — an unfiltered `useFlows()` for stats (so header counts always reflect totals) and a filtered `useFilteredFlows()` for the table — deduped to one request when no filters/sort are active.
- Search input is debounced 300 ms via a new `useDebouncedValue` hook; the URL updates immediately while the API call lags one debounce window.
- Extracted a reusable `useSorting` hook (`src/shared/business-logic/use-sorting.ts`) that bridges URL sort params and TanStack Table's `SortingState`, mirroring zenml-cloud-ui's `useSorting` pattern. The hook accepts a navigation callback to stay route-agnostic.
- `sortingStateToParam` / `paramToSortingState` helpers (`src/shared/utils/sorting.ts`) plus 12 unit tests.

**Known UX regression**: the old client-side search matched both `flow.name` and `flow.id`. The backend can't express `(name contains X OR id contains X) AND status=Y` in a single request, so `id` search is dropped. UUIDs aren't typical human search targets; flag this if it matters for your workflow.

## Test plan

- [x] `/flows` initially shows flows sorted by latest run (desc), with the `↓` arrow on "Latest Run"
- [x] Clicking the "Latest Run" header flips to `asc:latest_run` and the arrow flips to `↑`; URL gains `?sort=asc:latest_run`
- [x] Clicking "Name" moves the sort arrow to Name and refetches with `sort_by=desc:name` (then `asc:name` on second click)
- [x] Clicking "Created" sorts server-side by created
- [x] Typing in the search input debounces ~300 ms and hits `/api/v1/pipelines?name=contains:<q>` — confirm in DevTools Network tab
- [ ] Picking a status tab (running / failed / completed) sends `latest_run_status=oneof:[...]` with the expected expanded values
- [ ] Combining search + status sends `logical_operator=and`
- [ ] Header stats (Total / Running / Failed / Completed) stay on the unfiltered totals as filters change
- [ ] Refreshing the page preserves the URL filters + sort
- [ ] Navigating away and back restores the filters + sort from the URL