### PR TITLE
Distinguish execution row styling in log scope sidebar

### DIFF
--- a/src/modules/executions/ui/ExecutionLogsScopeSidebar.tsx
+++ b/src/modules/executions/ui/ExecutionLogsScopeSidebar.tsx
@@ -24,19 +24,12 @@ export function ExecutionLogsScopeSidebar({
 			aria-label="Log scope"
 			className="border-border bg-card flex w-56 shrink-0 flex-col border-r"
 		>
-			<button
-				type="button"
+			<ScopeRow
+				label={`Execution #${formatExecutionIndex(executionIndex)}`}
+				isActive={isRootActive}
 				onClick={onSelectRoot}
-				aria-current={isRootActive ? "true" : undefined}
-				className={cn(
-					"border-border flex h-9 shrink-0 items-center truncate border-b px-3 text-left text-xs font-semibold transition-colors",
-					isRootActive
-						? "bg-accent text-foreground"
-						: "text-foreground hover:bg-accent/50"
-				)}
-			>
-				Execution #{formatExecutionIndex(executionIndex)}
-			</button>
+				emphasized
+			/>
 			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
 				{checkpoints.map((cp) => (
 					<ScopeRow
@@ -55,19 +48,22 @@ type ScopeRowProps = {
 	label: string;
 	isActive: boolean;
 	onClick: () => void;
+	emphasized?: boolean;
 };
 
-function ScopeRow({ label, isActive, onClick }: ScopeRowProps) {
+function ScopeRow({ label, isActive, onClick, emphasized }: ScopeRowProps) {
 	return (
 		<button
 			type="button"
 			onClick={onClick}
 			aria-current={isActive ? "true" : undefined}
 			className={cn(
-				"shrink-0 truncate px-3 py-2 text-left text-xs transition-colors",
-				isActive
-					? "bg-accent text-foreground font-medium"
-					: "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+				"shrink-0 truncate px-3 text-left text-xs transition-colors",
+				emphasized
+					? "border-border text-foreground flex h-9 items-center border-b font-semibold"
+					: "text-muted-foreground hover:text-foreground py-2",
+				isActive ? "bg-accent" : "hover:bg-accent/50",
+				isActive && !emphasized && "text-foreground font-medium"
 			)}
 		>
 			{label}

--- a/src/modules/executions/ui/ExecutionLogsScopeSidebar.tsx
+++ b/src/modules/executions/ui/ExecutionLogsScopeSidebar.tsx
@@ -24,12 +24,19 @@ export function ExecutionLogsScopeSidebar({
 			aria-label="Log scope"
 			className="border-border bg-card flex w-56 shrink-0 flex-col border-r"
 		>
-			<ScopeRow
-				label={`Execution #${formatExecutionIndex(executionIndex)}`}
-				isActive={isRootActive}
+			<button
+				type="button"
 				onClick={onSelectRoot}
-			/>
-			<div className="border-border border-t" />
+				aria-current={isRootActive ? "true" : undefined}
+				className={cn(
+					"border-border flex h-9 shrink-0 items-center truncate border-b px-3 text-left text-xs font-semibold transition-colors",
+					isRootActive
+						? "bg-accent text-foreground"
+						: "text-foreground hover:bg-accent/50"
+				)}
+			>
+				Execution #{formatExecutionIndex(executionIndex)}
+			</button>
 			<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
 				{checkpoints.map((cp) => (
 					<ScopeRow


### PR DESCRIPTION
## Summary
- Give the log scope sidebar's `Execution #` row a distinct look (heavier font weight, full-contrast foreground) versus the muted checkpoint rows.
- Match the row's height to the logs table header (36px) by rebuilding it with the same structural pattern: fixed height + `border-b` (replacing the previous external divider).

## Test plan
- [x] Sidebar exec row and `LEVEL / TIME / EVENT` header share identical top/bottom edges (verified via agent-browser at 158→194, 36px each).
- [x] Visual check: exec row reads heavier than checkpoint rows; checkpoint rows unchanged.