### PR TITLE
Make Logs the first checkpoint tab and persist selection

### DIFF
--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -18,10 +18,14 @@ import { CheckpointLogsTabContainer } from "./CheckpointLogsTabContainer";
 
 type CheckpointDetailPanelContainerProps = {
 	checkpointId?: string;
+	activeTab: PanelTab;
+	onTabChange: (tab: PanelTab) => void;
 };
 
 export function CheckpointDetailPanelContainer({
 	checkpointId,
+	activeTab,
+	onTabChange,
 }: CheckpointDetailPanelContainerProps) {
 	if (!checkpointId) {
 		return <CheckpointDetailsEmptyView />;
@@ -29,15 +33,23 @@ export function CheckpointDetailPanelContainer({
 
 	return (
 		<Suspense fallback={<CheckpointDetailPanelSkeleton />}>
-			<CheckpointDetailPanelContentContainer checkpointId={checkpointId} />
+			<CheckpointDetailPanelContentContainer
+				checkpointId={checkpointId}
+				activeTab={activeTab}
+				onTabChange={onTabChange}
+			/>
 		</Suspense>
 	);
 }
 
 function CheckpointDetailPanelContentContainer({
 	checkpointId,
+	activeTab,
+	onTabChange,
 }: {
 	checkpointId: string;
+	activeTab: PanelTab;
+	onTabChange: (tab: PanelTab) => void;
 }) {
 	const { detailsData } = useCheckpointDetails(checkpointId, {
 		refetchInterval: getCheckpointDetailsPollingInterval,
@@ -46,14 +58,13 @@ function CheckpointDetailPanelContentContainer({
 	const inputs = detailsData?.inputs ?? [];
 	const outputs = detailsData?.outputs ?? [];
 
-	const [activeTab, setActiveTab] = useState<PanelTab>("checkpoint");
 	const [selectedArtifact, setSelectedArtifact] = useState<{
 		artifact: ArtifactEntry;
 		direction: "input" | "output";
 	} | null>(null);
 
 	function handleTabChange(tab: PanelTab) {
-		setActiveTab(tab);
+		onTabChange(tab);
 		if (tab === "artifacts" && !selectedArtifact) {
 			const first = outputs[0] ?? inputs[0];
 			if (first) {

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/shared/utils/styles";
 
 export type PanelTab = "checkpoint" | "artifacts" | "memory" | "logs";
 
-const TABS = ["checkpoint", "artifacts", "memory", "logs"] as const;
+const TABS = ["logs", "checkpoint", "artifacts", "memory"] as const;
 
 interface CheckpointDetailPanelTabsProps {
 	activeTab: PanelTab;

--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/modules/checkpoints/business-logic/use-checkpoints";
 import { useTimelineEntries } from "../business-logic/use-timeline-entries";
 import { CheckpointDetailPanelContainer } from "@/modules/checkpoints/feature/CheckpointDetailPanelContainer";
+import type { PanelTab } from "@/modules/checkpoints/ui/CheckpointDetailPanelTabs";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import { CopyCommand } from "@/shared/ui/CopyCommand";
 import { RefreshButton } from "@/shared/ui/RefreshButton";
@@ -93,6 +94,8 @@ export function ExecutionContainer() {
 	const [selectedCheckpointId, setSelectedCheckpointId] = useState<
 		string | undefined
 	>();
+	const [activeCheckpointTab, setActiveCheckpointTab] =
+		useState<PanelTab>("logs");
 	const layoutRef = useRef<ThreePanelLayoutHandle>(null);
 
 	const executionsSortedByCreatedAtDesc = [...executionsData].sort((a, b) => {
@@ -163,6 +166,8 @@ export function ExecutionContainer() {
 				<CheckpointDetailPanelContainer
 					key={selectedCheckpointId}
 					checkpointId={selectedCheckpointId}
+					activeTab={activeCheckpointTab}
+					onTabChange={setActiveCheckpointTab}
 				/>
 			}
 		/>


### PR DESCRIPTION
## Summary
- Reorder checkpoint detail tabs so **Logs** is first (and the default)
- Lift active tab state to `ExecutionContainer` so the selection survives the panel's remount when switching checkpoints
- Per-checkpoint `selectedArtifact` still resets as before (via the `key` on the panel)

## Test plan
- [ ] Open a checkpoint — Logs tab is active by default
- [ ] Switch to Artifacts/Memory/Checkpoint, then click another checkpoint — the same tab stays selected
- [ ] Selecting Artifacts still auto-picks the first output/input for the current checkpoint