### PR TITLE
fix: timeline bar full width when all cached

### DIFF
--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.stories.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExecutionTimelineBar } from "./ExecutionTimelineBar";
+import type { TimelineEntry } from "../../domain/waiting-block";
+
+function checkpoint(
+	id: string,
+	name: string,
+	type: "llm_call" | "tool_call",
+	durationMs?: number
+): TimelineEntry {
+	return {
+		kind: "checkpoint",
+		data: {
+			id,
+			name,
+			type,
+			durationMs,
+			status: "completed",
+			startTime: new Date("2026-01-01T00:00:00Z"),
+		},
+	};
+}
+
+function waitBlock(id: string, waitDurationMs?: number): TimelineEntry {
+	return {
+		kind: "waiting",
+		data: {
+			id,
+			question: "Approve?",
+			answer: "yes",
+			waitDurationMs,
+			createdAt: new Date("2026-01-01T00:00:00Z"),
+		},
+	};
+}
+
+const meta: Meta<typeof ExecutionTimelineBar> = {
+	title: "Executions/Traces/ExecutionTimelineBar",
+	component: ExecutionTimelineBar,
+	args: {
+		onSelect: () => {},
+	},
+	parameters: {
+		layout: "padded",
+	},
+	decorators: [
+		(Story) => (
+			<div className="w-full max-w-3xl border">
+				<Story />
+			</div>
+		),
+	],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ExecutionTimelineBar>;
+
+export const MixedDurations: Story = {
+	args: {
+		timelineEntries: [
+			checkpoint("1", "llm_0", "llm_call", 300_000),
+			checkpoint("2", "run_command_0", "tool_call", 5_000),
+			checkpoint("3", "llm_1", "llm_call", 45_000),
+			checkpoint("4", "read_file_1", "tool_call", 1_200),
+			checkpoint("5", "llm_2", "llm_call", 120_000),
+		],
+	},
+};
+
+export const AllCached: Story = {
+	args: {
+		timelineEntries: [
+			checkpoint("1", "llm_0", "llm_call", 0),
+			checkpoint("2", "run_command_0", "tool_call", 0),
+			checkpoint("3", "llm_1", "llm_call", 0),
+			checkpoint("4", "read_file_1", "tool_call", 0),
+			checkpoint("5", "llm_2", "llm_call", 0),
+			checkpoint("6", "read_file_2", "tool_call", 0),
+			checkpoint("7", "llm_3", "llm_call", 0),
+		],
+	},
+};
+
+export const SomeCached: Story = {
+	args: {
+		timelineEntries: [
+			checkpoint("1", "llm_0", "llm_call", 0),
+			checkpoint("2", "run_command_0", "tool_call", 8_000),
+			checkpoint("3", "llm_1", "llm_call", 0),
+			checkpoint("4", "read_file_1", "tool_call", 0),
+			checkpoint("5", "llm_2", "llm_call", 60_000),
+		],
+	},
+};
+
+export const SingleCheckpoint: Story = {
+	args: {
+		timelineEntries: [checkpoint("1", "llm_0", "llm_call", 15_000)],
+	},
+};
+
+export const SingleCachedCheckpoint: Story = {
+	args: {
+		timelineEntries: [checkpoint("1", "llm_0", "llm_call", 0)],
+	},
+};
+
+export const WithWaitBlocks: Story = {
+	args: {
+		timelineEntries: [
+			checkpoint("1", "llm_0", "llm_call", 30_000),
+			waitBlock("w1", 120_000),
+			checkpoint("2", "llm_1", "llm_call", 15_000),
+			checkpoint("3", "run_command_0", "tool_call", 3_000),
+		],
+	},
+};
+
+export const OneLongManyShort: Story = {
+	args: {
+		timelineEntries: [
+			checkpoint("1", "llm_main", "llm_call", 600_000),
+			...Array.from({ length: 10 }, (_, i) =>
+				checkpoint(`s${i}`, `tool_${i}`, "tool_call", 1_000)
+			),
+		],
+	},
+};
+
+export const ManyCheckpoints: Story = {
+	args: {
+		timelineEntries: Array.from({ length: 30 }, (_, i) =>
+			checkpoint(
+				`${i}`,
+				`step_${i}`,
+				i % 2 === 0 ? "llm_call" : "tool_call",
+				Math.random() * 50_000 + 500
+			)
+		),
+	},
+};
+
+export const FiveHundredCheckpoints: Story = {
+	args: {
+		timelineEntries: Array.from({ length: 500 }, (_, i) =>
+			checkpoint(
+				`${i}`,
+				`step_${i}`,
+				i % 2 === 0 ? "llm_call" : "tool_call",
+				Math.random() * 300_000 + 100
+			)
+		),
+	},
+};

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -32,11 +32,11 @@ export function ExecutionTimelineBar({
 	};
 
 	return (
-		<div className="border-border flex shrink-0 items-center border-b px-4 py-2.5">
+		<div className="border-border shrink-0 overflow-x-auto border-b px-4 py-2.5">
 			<div
 				role="toolbar"
 				aria-label="Execution timeline"
-				className="flex h-7 w-full gap-0.5"
+				className="flex h-7 min-w-full gap-0.5"
 			>
 				{segments.map((segment, index, arr) => {
 					const isSelected = segment.id === selectedSegmentId;

--- a/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
+++ b/src/modules/executions/ui/traces/ExecutionTimelineBar.tsx
@@ -32,65 +32,67 @@ export function ExecutionTimelineBar({
 	};
 
 	return (
-		<div className="border-border shrink-0 overflow-x-auto border-b px-4 py-2.5">
-			<div
-				role="toolbar"
-				aria-label="Execution timeline"
-				className="flex h-7 min-w-full gap-0.5"
-			>
-				{segments.map((segment, index, arr) => {
-					const isSelected = segment.id === selectedSegmentId;
-					const isFirst = index === 0;
-					const isLast = index === arr.length - 1;
-					const fillClass = getCheckpointFillClass(segment.type);
+		<div className="border-border shrink-0 border-b px-4 py-2.5">
+			<div className="overflow-x-auto">
+				<div
+					role="toolbar"
+					aria-label="Execution timeline"
+					className="flex h-7 gap-0.5"
+				>
+					{segments.map((segment, index, arr) => {
+						const isSelected = segment.id === selectedSegmentId;
+						const isFirst = index === 0;
+						const isLast = index === arr.length - 1;
+						const fillClass = getCheckpointFillClass(segment.type);
 
-					return (
-						<Tooltip key={segment.id}>
-							<TooltipTrigger
-								render={
-									<button
-										type="button"
-										onClick={() => handleSelect(segment.entry)}
-										aria-label={`${segment.name}, duration ${formatDurationShort(segment.durationMs)}`}
-										aria-pressed={isSelected}
-										className={cn(
-											"relative h-full min-w-[6px] transition-opacity",
-											isFirst && "rounded-l-md",
-											isLast && "rounded-r-md",
-											fillClass,
-											isSelected
-												? "ring-foreground opacity-100 ring-2 ring-inset"
-												: "opacity-80 hover:opacity-100"
-										)}
-										style={{ width: `${widths[index]}%` }}
-									/>
-								}
-							/>
-							<TooltipContent
-								side="bottom"
-								className="block max-w-64 overflow-hidden p-0"
-							>
-								<div className="border-background/20 flex items-center gap-2 border-b px-3 py-2">
-									<ColorDot size="sm" className={cn("shrink-0", fillClass)} />
-									<span className="min-w-0 flex-1 truncate font-mono text-xs font-semibold">
-										{segment.name}
-									</span>
-									{segment.type && (
-										<span className="text-2xs shrink-0 font-medium opacity-70">
-											{segment.type}
+						return (
+							<Tooltip key={segment.id}>
+								<TooltipTrigger
+									render={
+										<button
+											type="button"
+											onClick={() => handleSelect(segment.entry)}
+											aria-label={`${segment.name}, duration ${formatDurationShort(segment.durationMs)}`}
+											aria-pressed={isSelected}
+											className={cn(
+												"relative h-full min-w-[6px] transition-opacity",
+												isFirst && "rounded-l-md",
+												isLast && "rounded-r-md",
+												fillClass,
+												isSelected
+													? "ring-foreground opacity-100 ring-2 ring-inset"
+													: "opacity-80 hover:opacity-100"
+											)}
+											style={{ width: `${widths[index]}%` }}
+										/>
+									}
+								/>
+								<TooltipContent
+									side="bottom"
+									className="block max-w-64 overflow-hidden p-0"
+								>
+									<div className="border-background/20 flex items-center gap-2 border-b px-3 py-2">
+										<ColorDot size="sm" className={cn("shrink-0", fillClass)} />
+										<span className="min-w-0 flex-1 truncate font-mono text-xs font-semibold">
+											{segment.name}
 										</span>
-									)}
-								</div>
-								<div className="grid grid-cols-2 gap-x-4 gap-y-1 px-3 py-2 text-xs">
-									<span className="opacity-70">Duration</span>
-									<span className="text-right font-mono tabular-nums">
-										{formatDurationShort(segment.durationMs)}
-									</span>
-								</div>
-							</TooltipContent>
-						</Tooltip>
-					);
-				})}
+										{segment.type && (
+											<span className="text-2xs shrink-0 font-medium opacity-70">
+												{segment.type}
+											</span>
+										)}
+									</div>
+									<div className="grid grid-cols-2 gap-x-4 gap-y-1 px-3 py-2 text-xs">
+										<span className="opacity-70">Duration</span>
+										<span className="text-right font-mono tabular-nums">
+											{formatDurationShort(segment.durationMs)}
+										</span>
+									</div>
+								</TooltipContent>
+							</Tooltip>
+						);
+					})}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/modules/executions/util/timeline-scale.spec.ts
+++ b/src/modules/executions/util/timeline-scale.spec.ts
@@ -20,8 +20,13 @@ describe("computeTimelineWidths", () => {
 		expect(sum).toBeCloseTo(100, 9);
 	});
 
-	it("returns all zeros when every duration is zero", () => {
-		expect(computeTimelineWidths([0, 0, 0])).toEqual([0, 0, 0]);
+	it("distributes width equally when every duration is zero", () => {
+		const widths = computeTimelineWidths([0, 0, 0]);
+		for (const w of widths) {
+			expect(w).toBeCloseTo(100 / 3, 9);
+		}
+		const sum = widths.reduce((a, b) => a + b, 0);
+		expect(sum).toBeCloseTo(100, 9);
 	});
 
 	it("scales widths by sqrt of duration ratio", () => {

--- a/src/modules/executions/util/timeline-scale.ts
+++ b/src/modules/executions/util/timeline-scale.ts
@@ -8,7 +8,7 @@ export function computeTimelineWidths(durations: number[]): number[] {
 		d > 0 ? Math.pow(d, POWER_SCALE_EXPONENT) : 0
 	);
 	const total = scaled.reduce((sum, v) => sum + v, 0);
-	if (total === 0) return durations.map(() => 0);
+	if (total === 0) return durations.map(() => 100 / durations.length);
 
 	return scaled.map((v) => (v / total) * 100);
 }


### PR DESCRIPTION
## Summary
- Fix timeline bar not spanning full width when all checkpoints have zero duration (cached) — distribute width equally instead of returning 0%
- Add horizontal scroll to timeline bar for large checkpoint counts
- Add Storybook stories for ExecutionTimelineBar

## Test plan
- [ ] Open Storybook **AllCached** story — bar should fill the full container width
- [ ] Open **FiveHundredCheckpoints** story — bar should be horizontally scrollable
- [ ] Verify **MixedDurations** and **SomeCached** stories still render correctly