### PR TITLE
Add zizmor audit to workflow validation

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -42,3 +42,21 @@ jobs:
 
       - name: Run Unit Tests and Coverage
         run: pnpm test:unit
+
+  actions-security-audit:
+    name: GitHub Actions Security Audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          inputs: .github
+          min-severity: low
+          version: 1.24.1
+          advanced-security: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ### GitHub Actions hardening
 
@@ -252,3 +253,4 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 - Pin all `uses:` actions to full commit SHAs, keeping a nearby version comment for human review and Dependabot maintenance.
 - Set `persist-credentials: false` on `actions/checkout` unless the workflow explicitly needs persisted git credentials.
 - Dependabot is configured only for the `github-actions` ecosystem and targets `develop`; do not add npm/pnpm Dependabot updates unless explicitly requested because they are intentionally avoided to reduce noise.
+- CI runs `zizmor` 1.24.1 against `.github` and blocks non-informational findings (`min-severity: low`) so workflow and Dependabot changes should be checked locally with `uvx zizmor==1.24.1 --min-severity low .github` when possible.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ GitHub Actions (`.github/workflows/build-validation.yml`) runs on pushes to `mai
 2. `pnpm lint`
 3. `pnpm build`
 4. `pnpm test:unit`
+5. `zizmor` audit for GitHub Actions workflow hardening
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- add a `GitHub Actions Security Audit` job to the existing build-validation workflow
- run pinned `zizmorcore/zizmor-action` with pinned `zizmor` CLI version `1.24.1`
- audit `.github`, including workflows and Dependabot config
- fail CI for non-informational findings with `min-severity: low`
- keep `advanced-security: false` so the job only needs read-only workflow permissions
- document the local reproduction command in `AGENTS.md`

## Issue context

Addresses #82.

This PR is stacked after the workflow-hardening and Dependabot PRs because `zizmor` would fail against the original unpinned workflows.

## Validation

- `pnpm lint` — passes with existing React Compiler / TanStack Table warnings
- `pnpm build` — passes with existing chunk-size warnings
- `pnpm test:unit` — 23 files / 198 tests passed
- `uvx zizmor==1.24.1 --format plain --min-severity low .github` — passes
