### PR TITLE
Add Playwright e2e test infrastructure with smoke test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,75 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Build app
+        run: pnpm build
+
+      - name: Run E2E tests
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ docs/superpowers
 
 *storybook.log
 storybook-static
+
+# Playwright
+playwright-report
+test-results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,7 @@ Keep both files accurate — stale docs erode trust faster than missing docs.
 
 - E2E test files live in `e2e/specs/` and are named `*.spec.ts`
 - Import `test` and `expect` from `e2e/fixtures/test.ts`, not directly from `@playwright/test`
-- Use the `authenticatedPage` fixture for tests that need an authenticated session — it mocks `/api/v1/info` and `/api/v1/current-user` automatically. It is `auto: false`, so tests must destructure it to activate it; use `void authenticatedPage` to suppress the `noUnusedLocals` TypeScript error (this is intentional — see the smoke test for the pattern)
+- Use the `authenticatedPage` fixture for tests that need an authenticated session — it mocks `/api/v1/info` and `/api/v1/current-user` automatically. It is `auto: false`; Playwright activates it when it appears in the destructured parameter list. Use `void authenticatedPage` to suppress the `noUnusedLocals` TypeScript error since the fixture's type is `void` and the variable is never referenced in the test body (see the smoke test for the pattern)
 - Add per-test mocks with `await mockApi({ "/api/v1/some-endpoint": fixture })` **before** calling `page.goto()` — mock-api registers the route handler lazily, and loaders run during navigation
 - Any `/api/v1/*` call with no matching mock returns HTTP 500 and fails the test — add the endpoint to the mock map when you see "Unmocked endpoint: X" in output
 - Factory functions for API fixture data live in `e2e/fixtures/api/` and are typed against `src/shared/api/openapi.d.ts` — TypeScript catches schema drift at compile time

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ pnpm build            # Build for production (tsc + vite build)
 pnpm lint             # Run ESLint
 pnpm format           # Format code with Prettier
 pnpm test:unit        # Run unit tests (Vitest)
+pnpm test:e2e          # Run e2e tests headless (requires pnpm build first)
+pnpm test:e2e:ui       # Interactive Playwright UI mode — use this when writing tests
+pnpm test:e2e:install  # One-time: download Chromium browser (~150MB)
 pnpm preview          # Preview the production build locally
 pnpm generate:types   # Generate OpenAPI types: pnpm generate:types -- <base-url>
 ```
@@ -230,6 +233,17 @@ Keep both files accurate — stale docs erode trust faster than missing docs.
 - Hooks with complex state transitions or derived logic are good candidates for testing with `renderHook` from Testing Library
 - Don't test presentational UI components unless they contain logic; prefer testing the logic in isolation
 
+### E2E Tests
+
+- E2E test files live in `e2e/specs/` and are named `*.spec.ts`
+- Import `test` and `expect` from `e2e/fixtures/test.ts`, not directly from `@playwright/test`
+- Use the `authenticatedPage` fixture for tests that need an authenticated session — it mocks `/api/v1/info` and `/api/v1/current-user` automatically. It is `auto: false`, so tests must destructure it to activate it; use `void authenticatedPage` to suppress the `noUnusedLocals` TypeScript error (this is intentional — see the smoke test for the pattern)
+- Add per-test mocks with `await mockApi({ "/api/v1/some-endpoint": fixture })` **before** calling `page.goto()` — mock-api registers the route handler lazily, and loaders run during navigation
+- Any `/api/v1/*` call with no matching mock returns HTTP 500 and fails the test — add the endpoint to the mock map when you see "Unmocked endpoint: X" in output
+- Factory functions for API fixture data live in `e2e/fixtures/api/` and are typed against `src/shared/api/openapi.d.ts` — TypeScript catches schema drift at compile time
+- Locator priority: `getByRole` → `getByLabel` → `getByText` → `getByTestId` (last resort) — never CSS class selectors
+- `pnpm build` must be run before `pnpm test:e2e` — the test server runs `pnpm preview` against `dist/`
+
 ## CI
 
 GitHub Actions (`.github/workflows/build-validation.yml`) runs on push to `main` and on all PRs:
@@ -238,3 +252,13 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on push to `main`
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+
+GitHub Actions also runs `.github/workflows/e2e.yml` on all PRs and pushes to `main`:
+
+1. `pnpm install --frozen-lockfile`
+2. `pnpm build`
+3. Playwright Chromium install (cached in `~/.cache/ms-playwright`)
+4. `pnpm test:e2e`
+5. Upload `playwright-report/` artifact on failure (14-day retention)
+
+The E2E workflow runs in parallel with `build-validation.yml`. Both must pass for PRs to merge.

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,3 @@
+// e2e/constants.ts
+export const E2E_PORT = 4173;
+export const E2E_BASE_URL = `http://localhost:${E2E_PORT}`;

--- a/e2e/fixtures/api/current-user.ts
+++ b/e2e/fixtures/api/current-user.ts
@@ -4,8 +4,14 @@ type UserResponse = components["schemas"]["UserResponse"];
 
 export function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
 	return {
-		id: "user-1",
+		id: "00000000-0000-0000-0000-000000000001",
 		name: "test-user",
+		body: {
+			created: "2024-01-01T00:00:00Z",
+			updated: "2024-01-01T00:00:00Z",
+			is_service_account: false,
+			is_admin: false,
+		},
 		...overrides,
 	};
 }

--- a/e2e/fixtures/api/current-user.ts
+++ b/e2e/fixtures/api/current-user.ts
@@ -1,0 +1,11 @@
+import type { components } from "@/shared/api/openapi";
+
+type UserResponse = components["schemas"]["UserResponse"];
+
+export function makeUser(overrides: Partial<UserResponse> = {}): UserResponse {
+	return {
+		id: "user-1",
+		name: "test-user",
+		...overrides,
+	};
+}

--- a/e2e/fixtures/api/index.ts
+++ b/e2e/fixtures/api/index.ts
@@ -1,0 +1,3 @@
+export { makeUser } from "./current-user";
+export { makeServerInfo } from "./server-info";
+export { makePipeline, makePipelinePage } from "./pipelines";

--- a/e2e/fixtures/api/pipelines.ts
+++ b/e2e/fixtures/api/pipelines.ts
@@ -1,0 +1,24 @@
+import type { components } from "@/shared/api/openapi";
+
+type PipelineResponse = components["schemas"]["PipelineResponse"];
+type PipelinePage = components["schemas"]["Page_PipelineResponse_"];
+
+export function makePipeline(
+	overrides: Partial<PipelineResponse> = {}
+): PipelineResponse {
+	return {
+		id: "pipeline-1",
+		name: "demo-pipeline",
+		...overrides,
+	};
+}
+
+export function makePipelinePage(items: PipelineResponse[] = []): PipelinePage {
+	return {
+		index: 1,
+		max_size: 1000,
+		total_pages: 1,
+		total: items.length,
+		items,
+	};
+}

--- a/e2e/fixtures/api/pipelines.ts
+++ b/e2e/fixtures/api/pipelines.ts
@@ -7,8 +7,13 @@ export function makePipeline(
 	overrides: Partial<PipelineResponse> = {}
 ): PipelineResponse {
 	return {
-		id: "pipeline-1",
+		id: "00000000-0000-0000-0000-000000000002",
 		name: "demo-pipeline",
+		body: {
+			created: "2024-01-01T00:00:00Z",
+			updated: "2024-01-01T00:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000010",
+		},
 		...overrides,
 	};
 }

--- a/e2e/fixtures/api/server-info.ts
+++ b/e2e/fixtures/api/server-info.ts
@@ -1,0 +1,14 @@
+import type { components } from "@/shared/api/openapi";
+
+type ServerModel = components["schemas"]["ServerModel"];
+
+export function makeServerInfo(
+	overrides: Partial<ServerModel> = {}
+): ServerModel {
+	return {
+		version: "0.0.0",
+		auth_scheme: "OAUTH2_PASSWORD_BEARER",
+		active: true,
+		...overrides,
+	};
+}

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,8 +1,8 @@
 // e2e/fixtures/test.ts
-/* eslint-disable react-hooks/rules-of-hooks */
 import { test as base, expect } from "@playwright/test";
 import { mockApi as mockApiHelper, type Mocks } from "../helpers/mock-api";
 import { makeServerInfo, makeUser } from "./api";
+import { E2E_BASE_URL } from "../constants";
 
 type TestFixtures = {
 	mockApi: (mocks: Mocks) => Promise<void>;
@@ -19,7 +19,7 @@ export const test = base.extend<TestFixtures>({
 			await page
 				.context()
 				.addCookies([
-					{ name: "session", value: "e2e-fake", url: "http://localhost:4173" },
+					{ name: "session", value: "e2e-fake", url: E2E_BASE_URL },
 				]);
 			await mockApi({
 				"/api/v1/info": makeServerInfo(),

--- a/e2e/fixtures/test.ts
+++ b/e2e/fixtures/test.ts
@@ -1,0 +1,34 @@
+// e2e/fixtures/test.ts
+/* eslint-disable react-hooks/rules-of-hooks */
+import { test as base, expect } from "@playwright/test";
+import { mockApi as mockApiHelper, type Mocks } from "../helpers/mock-api";
+import { makeServerInfo, makeUser } from "./api";
+
+type TestFixtures = {
+	mockApi: (mocks: Mocks) => Promise<void>;
+	authenticatedPage: void;
+};
+
+export const test = base.extend<TestFixtures>({
+	mockApi: async ({ page }, use) => {
+		await use((mocks) => mockApiHelper(page, mocks));
+	},
+
+	authenticatedPage: [
+		async ({ page, mockApi }, use) => {
+			await page
+				.context()
+				.addCookies([
+					{ name: "session", value: "e2e-fake", url: "http://localhost:4173" },
+				]);
+			await mockApi({
+				"/api/v1/info": makeServerInfo(),
+				"/api/v1/current-user": makeUser(),
+			});
+			await use();
+		},
+		{ auto: false },
+	],
+});
+
+export { expect };

--- a/e2e/helpers/mock-api.ts
+++ b/e2e/helpers/mock-api.ts
@@ -12,24 +12,32 @@ export async function mockApi(page: Page, additions: Mocks): Promise<void> {
 
 	if (!pageRegistered.has(page)) {
 		pageRegistered.add(page);
-		await page.route("**/api/v1/**", (route) => {
-			const { pathname } = new URL(route.request().url());
-			const mocks = pageMocks.get(page) ?? {};
-			const body = mocks[pathname];
+		await page.route("**/api/v1/**", async (route) => {
+			try {
+				const { pathname } = new URL(route.request().url());
+				const mocks = pageMocks.get(page) ?? {};
+				const body = mocks[pathname];
 
-			if (body === undefined) {
-				return route.fulfill({
-					status: 500,
+				if (body === undefined) {
+					await route.fulfill({
+						status: 500,
+						contentType: "application/json",
+						body: JSON.stringify({ detail: `Unmocked endpoint: ${pathname}` }),
+					});
+					return;
+				}
+
+				await route.fulfill({
+					status: 200,
 					contentType: "application/json",
-					body: JSON.stringify({ detail: `Unmocked endpoint: ${pathname}` }),
+					body: JSON.stringify(body),
 				});
+			} catch (err) {
+				console.error(
+					`[mock-api] route.fulfill() failed for ${route.request().url()}:`,
+					err
+				);
 			}
-
-			return route.fulfill({
-				status: 200,
-				contentType: "application/json",
-				body: JSON.stringify(body),
-			});
 		});
 	}
 }

--- a/e2e/helpers/mock-api.ts
+++ b/e2e/helpers/mock-api.ts
@@ -1,0 +1,35 @@
+// e2e/helpers/mock-api.ts
+import type { Page } from "@playwright/test";
+
+export type Mocks = Record<string, unknown>;
+
+const pageMocks = new WeakMap<Page, Mocks>();
+const pageRegistered = new WeakSet<Page>();
+
+export async function mockApi(page: Page, additions: Mocks): Promise<void> {
+	const current = pageMocks.get(page) ?? {};
+	pageMocks.set(page, { ...current, ...additions });
+
+	if (!pageRegistered.has(page)) {
+		pageRegistered.add(page);
+		await page.route("**/api/v1/**", (route) => {
+			const { pathname } = new URL(route.request().url());
+			const mocks = pageMocks.get(page) ?? {};
+			const body = mocks[pathname];
+
+			if (body === undefined) {
+				return route.fulfill({
+					status: 500,
+					contentType: "application/json",
+					body: JSON.stringify({ detail: `Unmocked endpoint: ${pathname}` }),
+				});
+			}
+
+			return route.fulfill({
+				status: 200,
+				contentType: "application/json",
+				body: JSON.stringify(body),
+			});
+		});
+	}
+}

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -8,7 +8,9 @@ test("authenticated user is redirected to /flows and the app shell renders", asy
 	authenticatedPage,
 }) => {
 	// authenticatedPage is a side-effect fixture (sets cookie + mocks /info and /current-user).
-	// Destructuring it activates it; void suppresses the noUnusedLocals TS error.
+	// Playwright activates it by virtue of it appearing in the destructured parameter list above.
+	// void suppresses the noUnusedLocals TS error since the fixture's type is void
+	// and the variable is never referenced in the test body.
 	void authenticatedPage;
 
 	await mockApi({

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -1,0 +1,23 @@
+// e2e/specs/smoke.spec.ts
+import { test, expect } from "../fixtures/test";
+import { makePipelinePage } from "../fixtures/api";
+
+test("authenticated user is redirected to /flows and the app shell renders", async ({
+	page,
+	mockApi,
+	authenticatedPage,
+}) => {
+	void authenticatedPage;
+
+	await mockApi({
+		"/api/v1/pipelines": makePipelinePage(),
+	});
+
+	await page.goto("/");
+
+	// Root "/" redirects to "/flows" — confirms auth gate passed
+	await expect(page).toHaveURL("/flows");
+
+	// NavbarLayout's <nav> is visible — confirms React mounted and no error boundary fired
+	await expect(page.getByRole("navigation")).toBeVisible();
+});

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -7,6 +7,8 @@ test("authenticated user is redirected to /flows and the app shell renders", asy
 	mockApi,
 	authenticatedPage,
 }) => {
+	// authenticatedPage is a side-effect fixture (sets cookie + mocks /info and /current-user).
+	// Destructuring it activates it; void suppresses the noUnusedLocals TS error.
 	void authenticatedPage;
 
 	await mockApi({

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"lib": ["ES2022"],
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"skipLibCheck": true,
+		"verbatimModuleSyntax": true,
+		"moduleDetection": "force",
+		"noEmit": true,
+		"baseUrl": "..",
+		"paths": {
+			"@/*": ["src/*"]
+		}
+	},
+	"include": ["./**/*.ts", "../src/shared/api/openapi.d.ts"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,4 +25,10 @@ export default defineConfig([
 			"eslint-comments/no-unused-disable": "off",
 		},
 	},
+	{
+		files: ["e2e/**/*.ts"],
+		rules: {
+			"react-hooks/rules-of-hooks": "off",
+		},
+	},
 ]);

--- a/package.json
+++ b/package.json
@@ -6,13 +6,16 @@
 	"scripts": {
 		"build": "tsc -b && vite build",
 		"build-storybook": "storybook build",
-		"check:types": "tsc -b --noEmit",
+		"check:types": "tsc -b --noEmit && tsc --project e2e/tsconfig.json --noEmit",
 		"dev": "vite",
 		"format": "prettier --write .",
 		"generate:types": "node scripts/types.js",
 		"lint": "eslint .",
 		"preview": "vite preview",
 		"storybook": "storybook dev -p 6006",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:install": "playwright install --with-deps chromium",
 		"test:unit": "vitest"
 	},
 	"dependencies": {
@@ -50,6 +53,7 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.39.4",
+		"@playwright/test": "^1.59.1",
 		"@rolldown/plugin-babel": "^0.2.3",
 		"@storybook/react-vite": "^10.3.5",
 		"@tailwindcss/vite": "^4.2.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
-
-const PORT = 4173;
-const BASE_URL = `http://localhost:${PORT}`;
+import { E2E_BASE_URL, E2E_PORT } from "./e2e/constants";
 
 export default defineConfig({
 	testDir: "./e2e/specs",
@@ -10,14 +8,14 @@ export default defineConfig({
 	retries: process.env.CI ? 2 : 0,
 	reporter: process.env.CI ? [["html"], ["github"]] : "list",
 	use: {
-		baseURL: BASE_URL,
+		baseURL: E2E_BASE_URL,
 		trace: "retain-on-failure",
 		screenshot: "only-on-failure",
 	},
 	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 	webServer: {
-		command: `pnpm preview --port ${PORT} --strictPort`,
-		url: BASE_URL,
+		command: `pnpm preview --port ${E2E_PORT} --strictPort`,
+		url: E2E_BASE_URL,
 		reuseExistingServer: !process.env.CI,
 		timeout: 120_000,
 	},

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+	testDir: "./e2e/specs",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	reporter: process.env.CI ? [["html"], ["github"]] : "list",
+	use: {
+		baseURL: BASE_URL,
+		trace: "retain-on-failure",
+		screenshot: "only-on-failure",
+	},
+	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+	webServer: {
+		command: `pnpm preview --port ${PORT} --strictPort`,
+		url: BASE_URL,
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000,
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.15)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0))
@@ -646,6 +649,11 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2236,6 +2244,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2798,6 +2811,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -3879,6 +3902,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.124.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5507,6 +5534,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -6003,6 +6033,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## Summary

- Installs `@playwright/test` (Chromium only) and wires `pnpm test:e2e` / `pnpm test:e2e:ui` / `pnpm test:e2e:install` scripts
- Adds `e2e/` infrastructure: `mock-api` helper (WeakMap-based `page.route()` interception with fail-loud guard), typed API fixture factories (`makeUser`, `makeServerInfo`, `makePipeline`, `makePipelinePage`), and a custom `test` fixture (`mockApi` + `authenticatedPage`)
- Ships one smoke test: authenticated user navigates to `/`, redirects to `/flows`, nav visible — proves the full auth chain and app shell render end-to-end
- Adds `.github/workflows/e2e.yml` (parallel with `build-validation`, pnpm + Playwright browser caching, trace artifact on failure)

## Test Plan

- [ ] `pnpm test:e2e:install` (one-time — downloads Chromium)
- [ ] `pnpm build && pnpm test:e2e` — smoke test passes (1 passed)
- [ ] `pnpm check:types` — both app and e2e types clean
- [ ] CI E2E workflow passes on this PR