### PR TITLE
Add Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -42,3 +42,21 @@ jobs:
 
       - name: Run Unit Tests and Coverage
         run: pnpm test:unit
+
+  actions-security-audit:
+    name: GitHub Actions Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          inputs: .github
+          min-severity: low
+          version: 1.24.1
+          advanced-security: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,3 +251,4 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 - Every workflow must declare explicit `permissions:` using least privilege. Build/test workflows should normally use `contents: read`; release workflows should only request the write scopes they actually need.
 - Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
 - Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.
+- Dependabot is configured only for the `github-actions` ecosystem and targets `develop`; do not add npm/pnpm Dependabot updates unless explicitly requested because they are intentionally avoided to reduce noise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ### GitHub Actions hardening
 
@@ -252,3 +253,4 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 - Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
 - Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.
 - Dependabot is configured only for the `github-actions` ecosystem and targets `develop`; do not add npm/pnpm Dependabot updates unless explicitly requested because they are intentionally avoided to reduce noise.
+- CI runs `zizmor` 1.24.1 against `.github` and blocks non-informational findings (`min-severity: low`) so workflow and Dependabot changes should be checked locally with `uvx zizmor==1.24.1 --min-severity low .github` when possible.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- add `.github/dependabot.yml`
- configure Dependabot only for the `github-actions` ecosystem
- target Dependabot PRs at `develop`
- use weekly grouped updates with a 7-day cooldown
- intentionally avoid npm/pnpm Dependabot updates to prevent noisy package-update PRs

## Issue context

Addresses #81.

This PR is stacked on top of the baseline workflow-hardening PR so Dependabot can maintain the pinned GitHub Actions references introduced there.

## Validation

- `uvx zizmor --format plain --collect dependabot -- .github/dependabot.yml` — passes
- full stack validation on the top branch:
  - `pnpm lint` — passes with existing React Compiler / TanStack Table warnings
  - `pnpm build` — passes with existing chunk-size warnings
  - `pnpm test:unit` — 23 files / 198 tests passed
  - `uvx zizmor==1.24.1 --format plain --min-severity low .github` — passes
