### PR TITLE
feat: add reads-only data-fetching layer for Deployments

### DIFF
--- a/src/modules/deployments/business-logic/deployments-queries.ts
+++ b/src/modules/deployments/business-logic/deployments-queries.ts
@@ -1,0 +1,24 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchDeployments } from "../domain/fetch-deployments";
+import { fetchDeployment } from "../domain/fetch-deployment";
+
+export const deploymentsQueryKeys = {
+	base: ["deployments"] as const,
+	list: (flowId: string) =>
+		[...deploymentsQueryKeys.base, "list", flowId] as const,
+	detail: (snapshotId: string) =>
+		[...deploymentsQueryKeys.base, "detail", snapshotId] as const,
+};
+
+export const deploymentsQueries = {
+	list: (flowId: string) =>
+		queryOptions({
+			queryKey: deploymentsQueryKeys.list(flowId),
+			queryFn: () => fetchDeployments(flowId),
+		}),
+	detail: (snapshotId: string) =>
+		queryOptions({
+			queryKey: deploymentsQueryKeys.detail(snapshotId),
+			queryFn: () => fetchDeployment(snapshotId),
+		}),
+};

--- a/src/modules/deployments/business-logic/resolve-deployment.spec.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { Deployment } from "../domain/deployment";
+import type { Execution } from "@/modules/executions/domain/execution";
+import {
+	resolveDefaultDeployment,
+	resolveDeploymentByExclusiveTag,
+	resolveDeploymentByVersion,
+	resolveDeploymentForExecution,
+} from "./resolve-deployment";
+
+function mkDeployment(overrides: Partial<Deployment>): Deployment {
+	return {
+		id: "snap-x",
+		flowId: "flow-1",
+		flowName: "research_agent",
+		versionNumber: 1,
+		tags: [],
+		runnable: true,
+		deployable: true,
+		...overrides,
+	};
+}
+
+function mkExecution(overrides: Partial<Execution>): Execution {
+	return {
+		id: "run-1",
+		name: "run",
+		index: 1,
+		logSources: [],
+		...overrides,
+	};
+}
+
+// Intentionally unsorted — selectors must not depend on list order.
+const d3 = mkDeployment({
+	id: "snap-3",
+	versionNumber: 3,
+	tags: [{ id: "t1", name: "default", exclusive: true }],
+});
+const d2 = mkDeployment({
+	id: "snap-2",
+	versionNumber: 2,
+	tags: [{ id: "t2", name: "beta", exclusive: false }],
+});
+const d1 = mkDeployment({
+	id: "snap-1",
+	versionNumber: 1,
+	tags: [{ id: "t2", name: "beta", exclusive: false }],
+});
+const deployments: Deployment[] = [d1, d3, d2];
+
+describe("resolveDefaultDeployment", () => {
+	it("returns the deployment carrying the 'default' tag", () => {
+		expect(resolveDefaultDeployment(deployments)).toBe(d3);
+	});
+
+	it("returns undefined when no deployment has the default tag", () => {
+		expect(resolveDefaultDeployment([d2, d1])).toBeUndefined();
+	});
+
+	it("returns undefined for an empty list", () => {
+		expect(resolveDefaultDeployment([])).toBeUndefined();
+	});
+});
+
+describe("resolveDeploymentByVersion", () => {
+	it("returns the exact-version match", () => {
+		expect(resolveDeploymentByVersion(deployments, 2)).toBe(d2);
+	});
+
+	it("returns undefined for a missing version", () => {
+		expect(resolveDeploymentByVersion(deployments, 99)).toBeUndefined();
+	});
+});
+
+describe("resolveDeploymentByExclusiveTag", () => {
+	it("returns the deployment whose tag matches by name and is exclusive", () => {
+		expect(resolveDeploymentByExclusiveTag(deployments, "default")).toBe(d3);
+	});
+
+	it("returns undefined when the named tag exists but is not exclusive", () => {
+		expect(
+			resolveDeploymentByExclusiveTag(deployments, "beta")
+		).toBeUndefined();
+	});
+
+	it("returns undefined for an unknown tag", () => {
+		expect(
+			resolveDeploymentByExclusiveTag(deployments, "no-such-tag")
+		).toBeUndefined();
+	});
+});
+
+describe("resolveDeploymentForExecution", () => {
+	it("returns the deployment matching execution.snapshotId", () => {
+		const exec = mkExecution({ snapshotId: "snap-2" });
+		expect(resolveDeploymentForExecution(exec, deployments)).toBe(d2);
+	});
+
+	it("returns undefined when execution has no snapshotId", () => {
+		const exec = mkExecution({ snapshotId: undefined });
+		expect(resolveDeploymentForExecution(exec, deployments)).toBeUndefined();
+	});
+
+	it("returns undefined when the snapshotId isn't in the list", () => {
+		const exec = mkExecution({ snapshotId: "snap-missing" });
+		expect(resolveDeploymentForExecution(exec, deployments)).toBeUndefined();
+	});
+});

--- a/src/modules/deployments/business-logic/resolve-deployment.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.ts
@@ -1,0 +1,33 @@
+import type { Execution } from "@/modules/executions/domain/execution";
+import type { Deployment } from "../domain/deployment";
+
+export function resolveDefaultDeployment(
+	deployments: Deployment[]
+): Deployment | undefined {
+	return deployments.find((d) => d.tags.some((t) => t.name === "default"));
+}
+
+export function resolveDeploymentByVersion(
+	deployments: Deployment[],
+	version: number
+): Deployment | undefined {
+	return deployments.find((d) => d.versionNumber === version);
+}
+
+export function resolveDeploymentByExclusiveTag(
+	deployments: Deployment[],
+	tagName: string
+): Deployment | undefined {
+	return deployments.find((d) =>
+		d.tags.some((t) => t.name === tagName && t.exclusive)
+	);
+}
+
+export function resolveDeploymentForExecution(
+	execution: Execution,
+	deployments: Deployment[]
+): Deployment | undefined {
+	return execution.snapshotId
+		? deployments.find((d) => d.id === execution.snapshotId)
+		: undefined;
+}

--- a/src/modules/deployments/business-logic/use-deployment.ts
+++ b/src/modules/deployments/business-logic/use-deployment.ts
@@ -1,0 +1,6 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { deploymentsQueries } from "./deployments-queries";
+
+export function useDeployment(snapshotId: string) {
+	return useSuspenseQuery(deploymentsQueries.detail(snapshotId));
+}

--- a/src/modules/deployments/business-logic/use-deployments.ts
+++ b/src/modules/deployments/business-logic/use-deployments.ts
@@ -1,0 +1,6 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { deploymentsQueries } from "./deployments-queries";
+
+export function useDeployments(flowId: string) {
+	return useSuspenseQuery(deploymentsQueries.list(flowId));
+}

--- a/src/modules/deployments/domain/deployment.spec.ts
+++ b/src/modules/deployments/domain/deployment.spec.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "@/shared/api/openapi";
+import {
+	deploymentFromApiToDomain,
+	KITARU_SNAPSHOT_NAME,
+	NotAKitaruDeploymentError,
+} from "./deployment";
+
+type SnapshotResponse = components["schemas"]["PipelineSnapshotResponse"];
+
+function mkSnapshot(
+	overrides: Partial<SnapshotResponse> = {}
+): SnapshotResponse {
+	return {
+		id: "snap-1",
+		name: "kitaru::research_agent::v3",
+		body: {
+			created: "2026-04-22T10:00:00Z",
+			updated: "2026-04-22T10:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			runnable: true,
+			deployable: true,
+			is_dynamic: false,
+		},
+		metadata: {
+			run_name_template: "",
+			pipeline_configuration: {},
+			client_version: null,
+			server_version: null,
+		},
+		resources: {
+			pipeline: {
+				id: "flow-1",
+				name: "research_agent",
+				body: {
+					created: "2026-04-22T10:00:00Z",
+					updated: "2026-04-22T10:00:00Z",
+					project_id: "00000000-0000-0000-0000-000000000000",
+				},
+			},
+			tags: [],
+		},
+		...overrides,
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	} as any as SnapshotResponse;
+}
+
+describe("KITARU_SNAPSHOT_NAME regex", () => {
+	it("matches kitaru::<flow>::v<N>", () => {
+		const match = "kitaru::research_agent::v3".match(KITARU_SNAPSHOT_NAME);
+		expect(match).not.toBeNull();
+		expect(match?.[1]).toBe("research_agent");
+		expect(match?.[2]).toBe("3");
+	});
+
+	it("rejects vanilla ZenML snapshot names", () => {
+		expect("some-pipeline-run-42".match(KITARU_SNAPSHOT_NAME)).toBeNull();
+		expect("kitaru::research_agent".match(KITARU_SNAPSHOT_NAME)).toBeNull();
+		expect("research_agent::v1".match(KITARU_SNAPSHOT_NAME)).toBeNull();
+	});
+});
+
+describe("deploymentFromApiToDomain", () => {
+	it("returns null for a non-Kitaru snapshot name", () => {
+		const snapshot = mkSnapshot({ name: "vanilla-snapshot" });
+		expect(deploymentFromApiToDomain(snapshot)).toBeNull();
+	});
+
+	it("returns null when snapshot.name is missing", () => {
+		const snapshot = mkSnapshot({ name: null });
+		expect(deploymentFromApiToDomain(snapshot)).toBeNull();
+	});
+
+	it("maps a matching snapshot to a Deployment", () => {
+		const snapshot = mkSnapshot();
+		const result = deploymentFromApiToDomain(snapshot);
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe("snap-1");
+		expect(result?.flowId).toBe("flow-1");
+		expect(result?.flowName).toBe("research_agent");
+		expect(result?.versionNumber).toBe(3);
+		expect(result?.runnable).toBe(true);
+		expect(result?.deployable).toBe(true);
+		expect(result?.createdAt).toEqual(new Date("2026-04-22T10:00:00Z"));
+	});
+
+	it("maps tags with exclusive flag preserved", () => {
+		const snapshot = mkSnapshot({
+			resources: {
+				pipeline: {
+					id: "flow-1",
+					name: "research_agent",
+					body: {
+						created: "2026-04-22T10:00:00Z",
+						updated: "2026-04-22T10:00:00Z",
+						project_id: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				tags: [
+					{
+						id: "tag-default",
+						name: "default",
+						body: {
+							created: "2026-04-22T10:00:00Z",
+							updated: "2026-04-22T10:00:00Z",
+							exclusive: true,
+						},
+					},
+					{
+						id: "tag-beta",
+						name: "beta",
+						body: {
+							created: "2026-04-22T10:00:00Z",
+							updated: "2026-04-22T10:00:00Z",
+							exclusive: false,
+						},
+					},
+				],
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any,
+		});
+		const result = deploymentFromApiToDomain(snapshot);
+		expect(result?.tags).toEqual([
+			{ id: "tag-default", name: "default", exclusive: true, color: undefined },
+			{ id: "tag-beta", name: "beta", exclusive: false, color: undefined },
+		]);
+	});
+
+	it("maps stackName, latestRun*, and inputSchema when hydrated", () => {
+		const snapshot = mkSnapshot({
+			metadata: {
+				run_name_template: "",
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				pipeline_configuration: {} as any,
+				client_version: null,
+				server_version: null,
+				config_schema: {
+					type: "object",
+					properties: { topic: { type: "string" } },
+				},
+			},
+			resources: {
+				pipeline: {
+					id: "flow-1",
+					name: "research_agent",
+					body: {
+						created: "2026-04-22T10:00:00Z",
+						updated: "2026-04-22T10:00:00Z",
+						project_id: "00000000-0000-0000-0000-000000000000",
+					},
+				},
+				tags: [],
+				stack: {
+					id: "stack-1",
+					name: "prod-stack",
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				} as any,
+				latest_run_id: "run-99",
+				latest_run_status: "completed",
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any,
+		});
+		const result = deploymentFromApiToDomain(snapshot);
+		expect(result?.stackName).toBe("prod-stack");
+		expect(result?.latestRunId).toBe("run-99");
+		expect(result?.latestRunStatus).toBe("completed");
+		expect(result?.inputSchema).toEqual({
+			type: "object",
+			properties: { topic: { type: "string" } },
+		});
+	});
+});
+
+describe("NotAKitaruDeploymentError", () => {
+	it("carries the snapshot id and a distinctive name", () => {
+		const err = new NotAKitaruDeploymentError("snap-xyz");
+		expect(err.name).toBe("NotAKitaruDeploymentError");
+		expect(err.message).toContain("snap-xyz");
+	});
+});

--- a/src/modules/deployments/domain/deployment.ts
+++ b/src/modules/deployments/domain/deployment.ts
@@ -1,0 +1,78 @@
+import type { components } from "@/shared/api/openapi";
+import type { ExecutionStatus } from "@/modules/executions/domain/execution";
+import { parseBackendTimestamp } from "@/shared/utils/time";
+
+export const KITARU_SNAPSHOT_NAME = /^kitaru::(.+)::v(\d+)$/;
+
+export type DeploymentTag = {
+	id: string;
+	name: string;
+	exclusive: boolean;
+	color?: components["schemas"]["ColorVariants"];
+};
+
+export type Deployment = {
+	id: string;
+	flowId: string;
+	flowName: string;
+	versionNumber: number;
+	tags: DeploymentTag[];
+	createdAt?: Date;
+	updatedAt?: Date;
+	stackName?: string;
+	inputSchema?: Record<string, unknown>;
+	latestRunId?: string;
+	latestRunStatus?: ExecutionStatus;
+	runnable: boolean;
+	deployable: boolean;
+};
+
+export class NotAKitaruDeploymentError extends Error {
+	constructor(snapshotId: string) {
+		super(`Snapshot ${snapshotId} is not a Kitaru deployment`);
+		this.name = "NotAKitaruDeploymentError";
+	}
+}
+
+function tagFromApiToDomain(
+	tag: components["schemas"]["TagResponse"]
+): DeploymentTag {
+	return {
+		id: tag.id,
+		name: tag.name,
+		exclusive: tag.body?.exclusive ?? false,
+		color: tag.body?.color,
+	};
+}
+
+export function deploymentFromApiToDomain(
+	snapshot: components["schemas"]["PipelineSnapshotResponse"]
+): Deployment | null {
+	const match = snapshot.name?.match(KITARU_SNAPSHOT_NAME);
+	if (!match) return null;
+
+	const pipeline = snapshot.resources?.pipeline;
+	if (!pipeline) return null;
+
+	const versionNumber = Number.parseInt(match[2], 10);
+
+	return {
+		id: snapshot.id,
+		flowId: pipeline.id,
+		flowName: pipeline.name,
+		versionNumber,
+		tags: (snapshot.resources?.tags ?? []).map(tagFromApiToDomain),
+		createdAt: snapshot.body?.created
+			? parseBackendTimestamp(snapshot.body.created)
+			: undefined,
+		updatedAt: snapshot.body?.updated
+			? parseBackendTimestamp(snapshot.body.updated)
+			: undefined,
+		stackName: snapshot.resources?.stack?.name,
+		inputSchema: snapshot.metadata?.config_schema ?? undefined,
+		latestRunId: snapshot.resources?.latest_run_id ?? undefined,
+		latestRunStatus: snapshot.resources?.latest_run_status ?? undefined,
+		runnable: snapshot.body?.runnable ?? false,
+		deployable: snapshot.body?.deployable ?? false,
+	};
+}

--- a/src/modules/deployments/domain/fetch-deployment.spec.ts
+++ b/src/modules/deployments/domain/fetch-deployment.spec.ts
@@ -1,0 +1,107 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type MockInstance,
+} from "vitest";
+import { apiClient } from "@/shared/api/domain/api-client";
+import { NotAKitaruDeploymentError } from "./deployment";
+import { fetchDeployment } from "./fetch-deployment";
+
+function mkSnapshot(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "snap-1",
+		name: "kitaru::research_agent::v3",
+		body: {
+			created: "2026-04-22T10:00:00Z",
+			updated: "2026-04-22T10:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			runnable: true,
+			deployable: true,
+			is_dynamic: false,
+		},
+		metadata: {
+			run_name_template: "",
+			pipeline_configuration: {},
+			client_version: null,
+			server_version: null,
+		},
+		resources: {
+			pipeline: {
+				id: "flow-1",
+				name: "research_agent",
+				body: {
+					created: "2026-04-22T10:00:00Z",
+					updated: "2026-04-22T10:00:00Z",
+					project_id: "00000000-0000-0000-0000-000000000000",
+				},
+			},
+			tags: [],
+		},
+		...overrides,
+	};
+}
+
+describe("fetchDeployment", () => {
+	let getSpy: MockInstance;
+
+	beforeEach(() => {
+		getSpy = vi.spyOn(apiClient, "GET");
+	});
+
+	afterEach(() => {
+		getSpy.mockRestore();
+	});
+
+	it("calls the detail endpoint with hydrate=true", async () => {
+		getSpy.mockResolvedValue({
+			data: mkSnapshot(),
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		await fetchDeployment("snap-1");
+
+		expect(getSpy).toHaveBeenCalledWith(
+			"/api/v1/pipeline_snapshots/{snapshot_id}",
+			{
+				params: {
+					path: { snapshot_id: "snap-1" },
+					query: { hydrate: true },
+				},
+			}
+		);
+	});
+
+	it("returns a mapped Deployment on success", async () => {
+		getSpy.mockResolvedValue({
+			data: mkSnapshot(),
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		const result = await fetchDeployment("snap-1");
+
+		expect(result.id).toBe("snap-1");
+		expect(result.versionNumber).toBe(3);
+		expect(result.flowName).toBe("research_agent");
+	});
+
+	it("throws NotAKitaruDeploymentError when the name doesn't match", async () => {
+		getSpy.mockResolvedValue({
+			data: mkSnapshot({ name: "vanilla-snapshot" }),
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		await expect(fetchDeployment("snap-1")).rejects.toBeInstanceOf(
+			NotAKitaruDeploymentError
+		);
+	});
+});

--- a/src/modules/deployments/domain/fetch-deployment.ts
+++ b/src/modules/deployments/domain/fetch-deployment.ts
@@ -1,0 +1,22 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+import {
+	type Deployment,
+	NotAKitaruDeploymentError,
+	deploymentFromApiToDomain,
+} from "./deployment";
+
+export async function fetchDeployment(snapshotId: string): Promise<Deployment> {
+	const response = await apiClient.GET(
+		"/api/v1/pipeline_snapshots/{snapshot_id}",
+		{
+			params: {
+				path: { snapshot_id: snapshotId },
+				query: { hydrate: true },
+			},
+		}
+	);
+	const deployment = deploymentFromApiToDomain(expectData(response));
+	if (deployment === null) throw new NotAKitaruDeploymentError(snapshotId);
+	return deployment;
+}

--- a/src/modules/deployments/domain/fetch-deployments.spec.ts
+++ b/src/modules/deployments/domain/fetch-deployments.spec.ts
@@ -1,0 +1,102 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type MockInstance,
+} from "vitest";
+import { apiClient } from "@/shared/api/domain/api-client";
+import { fetchDeployments } from "./fetch-deployments";
+
+function mkSnapshotItem(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "snap-x",
+		name: "kitaru::research_agent::v1",
+		body: {
+			created: "2026-04-22T10:00:00Z",
+			updated: "2026-04-22T10:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			runnable: true,
+			deployable: true,
+			is_dynamic: false,
+		},
+		metadata: {
+			run_name_template: "",
+			pipeline_configuration: {},
+			client_version: null,
+			server_version: null,
+		},
+		resources: {
+			pipeline: {
+				id: "flow-1",
+				name: "research_agent",
+				body: {
+					created: "2026-04-22T10:00:00Z",
+					updated: "2026-04-22T10:00:00Z",
+					project_id: "00000000-0000-0000-0000-000000000000",
+				},
+			},
+			tags: [],
+		},
+		...overrides,
+	};
+}
+
+describe("fetchDeployments", () => {
+	let getSpy: MockInstance;
+
+	beforeEach(() => {
+		getSpy = vi.spyOn(apiClient, "GET");
+	});
+
+	afterEach(() => {
+		getSpy.mockRestore();
+	});
+
+	it("calls the snapshots endpoint with pipeline filter and hydrate=true", async () => {
+		getSpy.mockResolvedValue({
+			data: { items: [], total: 0, page: 1, size: 1000, total_pages: 0 },
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		await fetchDeployments("flow-1");
+
+		expect(getSpy).toHaveBeenCalledWith("/api/v1/pipeline_snapshots", {
+			params: {
+				query: {
+					pipeline: "flow-1",
+					page: 1,
+					size: 1000,
+					hydrate: true,
+				},
+			},
+		});
+	});
+
+	it("filters out non-Kitaru snapshots", async () => {
+		getSpy.mockResolvedValue({
+			data: {
+				items: [
+					mkSnapshotItem({ id: "snap-1", name: "kitaru::research_agent::v1" }),
+					mkSnapshotItem({ id: "snap-2", name: "vanilla-snapshot" }),
+					mkSnapshotItem({ id: "snap-3", name: "kitaru::research_agent::v2" }),
+				],
+				total: 3,
+				page: 1,
+				size: 1000,
+				total_pages: 1,
+			},
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+
+		const result = await fetchDeployments("flow-1");
+
+		expect(result.map((d) => d.id).sort()).toEqual(["snap-1", "snap-3"]);
+	});
+});

--- a/src/modules/deployments/domain/fetch-deployments.ts
+++ b/src/modules/deployments/domain/fetch-deployments.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+import { type Deployment, deploymentFromApiToDomain } from "./deployment";
+
+// TODO: Remove these constants and use the API pagination instead
+const DEFAULT_PAGE = 1;
+const MAX_PAGE_SIZE = 1000;
+
+export async function fetchDeployments(flowId: string): Promise<Deployment[]> {
+	const response = await apiClient.GET("/api/v1/pipeline_snapshots", {
+		params: {
+			query: {
+				pipeline: flowId,
+				page: DEFAULT_PAGE,
+				size: MAX_PAGE_SIZE,
+				hydrate: true,
+			},
+		},
+	});
+	const page = expectData(response);
+	return page.items
+		.map(deploymentFromApiToDomain)
+		.filter((d): d is Deployment => d !== null);
+}

--- a/src/modules/executions/business-logic/executions-queries.ts
+++ b/src/modules/executions/business-logic/executions-queries.ts
@@ -8,6 +8,8 @@ import { fetchWaitConditions } from "../domain/fetch-wait-conditions";
 export const executionsQueryKeys = {
 	base: ["executions"] as const,
 	all: (flowId: string) => [...executionsQueryKeys.base, flowId] as const,
+	listWithSnapshots: (flowId: string) =>
+		[...executionsQueryKeys.base, "list-with-snapshots", flowId] as const,
 	detail: (executionId: string) =>
 		[...executionsQueryKeys.base, "detail", executionId] as const,
 	logs: (runId: string, source: string) =>
@@ -23,6 +25,11 @@ export const executionsQueries = {
 		queryOptions({
 			queryKey: executionsQueryKeys.all(flowId),
 			queryFn: () => fetchExecutions(flowId),
+		}),
+	listWithSnapshots: (flowId: string) =>
+		queryOptions({
+			queryKey: executionsQueryKeys.listWithSnapshots(flowId),
+			queryFn: () => fetchExecutions(flowId, { hydrate: true }),
 		}),
 	detail: (executionId: string) =>
 		queryOptions({

--- a/src/modules/executions/domain/execution.spec.ts
+++ b/src/modules/executions/domain/execution.spec.ts
@@ -61,4 +61,19 @@ describe("executionFromApiToDomain", () => {
 			executionFromApiToDomain(mkRun({ log_collection: undefined })).logSources
 		).toEqual([]);
 	});
+
+	it("extracts snapshotId when the run is hydrated with a snapshot resource", () => {
+		const run = mkRun({
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			snapshot: { id: "snap-42" } as any,
+		});
+		const result = executionFromApiToDomain(run);
+		expect(result.snapshotId).toBe("snap-42");
+	});
+
+	it("leaves snapshotId undefined when run.resources.snapshot is absent", () => {
+		const run = mkRun();
+		const result = executionFromApiToDomain(run);
+		expect(result.snapshotId).toBeUndefined();
+	});
 });

--- a/src/modules/executions/domain/execution.spec.ts
+++ b/src/modules/executions/domain/execution.spec.ts
@@ -61,19 +61,4 @@ describe("executionFromApiToDomain", () => {
 			executionFromApiToDomain(mkRun({ log_collection: undefined })).logSources
 		).toEqual([]);
 	});
-
-	it("extracts snapshotId when the run is hydrated with a snapshot resource", () => {
-		const run = mkRun({
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			snapshot: { id: "snap-42" } as any,
-		});
-		const result = executionFromApiToDomain(run);
-		expect(result.snapshotId).toBe("snap-42");
-	});
-
-	it("leaves snapshotId undefined when run.resources.snapshot is absent", () => {
-		const run = mkRun();
-		const result = executionFromApiToDomain(run);
-		expect(result.snapshotId).toBeUndefined();
-	});
 });

--- a/src/modules/executions/domain/execution.ts
+++ b/src/modules/executions/domain/execution.ts
@@ -45,6 +45,7 @@ export type Execution = {
 		id?: string;
 		name?: string;
 	};
+	snapshotId?: string;
 };
 
 export function executionFromApiToDomain(
@@ -83,5 +84,6 @@ export function executionFromApiToDomain(
 						name: run.resources?.active_wait_condition?.name,
 					}
 				: undefined,
+		snapshotId: run.resources?.snapshot?.id,
 	};
 }

--- a/src/modules/executions/domain/fetch-executions.spec.ts
+++ b/src/modules/executions/domain/fetch-executions.spec.ts
@@ -1,0 +1,57 @@
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	it,
+	vi,
+	type MockInstance,
+} from "vitest";
+import { apiClient } from "@/shared/api/domain/api-client";
+import { fetchExecutions } from "./fetch-executions";
+
+describe("fetchExecutions", () => {
+	let getSpy: MockInstance;
+
+	beforeEach(() => {
+		getSpy = vi.spyOn(apiClient, "GET");
+		getSpy.mockResolvedValue({
+			data: { items: [], total: 0, page: 1, size: 1000, total_pages: 0 },
+			error: undefined,
+			response: new Response(),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any);
+	});
+
+	afterEach(() => {
+		getSpy.mockRestore();
+	});
+
+	it("does not request hydrate by default", async () => {
+		await fetchExecutions("flow-1");
+		expect(getSpy).toHaveBeenCalledWith("/api/v1/runs", {
+			params: {
+				query: {
+					page: 1,
+					size: 1000,
+					pipeline_id: "flow-1",
+					hydrate: undefined,
+				},
+			},
+		});
+	});
+
+	it("requests hydrate=true when the option is passed", async () => {
+		await fetchExecutions("flow-1", { hydrate: true });
+		expect(getSpy).toHaveBeenCalledWith("/api/v1/runs", {
+			params: {
+				query: {
+					page: 1,
+					size: 1000,
+					pipeline_id: "flow-1",
+					hydrate: true,
+				},
+			},
+		});
+	});
+});

--- a/src/modules/executions/domain/fetch-executions.ts
+++ b/src/modules/executions/domain/fetch-executions.ts
@@ -7,13 +7,21 @@ const DEFAULT_PAGE = 1;
 const MAX_PAGE_SIZE = 1000;
 export const DEFAULT_EXECUTIONS_POLLING_INTERVAL = 5000;
 
-export async function fetchExecutions(flowId: string): Promise<Execution[]> {
+export type FetchExecutionsOptions = {
+	hydrate?: boolean;
+};
+
+export async function fetchExecutions(
+	flowId: string,
+	options?: FetchExecutionsOptions
+): Promise<Execution[]> {
 	const response = await apiClient.GET("/api/v1/runs", {
 		params: {
 			query: {
 				page: DEFAULT_PAGE,
 				size: MAX_PAGE_SIZE,
 				pipeline_id: flowId,
+				hydrate: options?.hydrate,
 			},
 		},
 	});


### PR DESCRIPTION
## Summary
- Adds a `modules/deployments/` module (domain types + parser, list/detail fetchers, React Query factory, suspense hooks, pure URL-resolution selectors) for Kitaru's versioned snapshots, named `kitaru::<flow>::v<N>`.
- Non-Kitaru snapshots returned by `/api/v1/pipeline_snapshots` are filtered out of the list; the detail fetcher throws `NotAKitaruDeploymentError` so deep-links to non-Kitaru ids fail cleanly.
- Exposes `executionsQueries.listWithSnapshots` (opt-in hydrate on `fetchExecutions`) so a future view can join runs to their handling deployment via a new `Execution.snapshotId` field.

## Scope
Reads only — no mutations, no UI wired up yet. This lays the data plumbing for issue #146 before the design is ready.

## Test plan
- [ ] `pnpm check:types` passes
- [ ] `pnpm test:unit` — 262/262 pass including 24 new deployments tests
- [ ] `pnpm lint` — no new warnings introduced