### PR TITLE
Remove Edit keys from secrets list row dropdown

### DIFF
--- a/src/modules/secrets/feature/SecretRowActionsContainer.tsx
+++ b/src/modules/secrets/feature/SecretRowActionsContainer.tsx
@@ -1,4 +1,4 @@
-import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { MoreHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/shared/ui/button";
@@ -11,7 +11,6 @@ import {
 
 import type { Secret } from "../domain/secrets";
 import { DeleteSecretAlertDialogContainer } from "./DeleteSecretAlertDialogContainer";
-import { SecretFormDialogContainer } from "./SecretFormDialogContainer";
 
 type SecretRowActionsContainerProps = {
 	secret: Secret;
@@ -20,19 +19,10 @@ type SecretRowActionsContainerProps = {
 export function SecretRowActionsContainer({
 	secret,
 }: SecretRowActionsContainerProps) {
-	const [showEdit, setShowEdit] = useState(false);
 	const [showDelete, setShowDelete] = useState(false);
 
 	return (
 		<>
-			{showEdit && (
-				<SecretFormDialogContainer
-					mode="edit"
-					open={showEdit}
-					onOpenChange={setShowEdit}
-					secret={secret}
-				/>
-			)}
 			{showDelete && (
 				<DeleteSecretAlertDialogContainer
 					secret={secret}
@@ -54,9 +44,6 @@ export function SecretRowActionsContainer({
 					}
 				/>
 				<DropdownMenuContent align="end" className="w-40">
-					<DropdownMenuItem onClick={() => setShowEdit(true)}>
-						<Pencil className="size-4" /> Edit keys
-					</DropdownMenuItem>
 					<DropdownMenuItem
 						variant="destructive"
 						onClick={() => setShowDelete(true)}


### PR DESCRIPTION
## Summary
- The \"Edit keys\" action on the secrets list row dropdown opened the form with empty keys because the list endpoint (`GET /api/v1/secrets`) never returns decrypted `body.values` — only the detail endpoint does.
- Rather than fetching the hydrated secret on dropdown click, drop the action entirely. Users can still edit keys from the secret detail page, where the full secret is already loaded.

## Test plan
- [x] `pnpm check:types`
- [x] `pnpm exec playwright test e2e/specs/secrets.spec.ts` (7 passed)
- [ ] Manual: open a secret row dropdown on `/settings/secrets` and confirm only \"Delete secret\" is shown