### PR TITLE
Harden GitHub Actions workflow baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -17,15 +17,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -42,3 +42,21 @@ jobs:
 
       - name: Run Unit Tests and Coverage
         run: pnpm test:unit
+
+  actions-security-audit:
+    name: GitHub Actions Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          inputs: .github
+          min-severity: low
+          version: 1.24.1
+          advanced-security: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.ref }}
   cancel-in-progress: true
@@ -18,15 +21,17 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 
@@ -35,7 +40,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -46,7 +51,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -68,7 +73,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Get the version from the github tag ref
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-node@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: lts/*
+          package-manager-cache: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: latest
 
@@ -44,7 +48,7 @@ jobs:
           sha256sum -b kitaru-ui.tar.gz > kitaru-ui.tar.gz.sha256
 
       - name: Release to GitHub
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             kitaru-ui.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,3 +245,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+
+### GitHub Actions hardening
+
+- Every workflow must declare explicit `permissions:` using least privilege. Build/test workflows should normally use `contents: read`; release workflows should only request the write scopes they actually need.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,3 +251,4 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 - Every workflow must declare explicit `permissions:` using least privilege. Build/test workflows should normally use `contents: read`; release workflows should only request the write scopes they actually need.
 - Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
 - Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.
+- Dependabot is configured only for the `github-actions` ecosystem and targets `develop`; do not add npm/pnpm Dependabot updates unless explicitly requested because they are intentionally avoided to reduce noise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ Keep both files accurate — stale docs erode trust faster than missing docs.
 
 ## CI
 
-GitHub Actions (`.github/workflows/build-validation.yml`) runs on push to `main` and on all PRs:
+GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `main` and `develop`, on all PRs, and by manual dispatch:
 
 1. `pnpm install --frozen-lockfile`
 2. `pnpm lint`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,3 +249,5 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 ### GitHub Actions hardening
 
 - Every workflow must declare explicit `permissions:` using least privilege. Build/test workflows should normally use `contents: read`; release workflows should only request the write scopes they actually need.
+- Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
+- Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ### GitHub Actions hardening
 
@@ -252,3 +253,4 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 - Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
 - Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.
 - Dependabot is configured only for the `github-actions` ecosystem and targets `develop`; do not add npm/pnpm Dependabot updates unless explicitly requested because they are intentionally avoided to reduce noise.
+- CI runs `zizmor` 1.24.1 against `.github` and blocks non-informational findings (`min-severity: low`) so workflow and Dependabot changes should be checked locally with `uvx zizmor==1.24.1 --min-severity low .github` when possible.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Both are excluded from ESLint.
 
 ## CI
 
-GitHub Actions (`.github/workflows/build-validation.yml`) runs on push to `main` and on all PRs:
+GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `main` and `develop`, on all PRs, and by manual dispatch:
 
 1. `pnpm install --frozen-lockfile`
 2. `pnpm lint`

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- run build validation on pushes to `develop` while keeping `main`, PR, and manual-dispatch coverage
- add explicit least-privilege `GITHUB_TOKEN` permissions to the build and release workflows
- pin GitHub Actions to full commit SHAs and disable checkout credential persistence
- disable automatic setup-node package-manager caching in the release workflow so the workflow passes the planned Actions security audit
- document the workflow hardening conventions in `AGENTS.md` / `README.md`

## Issue context

Closes #84.

This also provides the baseline workflow hardening needed before adding a blocking `zizmor` audit for #82. It overlaps with the workflow-pinning and checkout-hardening parts of #80, but keeps this stack focused on GitHub Actions hardening.

## Validation

- `pnpm lint` — passes with existing React Compiler / TanStack Table warnings
- `pnpm build` — passes with existing chunk-size warnings
- `pnpm test:unit` — 23 files / 198 tests passed
- `uvx zizmor==1.24.1 --format plain --min-severity low .github` — passes
