### PR TITLE
Add API keys settings page

### DIFF
--- a/e2e/fixtures/api/api-keys.ts
+++ b/e2e/fixtures/api/api-keys.ts
@@ -1,0 +1,72 @@
+import type { components } from "@/shared/api/openapi";
+
+type ApiKeyResponse = components["schemas"]["APIKeyResponse"];
+type ApiKeyPage = components["schemas"]["Page_APIKeyResponse_"];
+type ServiceAccountResponse = components["schemas"]["ServiceAccountResponse"];
+type ServiceAccountPage = components["schemas"]["Page_ServiceAccountResponse_"];
+
+export function makeServiceAccount(
+	overrides: Partial<ServiceAccountResponse> = {}
+): ServiceAccountResponse {
+	const { body: bodyOverrides, ...rest } = overrides;
+	return {
+		id: "sa-11111111-1111-1111-1111-111111111111",
+		name: "pat-user-1",
+		body: {
+			created: "2026-01-01T00:00:00Z",
+			updated: "2026-01-01T00:00:00Z",
+			active: true,
+			...bodyOverrides,
+		},
+		...rest,
+	};
+}
+
+export function makeServiceAccountPage(
+	items: ServiceAccountResponse[] = []
+): ServiceAccountPage {
+	return {
+		index: 1,
+		max_size: 1,
+		total_pages: items.length > 0 ? 1 : 0,
+		total: items.length,
+		items,
+	};
+}
+
+export function makeApiKey(
+	overrides: Partial<ApiKeyResponse> = {}
+): ApiKeyResponse {
+	const {
+		body: bodyOverrides,
+		metadata: metadataOverrides,
+		...rest
+	} = overrides;
+	return {
+		id: "ak-11111111-1111-1111-1111-111111111111",
+		name: "demo-key",
+		body: {
+			created: "2026-01-01T00:00:00Z",
+			updated: "2026-01-01T00:00:00Z",
+			active: true,
+			service_account: makeServiceAccount(),
+			...bodyOverrides,
+		},
+		metadata: {
+			description: "",
+			retain_period_minutes: 0,
+			...metadataOverrides,
+		},
+		...rest,
+	};
+}
+
+export function makeApiKeyPage(items: ApiKeyResponse[] = []): ApiKeyPage {
+	return {
+		index: 1,
+		max_size: 1000,
+		total_pages: items.length > 0 ? 1 : 0,
+		total: items.length,
+		items,
+	};
+}

--- a/e2e/fixtures/api/index.ts
+++ b/e2e/fixtures/api/index.ts
@@ -2,3 +2,9 @@ export { makeUser } from "./current-user";
 export { makeServerInfo } from "./server-info";
 export { makePipeline, makePipelinePage } from "./pipelines";
 export { makeSecret, makeSecretsPage } from "./secrets";
+export {
+	makeApiKey,
+	makeApiKeyPage,
+	makeServiceAccount,
+	makeServiceAccountPage,
+} from "./api-keys";

--- a/e2e/specs/api-keys.spec.ts
+++ b/e2e/specs/api-keys.spec.ts
@@ -1,0 +1,216 @@
+import { test, expect } from "../fixtures/test";
+import {
+	makeApiKey,
+	makeApiKeyPage,
+	makeServiceAccount,
+	makeServiceAccountPage,
+} from "../fixtures/api";
+import { getRequests } from "../helpers/mock-api";
+
+const SA_ID = "sa-11111111-1111-1111-1111-111111111111";
+const KEY_ID = "ak-11111111-1111-1111-1111-111111111111";
+
+test.describe("api keys > empty state", () => {
+	test("renders empty state when no personal SA exists", async ({
+		page,
+		mockApi,
+		authenticatedPage,
+	}) => {
+		void authenticatedPage;
+		await mockApi({
+			"/api/v1/service_accounts": { get: makeServiceAccountPage([]) },
+		});
+		await page.goto("/settings/api-keys");
+
+		await expect(page.getByText("Create a new API key")).toBeVisible();
+	});
+});
+
+test.describe("api keys > list", () => {
+	test("renders existing keys", async ({
+		page,
+		mockApi,
+		authenticatedPage,
+	}) => {
+		void authenticatedPage;
+		await mockApi({
+			"/api/v1/service_accounts": {
+				get: makeServiceAccountPage([makeServiceAccount({ id: SA_ID })]),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys": {
+				get: makeApiKeyPage([
+					makeApiKey({ id: KEY_ID, name: "prod-ci" }),
+					makeApiKey({
+						id: "ak-22222222-2222-2222-2222-222222222222",
+						name: "staging-ci",
+					}),
+				]),
+			},
+		});
+		await page.goto("/settings/api-keys");
+
+		await expect(page.getByText("prod-ci")).toBeVisible();
+		await expect(page.getByText("staging-ci")).toBeVisible();
+	});
+});
+
+test.describe("api keys > create (happy path, provisions hidden SA)", () => {
+	test("creates key, shows plaintext, closes dialog", async ({
+		page,
+		mockApi,
+		authenticatedPage,
+	}) => {
+		void authenticatedPage;
+		const created = makeApiKey({
+			id: KEY_ID,
+			name: "my-new-key",
+			body: {
+				created: "2026-01-01T00:00:00Z",
+				updated: "2026-01-01T00:00:00Z",
+				active: true,
+				key: "ZENML_SK_PLAINTEXT_VALUE",
+				service_account: makeServiceAccount({ id: SA_ID }),
+			},
+		});
+		await mockApi({
+			"/api/v1/service_accounts": {
+				get: makeServiceAccountPage([]),
+				post: makeServiceAccount({ id: SA_ID }),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys": {
+				get: makeApiKeyPage([]),
+				post: created,
+			},
+		});
+		await page.goto("/settings/api-keys");
+		await page.getByRole("button", { name: "Create API key" }).first().click();
+		await page.getByLabel("Name").fill("my-new-key");
+
+		await page
+			.getByRole("button", { name: "Create API key", exact: true })
+			.click();
+
+		await expect(
+			page.getByText("ZENML_SK_PLAINTEXT_VALUE", { exact: true })
+		).toBeVisible();
+		const postSa = getRequests(page).find(
+			(r) => r.method === "post" && r.template === "/api/v1/service_accounts"
+		);
+		expect(postSa).toBeDefined();
+		const postKey = getRequests(page).find(
+			(r) =>
+				r.method === "post" &&
+				r.template === "/api/v1/service_accounts/{service_account_id}/api_keys"
+		);
+		expect(postKey).toBeDefined();
+		expect(postKey!.body).toMatchObject({ name: "my-new-key" });
+
+		await page.getByRole("button", { name: "Done" }).click();
+		await expect(page.getByText("ZENML_SK_PLAINTEXT_VALUE")).not.toBeVisible();
+	});
+});
+
+test.describe("api keys > rotate", () => {
+	test("rotate with retention sends retain_period_minutes", async ({
+		page,
+		mockApi,
+		authenticatedPage,
+	}) => {
+		void authenticatedPage;
+		const rotated = makeApiKey({
+			id: KEY_ID,
+			name: "prod-ci",
+			body: {
+				created: "2026-01-01T00:00:00Z",
+				updated: "2026-02-01T00:00:00Z",
+				active: true,
+				key: "ZENML_SK_ROTATED",
+				service_account: makeServiceAccount({ id: SA_ID }),
+			},
+		});
+		await mockApi({
+			"/api/v1/service_accounts": {
+				get: makeServiceAccountPage([makeServiceAccount({ id: SA_ID })]),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys": {
+				get: makeApiKeyPage([makeApiKey({ id: KEY_ID, name: "prod-ci" })]),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}/rotate":
+				{ put: rotated },
+		});
+		await page.goto("/settings/api-keys");
+		await page
+			.getByRole("button", { name: "Open actions for prod-ci" })
+			.click();
+		await page.getByRole("menuitem", { name: "Rotate" }).click();
+		await page
+			.getByRole("switch", {
+				name: "Keep the old key active for a retention period",
+			})
+			.click();
+		await page.getByLabel("Retention period (minutes)").fill("15");
+
+		await page.getByRole("button", { name: "Rotate key" }).click();
+
+		await expect
+			.poll(
+				() =>
+					getRequests(page).find(
+						(r) =>
+							r.method === "put" &&
+							r.template ===
+								"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}/rotate"
+					),
+				{ timeout: 5000 }
+			)
+			.toBeDefined();
+		const rotateReq = getRequests(page).find(
+			(r) =>
+				r.method === "put" &&
+				r.template ===
+					"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}/rotate"
+		);
+		expect(rotateReq!.body).toMatchObject({ retain_period_minutes: 15 });
+		expect(rotateReq!.pathParams.service_account_id).toBe(SA_ID);
+		expect(rotateReq!.pathParams.api_key_name_or_id).toBe(KEY_ID);
+	});
+});
+
+test.describe("api keys > delete", () => {
+	test("type-to-confirm deletes the key", async ({
+		page,
+		mockApi,
+		authenticatedPage,
+	}) => {
+		void authenticatedPage;
+		await mockApi({
+			"/api/v1/service_accounts": {
+				get: makeServiceAccountPage([makeServiceAccount({ id: SA_ID })]),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys": {
+				get: makeApiKeyPage([makeApiKey({ id: KEY_ID, name: "prod-ci" })]),
+			},
+			"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}":
+				{ delete: { status: 200 } },
+		});
+		await page.goto("/settings/api-keys");
+		await page
+			.getByRole("button", { name: "Open actions for prod-ci" })
+			.click();
+		await page.getByRole("menuitem", { name: "Delete" }).click();
+		const dialog = page.getByRole("alertdialog");
+		await dialog.getByLabel(/Type DELETE to confirm/i).fill("DELETE");
+
+		await dialog.getByRole("button", { name: "Delete API key" }).click();
+
+		await expect(page.getByText("API key deleted")).toBeVisible();
+		const del = getRequests(page).find(
+			(r) =>
+				r.method === "delete" &&
+				r.template ===
+					"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}"
+		);
+		expect(del).toBeDefined();
+		expect(del!.pathParams.api_key_name_or_id).toBe(KEY_ID);
+	});
+});

--- a/src/modules/api-keys/business-logic/api-key-form-schema.spec.ts
+++ b/src/modules/api-keys/business-logic/api-key-form-schema.spec.ts
@@ -28,9 +28,9 @@ describe("apiKeyFormSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
-	it("rejects names longer than 50 chars", () => {
+	it("rejects names longer than 255 chars", () => {
 		const result = apiKeyFormSchema.safeParse({
-			name: "a".repeat(51),
+			name: "a".repeat(256),
 			description: "",
 		});
 		expect(result.success).toBe(false);

--- a/src/modules/api-keys/business-logic/api-key-form-schema.spec.ts
+++ b/src/modules/api-keys/business-logic/api-key-form-schema.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { apiKeyFormSchema } from "./api-key-form-schema";
+
+describe("apiKeyFormSchema", () => {
+	it("accepts a name and empty description", () => {
+		const result = apiKeyFormSchema.safeParse({
+			name: "ci-token",
+			description: "",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("trims the name before validating", () => {
+		const result = apiKeyFormSchema.safeParse({
+			name: "  ci  ",
+			description: "",
+		});
+		expect(result.success).toBe(true);
+		if (result.success) expect(result.data.name).toBe("ci");
+	});
+
+	it("rejects an empty name", () => {
+		const result = apiKeyFormSchema.safeParse({
+			name: "  ",
+			description: "",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects names longer than 50 chars", () => {
+		const result = apiKeyFormSchema.safeParse({
+			name: "a".repeat(51),
+			description: "",
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/src/modules/api-keys/business-logic/api-key-form-schema.ts
+++ b/src/modules/api-keys/business-logic/api-key-form-schema.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const apiKeyFormSchema = z.object({
+	name: z
+		.string()
+		.trim()
+		.min(1, "Please enter a name.")
+		.max(50, "Name must be 50 characters or less."),
+	description: z.string().max(500, "Description is too long.").optional(),
+});
+
+export type ApiKeyFormValues = z.infer<typeof apiKeyFormSchema>;

--- a/src/modules/api-keys/business-logic/api-key-form-schema.ts
+++ b/src/modules/api-keys/business-logic/api-key-form-schema.ts
@@ -5,8 +5,8 @@ export const apiKeyFormSchema = z.object({
 		.string()
 		.trim()
 		.min(1, "Please enter a name.")
-		.max(50, "Name must be 50 characters or less."),
-	description: z.string().max(500, "Description is too long.").optional(),
+		.max(255, "Name must be 255 characters or less."),
+	description: z.string().max(65535, "Description is too long.").optional(),
 });
 
 export type ApiKeyFormValues = z.infer<typeof apiKeyFormSchema>;

--- a/src/modules/api-keys/business-logic/api-key-queries.ts
+++ b/src/modules/api-keys/business-logic/api-key-queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { fetchApiKeyList } from "../domain/fetch-api-key-list";
+
+export const apiKeyQueryKeys = {
+	all: ["api-keys"] as const,
+	list: (serviceAccountId: string) =>
+		[...apiKeyQueryKeys.all, "list", serviceAccountId] as const,
+};
+
+export const apiKeyQueries = {
+	list: (serviceAccountId: string) =>
+		queryOptions({
+			queryKey: apiKeyQueryKeys.list(serviceAccountId),
+			queryFn: () => fetchApiKeyList(serviceAccountId),
+		}),
+};

--- a/src/modules/api-keys/business-logic/get-error-message.ts
+++ b/src/modules/api-keys/business-logic/get-error-message.ts
@@ -1,0 +1,29 @@
+import { isFetchError } from "@/shared/api/domain/fetch-error";
+import { isRecord } from "@/shared/utils/is-record";
+
+export function getErrorMessage(error: unknown, fallback: string): string {
+	if (isFetchError(error)) {
+		const fromDetails = extractDetail(error.details);
+		if (fromDetails) return fromDetails;
+		if (error.status === 409)
+			return "An API key with this name already exists.";
+		if (error.status === 403) return "You don't have permission to do that.";
+		if (error.status === 404) return "This API key no longer exists.";
+	}
+	if (
+		error instanceof Error &&
+		!error.message.startsWith("Error while fetching")
+	) {
+		return error.message;
+	}
+	return fallback;
+}
+
+function extractDetail(details: unknown): string | undefined {
+	if (!isRecord(details)) return undefined;
+	const inner = details.error;
+	if (!isRecord(inner)) return undefined;
+	const detail = inner.detail;
+	if (typeof detail === "string" && detail.trim().length > 0) return detail;
+	return undefined;
+}

--- a/src/modules/api-keys/business-logic/personal-service-account-queries.ts
+++ b/src/modules/api-keys/business-logic/personal-service-account-queries.ts
@@ -1,0 +1,17 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { findPersonalServiceAccount } from "../domain/find-or-create-personal-service-account";
+
+export const personalServiceAccountQueryKeys = {
+	all: ["personal-service-account"] as const,
+	resolve: (userId: string) =>
+		[...personalServiceAccountQueryKeys.all, userId] as const,
+};
+
+export const personalServiceAccountQueries = {
+	resolve: (userId: string) =>
+		queryOptions({
+			queryKey: personalServiceAccountQueryKeys.resolve(userId),
+			queryFn: () => findPersonalServiceAccount(userId),
+		}),
+};

--- a/src/modules/api-keys/business-logic/rotate-api-key-form-schema.spec.ts
+++ b/src/modules/api-keys/business-logic/rotate-api-key-form-schema.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { rotateApiKeyFormSchema } from "./rotate-api-key-form-schema";
+
+describe("rotateApiKeyFormSchema", () => {
+	it("accepts rotation with retention disabled and no minutes", () => {
+		const result = rotateApiKeyFormSchema.safeParse({
+			enableRetention: false,
+			retainPeriodMinutes: "",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects enabled retention with empty minutes", () => {
+		const result = rotateApiKeyFormSchema.safeParse({
+			enableRetention: true,
+			retainPeriodMinutes: "",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects enabled retention with non-integer minutes", () => {
+		const result = rotateApiKeyFormSchema.safeParse({
+			enableRetention: true,
+			retainPeriodMinutes: "1.5",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects enabled retention with zero or negative minutes", () => {
+		const result = rotateApiKeyFormSchema.safeParse({
+			enableRetention: true,
+			retainPeriodMinutes: "0",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("accepts enabled retention with a positive integer", () => {
+		const result = rotateApiKeyFormSchema.safeParse({
+			enableRetention: true,
+			retainPeriodMinutes: "15",
+		});
+		expect(result.success).toBe(true);
+	});
+});

--- a/src/modules/api-keys/business-logic/rotate-api-key-form-schema.ts
+++ b/src/modules/api-keys/business-logic/rotate-api-key-form-schema.ts
@@ -10,7 +10,7 @@ export const rotateApiKeyFormSchema = z
 		const raw = values.retainPeriodMinutes.trim();
 		if (raw === "") {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: "custom",
 				path: ["retainPeriodMinutes"],
 				message: "Enter a retention period in minutes.",
 			});
@@ -19,7 +19,7 @@ export const rotateApiKeyFormSchema = z
 		const parsed = Number(raw);
 		if (!Number.isInteger(parsed) || parsed <= 0) {
 			ctx.addIssue({
-				code: z.ZodIssueCode.custom,
+				code: "custom",
 				path: ["retainPeriodMinutes"],
 				message: "Enter a positive whole number of minutes.",
 			});

--- a/src/modules/api-keys/business-logic/rotate-api-key-form-schema.ts
+++ b/src/modules/api-keys/business-logic/rotate-api-key-form-schema.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const rotateApiKeyFormSchema = z
+	.object({
+		enableRetention: z.boolean(),
+		retainPeriodMinutes: z.string(),
+	})
+	.superRefine((values, ctx) => {
+		if (!values.enableRetention) return;
+		const raw = values.retainPeriodMinutes.trim();
+		if (raw === "") {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["retainPeriodMinutes"],
+				message: "Enter a retention period in minutes.",
+			});
+			return;
+		}
+		const parsed = Number(raw);
+		if (!Number.isInteger(parsed) || parsed <= 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["retainPeriodMinutes"],
+				message: "Enter a positive whole number of minutes.",
+			});
+		}
+	});
+
+export type RotateApiKeyFormValues = z.infer<typeof rotateApiKeyFormSchema>;

--- a/src/modules/api-keys/business-logic/use-create-api-key.ts
+++ b/src/modules/api-keys/business-logic/use-create-api-key.ts
@@ -1,0 +1,26 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+
+import type { FetchError } from "@/shared/api/domain/fetch-error";
+
+import type { ApiKey } from "../domain/api-key";
+import {
+	createApiKeyRequest,
+	type CreateApiKeyPayload,
+} from "../domain/create-api-key";
+
+export function useCreateApiKey(
+	options?: Omit<
+		UseMutationOptions<ApiKey, FetchError, CreateApiKeyPayload, unknown>,
+		"mutationFn"
+	>
+) {
+	const mutation = useMutation({
+		...options,
+		mutationFn: createApiKeyRequest,
+	});
+	return {
+		...mutation,
+		createApiKey: mutation.mutate,
+		createApiKeyAsync: mutation.mutateAsync,
+	};
+}

--- a/src/modules/api-keys/business-logic/use-delete-api-key.ts
+++ b/src/modules/api-keys/business-logic/use-delete-api-key.ts
@@ -1,0 +1,25 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+
+import type { FetchError } from "@/shared/api/domain/fetch-error";
+
+import {
+	deleteApiKeyRequest,
+	type DeleteApiKeyPayload,
+} from "../domain/delete-api-key";
+
+export function useDeleteApiKey(
+	options?: Omit<
+		UseMutationOptions<void, FetchError, DeleteApiKeyPayload, unknown>,
+		"mutationFn"
+	>
+) {
+	const mutation = useMutation({
+		...options,
+		mutationFn: deleteApiKeyRequest,
+	});
+	return {
+		...mutation,
+		deleteApiKey: mutation.mutate,
+		deleteApiKeyAsync: mutation.mutateAsync,
+	};
+}

--- a/src/modules/api-keys/business-logic/use-rotate-api-key.ts
+++ b/src/modules/api-keys/business-logic/use-rotate-api-key.ts
@@ -1,0 +1,26 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+
+import type { FetchError } from "@/shared/api/domain/fetch-error";
+
+import type { ApiKey } from "../domain/api-key";
+import {
+	rotateApiKeyRequest,
+	type RotateApiKeyPayload,
+} from "../domain/rotate-api-key";
+
+export function useRotateApiKey(
+	options?: Omit<
+		UseMutationOptions<ApiKey, FetchError, RotateApiKeyPayload, unknown>,
+		"mutationFn"
+	>
+) {
+	const mutation = useMutation({
+		...options,
+		mutationFn: rotateApiKeyRequest,
+	});
+	return {
+		...mutation,
+		rotateApiKey: mutation.mutate,
+		rotateApiKeyAsync: mutation.mutateAsync,
+	};
+}

--- a/src/modules/api-keys/business-logic/use-update-api-key.ts
+++ b/src/modules/api-keys/business-logic/use-update-api-key.ts
@@ -1,0 +1,26 @@
+import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+
+import type { FetchError } from "@/shared/api/domain/fetch-error";
+
+import type { ApiKey } from "../domain/api-key";
+import {
+	updateApiKeyRequest,
+	type UpdateApiKeyPayload,
+} from "../domain/update-api-key";
+
+export function useUpdateApiKey(
+	options?: Omit<
+		UseMutationOptions<ApiKey, FetchError, UpdateApiKeyPayload, unknown>,
+		"mutationFn"
+	>
+) {
+	const mutation = useMutation({
+		...options,
+		mutationFn: updateApiKeyRequest,
+	});
+	return {
+		...mutation,
+		updateApiKey: mutation.mutate,
+		updateApiKeyAsync: mutation.mutateAsync,
+	};
+}

--- a/src/modules/api-keys/domain/api-key.spec.ts
+++ b/src/modules/api-keys/domain/api-key.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { apiKeyFromApiToDomain } from "./api-key";
+
+describe("apiKeyFromApiToDomain", () => {
+	it("maps the common fields", () => {
+		const result = apiKeyFromApiToDomain({
+			id: "aaaa",
+			name: "my-key",
+			body: {
+				created: "2026-01-01T00:00:00Z",
+				updated: "2026-01-02T00:00:00Z",
+				active: true,
+				service_account: {
+					id: "sa-1",
+					name: "pat-uuid",
+				},
+			},
+			metadata: {
+				description: "for CI",
+				retain_period_minutes: 0,
+				last_login: "2026-02-01T00:00:00Z",
+				last_rotated: null,
+			},
+		});
+
+		expect(result).toMatchObject({
+			id: "aaaa",
+			name: "my-key",
+			description: "for CI",
+			active: true,
+			plaintextKey: undefined,
+		});
+		expect(result.lastLogin?.toISOString()).toBe("2026-02-01T00:00:00.000Z");
+		expect(result.createdAt?.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+	});
+
+	it("defaults missing optional fields to undefined", () => {
+		const result = apiKeyFromApiToDomain({
+			id: "bbb",
+			name: "bare",
+		});
+		expect(result).toMatchObject({
+			id: "bbb",
+			name: "bare",
+			description: undefined,
+			lastLogin: undefined,
+			active: undefined,
+			plaintextKey: undefined,
+		});
+	});
+
+	it("exposes the plaintext key when the body contains one (post-create/rotate)", () => {
+		const result = apiKeyFromApiToDomain({
+			id: "ccc",
+			name: "fresh",
+			body: {
+				created: "2026-01-01T00:00:00Z",
+				updated: "2026-01-01T00:00:00Z",
+				key: "ZENML_SK_PLAINTEXT",
+				active: true,
+				service_account: { id: "sa-1", name: "pat-uuid" },
+			},
+		});
+
+		expect(result.plaintextKey).toBe("ZENML_SK_PLAINTEXT");
+		expect(result.active).toBe(true);
+	});
+
+	it("treats empty-string description as undefined", () => {
+		const result = apiKeyFromApiToDomain({
+			id: "ddd",
+			name: "k",
+			metadata: { description: "", retain_period_minutes: 0 },
+		});
+		expect(result.description).toBeUndefined();
+	});
+});

--- a/src/modules/api-keys/domain/api-key.ts
+++ b/src/modules/api-keys/domain/api-key.ts
@@ -1,0 +1,41 @@
+import type { components } from "@/shared/api/openapi";
+import { parseBackendTimestamp } from "@/shared/utils/time";
+
+export type ApiKey = {
+	id: string;
+	name: string;
+	description?: string;
+	active?: boolean;
+	lastLogin?: Date;
+	lastRotated?: Date;
+	createdAt?: Date;
+	updatedAt?: Date;
+	/** Only set immediately after create or rotate; never persisted in the list. */
+	plaintextKey?: string;
+};
+
+export function apiKeyFromApiToDomain(
+	apiKey: components["schemas"]["APIKeyResponse"]
+): ApiKey {
+	const description = apiKey.metadata?.description;
+	return {
+		id: apiKey.id,
+		name: apiKey.name,
+		description:
+			description && description.trim().length > 0 ? description : undefined,
+		active: apiKey.body?.active ?? undefined,
+		lastLogin: apiKey.metadata?.last_login
+			? parseBackendTimestamp(apiKey.metadata.last_login)
+			: undefined,
+		lastRotated: apiKey.metadata?.last_rotated
+			? parseBackendTimestamp(apiKey.metadata.last_rotated)
+			: undefined,
+		createdAt: apiKey.body?.created
+			? parseBackendTimestamp(apiKey.body.created)
+			: undefined,
+		updatedAt: apiKey.body?.updated
+			? parseBackendTimestamp(apiKey.body.updated)
+			: undefined,
+		plaintextKey: apiKey.body?.key ?? undefined,
+	};
+}

--- a/src/modules/api-keys/domain/create-api-key.ts
+++ b/src/modules/api-keys/domain/create-api-key.ts
@@ -1,0 +1,26 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+
+import { apiKeyFromApiToDomain } from "./api-key";
+
+export type CreateApiKeyPayload = {
+	serviceAccountId: string;
+	name: string;
+	description?: string;
+};
+
+export async function createApiKeyRequest(payload: CreateApiKeyPayload) {
+	const response = await apiClient.POST(
+		"/api/v1/service_accounts/{service_account_id}/api_keys",
+		{
+			params: {
+				path: { service_account_id: payload.serviceAccountId },
+			},
+			body: {
+				name: payload.name,
+				description: payload.description,
+			},
+		}
+	);
+	return apiKeyFromApiToDomain(expectData(response));
+}

--- a/src/modules/api-keys/domain/delete-api-key.ts
+++ b/src/modules/api-keys/domain/delete-api-key.ts
@@ -1,0 +1,24 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectOptionalData } from "@/shared/api/utils/unwrap-api-result";
+
+export type DeleteApiKeyPayload = {
+	serviceAccountId: string;
+	apiKeyId: string;
+};
+
+export async function deleteApiKeyRequest(
+	payload: DeleteApiKeyPayload
+): Promise<void> {
+	const response = await apiClient.DELETE(
+		"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}",
+		{
+			params: {
+				path: {
+					service_account_id: payload.serviceAccountId,
+					api_key_name_or_id: payload.apiKeyId,
+				},
+			},
+		}
+	);
+	expectOptionalData(response);
+}

--- a/src/modules/api-keys/domain/fetch-api-key-list.ts
+++ b/src/modules/api-keys/domain/fetch-api-key-list.ts
@@ -1,0 +1,26 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+
+import { apiKeyFromApiToDomain } from "./api-key";
+
+export async function fetchApiKeyList(serviceAccountId: string) {
+	const response = await apiClient.GET(
+		"/api/v1/service_accounts/{service_account_id}/api_keys",
+		{
+			params: {
+				path: { service_account_id: serviceAccountId },
+				query: {
+					sort_by: "desc:created",
+					hydrate: true,
+					page: 1,
+					size: 1000,
+				},
+			},
+		}
+	);
+	const data = expectData(response);
+	return {
+		...data,
+		items: data.items.map(apiKeyFromApiToDomain),
+	};
+}

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { apiClient } from "@/shared/api/domain/api-client";
+
+import {
+	buildPersonalServiceAccountName,
+	findOrCreatePersonalServiceAccount,
+} from "./find-or-create-personal-service-account";
+
+describe("buildPersonalServiceAccountName", () => {
+	it("derives the hidden SA name from the user id", () => {
+		expect(
+			buildPersonalServiceAccountName("8a9c4e38-01d8-4a91-b9a6-111111111111")
+		).toBe("pat-8a9c4e38-01d8-4a91-b9a6-111111111111");
+	});
+});
+
+describe("findOrCreatePersonalServiceAccount", () => {
+	const userId = "aaaa-bbbb";
+	const expectedName = `pat-${userId}`;
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns the existing SA id when the list has exactly one match", async () => {
+		const get = vi.spyOn(apiClient, "GET").mockResolvedValue({
+			data: {
+				index: 1,
+				max_size: 1,
+				total_pages: 1,
+				total: 1,
+				items: [{ id: "sa-existing", name: expectedName }],
+			},
+			response: new Response(null, { status: 200 }),
+		} as never);
+		const post = vi.spyOn(apiClient, "POST");
+
+		const result = await findOrCreatePersonalServiceAccount(userId);
+
+		expect(result).toEqual({ id: "sa-existing" });
+		expect(get).toHaveBeenCalledWith("/api/v1/service_accounts", {
+			params: {
+				query: {
+					name: expectedName,
+					size: 1,
+					page: 1,
+					hydrate: false,
+				},
+			},
+		});
+		expect(post).not.toHaveBeenCalled();
+	});
+
+	it("creates the SA when the list is empty", async () => {
+		vi.spyOn(apiClient, "GET").mockResolvedValue({
+			data: {
+				index: 1,
+				max_size: 1,
+				total_pages: 0,
+				total: 0,
+				items: [],
+			},
+			response: new Response(null, { status: 200 }),
+		} as never);
+		const post = vi.spyOn(apiClient, "POST").mockResolvedValue({
+			data: { id: "sa-new", name: expectedName },
+			response: new Response(null, { status: 200 }),
+		} as never);
+
+		const result = await findOrCreatePersonalServiceAccount(userId);
+
+		expect(result).toEqual({ id: "sa-new" });
+		expect(post).toHaveBeenCalledWith("/api/v1/service_accounts", {
+			body: {
+				name: expectedName,
+				active: true,
+				description: "Personal service account for UI-managed API keys.",
+			},
+		});
+	});
+
+	it("recovers from a 409 conflict by re-fetching the SA", async () => {
+		const get = vi.spyOn(apiClient, "GET");
+		get.mockResolvedValueOnce({
+			data: {
+				index: 1,
+				max_size: 1,
+				total_pages: 0,
+				total: 0,
+				items: [],
+			},
+			response: new Response(null, { status: 200 }),
+		} as never);
+		vi.spyOn(apiClient, "POST").mockResolvedValue({
+			error: { detail: "already exists" },
+			response: new Response(null, { status: 409 }),
+		} as never);
+		get.mockResolvedValueOnce({
+			data: {
+				index: 1,
+				max_size: 1,
+				total_pages: 1,
+				total: 1,
+				items: [{ id: "sa-raced", name: expectedName }],
+			},
+			response: new Response(null, { status: 200 }),
+		} as never);
+
+		const result = await findOrCreatePersonalServiceAccount(userId);
+
+		expect(result).toEqual({ id: "sa-raced" });
+	});
+});

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { apiClient } from "@/shared/api/domain/api-client";
+import { FetchError } from "@/shared/api/domain/fetch-error";
 
 import {
 	buildPersonalServiceAccountName,
@@ -96,10 +97,15 @@ describe("findOrCreatePersonalServiceAccount", () => {
 			},
 			response: new Response(null, { status: 200 }),
 		} as never);
-		vi.spyOn(apiClient, "POST").mockResolvedValue({
-			error: { detail: "already exists" },
-			response: new Response(null, { status: 409 }),
-		} as never);
+		const post = vi.spyOn(apiClient, "POST").mockRejectedValue(
+			new FetchError({
+				status: 409,
+				statusText: "Conflict",
+				message: "already exists",
+				url: "/api/v1/service_accounts",
+				method: "POST",
+			})
+		);
 		get.mockResolvedValueOnce({
 			data: {
 				index: 1,
@@ -114,5 +120,9 @@ describe("findOrCreatePersonalServiceAccount", () => {
 		const result = await findOrCreatePersonalServiceAccount(userId);
 
 		expect(result).toEqual({ id: "sa-raced" });
+		expect(get).toHaveBeenCalledTimes(2);
+		expect(post).toHaveBeenCalledTimes(1);
+		expect(get.mock.calls[0][0]).toBe("/api/v1/service_accounts");
+		expect(get.mock.calls[1][0]).toBe("/api/v1/service_accounts");
 	});
 });

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.spec.ts
@@ -125,4 +125,33 @@ describe("findOrCreatePersonalServiceAccount", () => {
 		expect(get.mock.calls[0][0]).toBe("/api/v1/service_accounts");
 		expect(get.mock.calls[1][0]).toBe("/api/v1/service_accounts");
 	});
+
+	it("throws a clear error when a 409 has no raced SA to recover", async () => {
+		const get = vi.spyOn(apiClient, "GET");
+		const emptyPage = {
+			data: {
+				index: 1,
+				max_size: 1,
+				total_pages: 0,
+				total: 0,
+				items: [],
+			},
+			response: new Response(null, { status: 200 }),
+		} as never;
+		get.mockResolvedValueOnce(emptyPage);
+		vi.spyOn(apiClient, "POST").mockRejectedValue(
+			new FetchError({
+				status: 409,
+				statusText: "Conflict",
+				message: "already exists",
+				url: "/api/v1/service_accounts",
+				method: "POST",
+			})
+		);
+		get.mockResolvedValueOnce(emptyPage);
+
+		await expect(findOrCreatePersonalServiceAccount(userId)).rejects.toThrow(
+			/personal service account/i
+		);
+	});
 });

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
@@ -1,0 +1,65 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { FetchError } from "@/shared/api/domain/fetch-error";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+
+export type PersonalServiceAccount = { id: string };
+
+const PERSONAL_SA_DESCRIPTION =
+	"Personal service account for UI-managed API keys.";
+
+export function buildPersonalServiceAccountName(userId: string) {
+	return `pat-${userId}`;
+}
+
+async function fetchSingleByName(name: string) {
+	const response = await apiClient.GET("/api/v1/service_accounts", {
+		params: {
+			query: {
+				name,
+				size: 1,
+				page: 1,
+				hydrate: false,
+			},
+		},
+	});
+	const data = expectData(response);
+	return data.items[0];
+}
+
+export async function findOrCreatePersonalServiceAccount(
+	userId: string
+): Promise<PersonalServiceAccount> {
+	const name = buildPersonalServiceAccountName(userId);
+	const existing = await fetchSingleByName(name);
+	if (existing) return { id: existing.id };
+
+	const createResponse = await apiClient.POST("/api/v1/service_accounts", {
+		body: {
+			name,
+			active: true,
+			description: PERSONAL_SA_DESCRIPTION,
+		},
+	});
+	if (createResponse.error === undefined && createResponse.data) {
+		return { id: createResponse.data.id };
+	}
+	if (createResponse.response.status === 409) {
+		const raced = await fetchSingleByName(name);
+		if (raced) return { id: raced.id };
+	}
+	throw new FetchError({
+		status: createResponse.response.status,
+		statusText: "Error while fetching data",
+		message: `Could not provision personal service account: ${createResponse.response.url}`,
+		url: createResponse.response.url,
+		details: createResponse,
+	});
+}
+
+export async function findPersonalServiceAccount(
+	userId: string
+): Promise<PersonalServiceAccount | null> {
+	const name = buildPersonalServiceAccountName(userId);
+	const existing = await fetchSingleByName(name);
+	return existing ? { id: existing.id } : null;
+}

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
@@ -46,6 +46,9 @@ export async function findOrCreatePersonalServiceAccount(
 		if (error instanceof FetchError && error.status === 409) {
 			const raced = await fetchSingleByName(name);
 			if (raced) return { id: raced.id };
+			throw new Error(
+				"Could not set up your personal service account. Please try again."
+			);
 		}
 		throw error;
 	}

--- a/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
+++ b/src/modules/api-keys/domain/find-or-create-personal-service-account.ts
@@ -33,27 +33,22 @@ export async function findOrCreatePersonalServiceAccount(
 	const existing = await fetchSingleByName(name);
 	if (existing) return { id: existing.id };
 
-	const createResponse = await apiClient.POST("/api/v1/service_accounts", {
-		body: {
-			name,
-			active: true,
-			description: PERSONAL_SA_DESCRIPTION,
-		},
-	});
-	if (createResponse.error === undefined && createResponse.data) {
-		return { id: createResponse.data.id };
+	try {
+		const createResponse = await apiClient.POST("/api/v1/service_accounts", {
+			body: {
+				name,
+				active: true,
+				description: PERSONAL_SA_DESCRIPTION,
+			},
+		});
+		return { id: expectData(createResponse).id };
+	} catch (error) {
+		if (error instanceof FetchError && error.status === 409) {
+			const raced = await fetchSingleByName(name);
+			if (raced) return { id: raced.id };
+		}
+		throw error;
 	}
-	if (createResponse.response.status === 409) {
-		const raced = await fetchSingleByName(name);
-		if (raced) return { id: raced.id };
-	}
-	throw new FetchError({
-		status: createResponse.response.status,
-		statusText: "Error while fetching data",
-		message: `Could not provision personal service account: ${createResponse.response.url}`,
-		url: createResponse.response.url,
-		details: createResponse,
-	});
 }
 
 export async function findPersonalServiceAccount(

--- a/src/modules/api-keys/domain/rotate-api-key.ts
+++ b/src/modules/api-keys/domain/rotate-api-key.ts
@@ -1,0 +1,28 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+
+import { apiKeyFromApiToDomain } from "./api-key";
+
+export type RotateApiKeyPayload = {
+	serviceAccountId: string;
+	apiKeyId: string;
+	retainPeriodMinutes?: number;
+};
+
+export async function rotateApiKeyRequest(payload: RotateApiKeyPayload) {
+	const response = await apiClient.PUT(
+		"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}/rotate",
+		{
+			params: {
+				path: {
+					service_account_id: payload.serviceAccountId,
+					api_key_name_or_id: payload.apiKeyId,
+				},
+			},
+			body: {
+				retain_period_minutes: payload.retainPeriodMinutes ?? 0,
+			},
+		}
+	);
+	return apiKeyFromApiToDomain(expectData(response));
+}

--- a/src/modules/api-keys/domain/update-api-key.ts
+++ b/src/modules/api-keys/domain/update-api-key.ts
@@ -1,0 +1,37 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+
+import { apiKeyFromApiToDomain } from "./api-key";
+
+export type UpdateApiKeyPayload = {
+	serviceAccountId: string;
+	apiKeyId: string;
+	name?: string;
+	description?: string | null;
+	active?: boolean;
+};
+
+export async function updateApiKeyRequest(payload: UpdateApiKeyPayload) {
+	const body: {
+		name?: string | null;
+		description?: string | null;
+		active?: boolean | null;
+	} = {};
+	if (payload.name !== undefined) body.name = payload.name;
+	if (payload.description !== undefined) body.description = payload.description;
+	if (payload.active !== undefined) body.active = payload.active;
+
+	const response = await apiClient.PUT(
+		"/api/v1/service_accounts/{service_account_id}/api_keys/{api_key_name_or_id}",
+		{
+			params: {
+				path: {
+					service_account_id: payload.serviceAccountId,
+					api_key_name_or_id: payload.apiKeyId,
+				},
+			},
+			body,
+		}
+	);
+	return apiKeyFromApiToDomain(expectData(response));
+}

--- a/src/modules/api-keys/feature/ApiKeyActiveToggleContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeyActiveToggleContainer.tsx
@@ -8,7 +8,7 @@ import { apiKeyQueryKeys } from "../business-logic/api-key-queries";
 import { getErrorMessage } from "../business-logic/get-error-message";
 import { useUpdateApiKey } from "../business-logic/use-update-api-key";
 import type { ApiKey } from "../domain/api-key";
-import { DeactivateApiKeyAlertDialogContainer } from "./DeactivateApiKeyAlertDialogContainer";
+import { DeactivateApiKeyAlertDialog } from "../ui/DeactivateApiKeyAlertDialog";
 
 type ApiKeyActiveToggleContainerProps = {
 	serviceAccountId: string;
@@ -62,7 +62,7 @@ export function ApiKeyActiveToggleContainer({
 				onCheckedChange={handleCheckedChange}
 			/>
 			{showDeactivate && (
-				<DeactivateApiKeyAlertDialogContainer
+				<DeactivateApiKeyAlertDialog
 					apiKey={apiKey}
 					open={showDeactivate}
 					onOpenChange={setShowDeactivate}

--- a/src/modules/api-keys/feature/ApiKeyActiveToggleContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeyActiveToggleContainer.tsx
@@ -1,0 +1,75 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+import { Switch } from "@/shared/ui/switch";
+
+import { apiKeyQueryKeys } from "../business-logic/api-key-queries";
+import { getErrorMessage } from "../business-logic/get-error-message";
+import { useUpdateApiKey } from "../business-logic/use-update-api-key";
+import type { ApiKey } from "../domain/api-key";
+import { DeactivateApiKeyAlertDialogContainer } from "./DeactivateApiKeyAlertDialogContainer";
+
+type ApiKeyActiveToggleContainerProps = {
+	serviceAccountId: string;
+	apiKey: ApiKey;
+};
+
+export function ApiKeyActiveToggleContainer({
+	serviceAccountId,
+	apiKey,
+}: ApiKeyActiveToggleContainerProps) {
+	const queryClient = useQueryClient();
+	const [showDeactivate, setShowDeactivate] = useState(false);
+
+	const { updateApiKey, isPending } = useUpdateApiKey({
+		onSuccess: () =>
+			queryClient.invalidateQueries({
+				queryKey: apiKeyQueryKeys.list(serviceAccountId),
+			}),
+		onError: (error) =>
+			toast.error(getErrorMessage(error, "Could not update API key.")),
+	});
+
+	const isActive = apiKey.active ?? true;
+
+	function handleCheckedChange(nextChecked: boolean) {
+		if (nextChecked === isActive) return;
+		if (!nextChecked) {
+			setShowDeactivate(true);
+			return;
+		}
+		updateApiKey({
+			serviceAccountId,
+			apiKeyId: apiKey.id,
+			active: true,
+		});
+	}
+
+	function handleConfirmDeactivate() {
+		updateApiKey(
+			{ serviceAccountId, apiKeyId: apiKey.id, active: false },
+			{ onSettled: () => setShowDeactivate(false) }
+		);
+	}
+
+	return (
+		<>
+			<Switch
+				aria-label={`Toggle active for ${apiKey.name}`}
+				checked={isActive}
+				disabled={isPending}
+				onCheckedChange={handleCheckedChange}
+			/>
+			{showDeactivate && (
+				<DeactivateApiKeyAlertDialogContainer
+					apiKey={apiKey}
+					open={showDeactivate}
+					onOpenChange={setShowDeactivate}
+					onConfirm={handleConfirmDeactivate}
+					isPending={isPending}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/modules/api-keys/feature/ApiKeyRowActionsContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeyRowActionsContainer.tsx
@@ -1,0 +1,73 @@
+import { MoreHorizontal, RefreshCcw, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/shared/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+
+import type { ApiKey } from "../domain/api-key";
+import { DeleteApiKeyAlertDialogContainer } from "./DeleteApiKeyAlertDialogContainer";
+import { RotateApiKeyDialogContainer } from "./RotateApiKeyDialogContainer";
+
+type ApiKeyRowActionsContainerProps = {
+	serviceAccountId: string;
+	apiKey: ApiKey;
+};
+
+export function ApiKeyRowActionsContainer({
+	serviceAccountId,
+	apiKey,
+}: ApiKeyRowActionsContainerProps) {
+	const [showRotate, setShowRotate] = useState(false);
+	const [showDelete, setShowDelete] = useState(false);
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger
+					render={
+						<Button
+							variant="ghost"
+							size="icon-sm"
+							aria-label={`Open actions for ${apiKey.name}`}
+						>
+							<MoreHorizontal />
+							<span className="sr-only">Open row actions</span>
+						</Button>
+					}
+				/>
+				<DropdownMenuContent align="end" className="w-40">
+					<DropdownMenuItem onClick={() => setShowRotate(true)}>
+						<RefreshCcw className="size-4" /> Rotate
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						onClick={() => setShowDelete(true)}
+					>
+						<Trash2 className="size-4" /> Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			{showRotate && (
+				<RotateApiKeyDialogContainer
+					serviceAccountId={serviceAccountId}
+					apiKey={apiKey}
+					open={showRotate}
+					onOpenChange={setShowRotate}
+				/>
+			)}
+			{showDelete && (
+				<DeleteApiKeyAlertDialogContainer
+					serviceAccountId={serviceAccountId}
+					apiKey={apiKey}
+					open={showDelete}
+					onOpenChange={setShowDelete}
+				/>
+			)}
+		</>
+	);
+}

--- a/src/modules/api-keys/feature/ApiKeysListHeaderContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeysListHeaderContainer.tsx
@@ -1,0 +1,45 @@
+import { Plus } from "lucide-react";
+
+import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
+import { Button } from "@/shared/ui/button";
+import {
+	CardAction,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/shared/ui/card";
+import { RefreshButton } from "@/shared/ui/RefreshButton";
+
+type ApiKeysListHeaderContainerProps = {
+	refetch: () => Promise<unknown>;
+	onCreate: () => void;
+	isCreatePending?: boolean;
+};
+
+export function ApiKeysListHeaderContainer({
+	refetch,
+	onCreate,
+	isCreatePending,
+}: ApiKeysListHeaderContainerProps) {
+	const { refresh, isPending: isRefreshing } = useManualRefresh(refetch);
+
+	return (
+		<CardHeader>
+			<CardTitle className="text-lg font-semibold">API keys</CardTitle>
+			<CardDescription>
+				Create private credentials for automated agents and services.
+			</CardDescription>
+			<CardAction className="flex items-center gap-4">
+				<RefreshButton
+					variant="outline"
+					isLoading={isRefreshing}
+					onClick={refresh}
+				/>
+				<Button onClick={onCreate} disabled={isCreatePending}>
+					<Plus className="size-4" />
+					Create API key
+				</Button>
+			</CardAction>
+		</CardHeader>
+	);
+}

--- a/src/modules/api-keys/feature/ApiKeysListHeaderContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeysListHeaderContainer.tsx
@@ -13,13 +13,11 @@ import { RefreshButton } from "@/shared/ui/RefreshButton";
 type ApiKeysListHeaderContainerProps = {
 	refetch: () => Promise<unknown>;
 	onCreate: () => void;
-	isCreatePending?: boolean;
 };
 
 export function ApiKeysListHeaderContainer({
 	refetch,
 	onCreate,
-	isCreatePending,
 }: ApiKeysListHeaderContainerProps) {
 	const { refresh, isPending: isRefreshing } = useManualRefresh(refetch);
 
@@ -35,7 +33,7 @@ export function ApiKeysListHeaderContainer({
 					isLoading={isRefreshing}
 					onClick={refresh}
 				/>
-				<Button onClick={onCreate} disabled={isCreatePending}>
+				<Button onClick={onCreate}>
 					<Plus className="size-4" />
 					Create API key
 				</Button>

--- a/src/modules/api-keys/feature/ApiKeysPageContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeysPageContainer.tsx
@@ -1,0 +1,68 @@
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { userQueries } from "@/modules/users/business-logic/user-queries";
+import { Card, CardContent } from "@/shared/ui/card";
+
+import { apiKeyQueries } from "../business-logic/api-key-queries";
+import { personalServiceAccountQueries } from "../business-logic/personal-service-account-queries";
+import { ApiKeysTable } from "../ui/ApiKeysTable";
+import { EmptyApiKeys } from "../ui/EmptyApiKeys";
+import { ApiKeyActiveToggleContainer } from "./ApiKeyActiveToggleContainer";
+import { ApiKeyRowActionsContainer } from "./ApiKeyRowActionsContainer";
+import { ApiKeysListHeaderContainer } from "./ApiKeysListHeaderContainer";
+import { CreateApiKeyDialogContainer } from "./CreateApiKeyDialogContainer";
+
+export function ApiKeysPageContainer() {
+	const { data: currentUser } = useSuspenseQuery(userQueries.currentUser());
+	const { data: personalSa } = useSuspenseQuery(
+		personalServiceAccountQueries.resolve(currentUser.id)
+	);
+	const [createOpen, setCreateOpen] = useState(false);
+
+	const hasServiceAccount = personalSa !== null;
+	const { data, refetch } = useQuery({
+		...apiKeyQueries.list(personalSa?.id ?? ""),
+		enabled: hasServiceAccount,
+	});
+
+	const items = data?.items ?? [];
+
+	return (
+		<Card>
+			<ApiKeysListHeaderContainer
+				refetch={refetch}
+				onCreate={() => setCreateOpen(true)}
+			/>
+			<CardContent className="space-y-6">
+				{hasServiceAccount && items.length > 0 ? (
+					<ApiKeysTable
+						apiKeys={items}
+						renderActiveCell={(apiKey) => (
+							<ApiKeyActiveToggleContainer
+								serviceAccountId={personalSa.id}
+								apiKey={apiKey}
+							/>
+						)}
+						renderActions={(apiKey) => (
+							<ApiKeyRowActionsContainer
+								serviceAccountId={personalSa.id}
+								apiKey={apiKey}
+							/>
+						)}
+					/>
+				) : (
+					<EmptyApiKeys onCreate={() => setCreateOpen(true)} />
+				)}
+			</CardContent>
+			{createOpen && (
+				<CreateApiKeyDialogContainer
+					open={createOpen}
+					onOpenChange={setCreateOpen}
+					userId={currentUser.id}
+					serviceAccountId={personalSa?.id ?? null}
+				/>
+			)}
+		</Card>
+	);
+}

--- a/src/modules/api-keys/feature/ApiKeysPageContainer.tsx
+++ b/src/modules/api-keys/feature/ApiKeysPageContainer.tsx
@@ -60,7 +60,7 @@ export function ApiKeysPageContainer() {
 					open={createOpen}
 					onOpenChange={setCreateOpen}
 					userId={currentUser.id}
-					serviceAccountId={personalSa?.id ?? null}
+					serviceAccountId={personalSa?.id}
 				/>
 			)}
 		</Card>

--- a/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
@@ -30,7 +30,7 @@ type CreateApiKeyDialogContainerProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	userId: string;
-	serviceAccountId: string | null;
+	serviceAccountId?: string;
 };
 
 export function CreateApiKeyDialogContainer({

--- a/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
@@ -99,7 +99,7 @@ export function CreateApiKeyDialogContainer({
 
 	return (
 		<Dialog open={open} onOpenChange={handleClose}>
-			<DialogContent className="sm:max-w-lg">
+			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>
 						{revealKey ? "API key created" : "Create API key"}

--- a/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
@@ -42,6 +42,9 @@ export function CreateApiKeyDialogContainer({
 	const queryClient = useQueryClient();
 	const [revealKey, setRevealKey] = useState<string | null>(null);
 	const [isResolvingSa, setIsResolvingSa] = useState(false);
+	const [resolvedServiceAccountId, setResolvedServiceAccountId] = useState<
+		string | undefined
+	>(undefined);
 
 	const form = useForm<ApiKeyFormValues>({
 		resolver: zodResolver(apiKeyFormSchema),
@@ -55,8 +58,14 @@ export function CreateApiKeyDialogContainer({
 
 	function handleClose(nextOpen: boolean) {
 		if (!nextOpen) {
+			if (revealKey && resolvedServiceAccountId) {
+				void queryClient.invalidateQueries({
+					queryKey: apiKeyQueryKeys.list(resolvedServiceAccountId),
+				});
+			}
 			form.reset({ name: "", description: "" });
 			setRevealKey(null);
+			setResolvedServiceAccountId(undefined);
 		}
 		onOpenChange(nextOpen);
 	}
@@ -77,9 +86,6 @@ export function CreateApiKeyDialogContainer({
 				name: values.name,
 				description: values.description?.trim() || undefined,
 			});
-			await queryClient.invalidateQueries({
-				queryKey: apiKeyQueryKeys.list(saId),
-			});
 			if (!created.plaintextKey) {
 				toast.error(
 					"API key was created but the plaintext value was missing from the response."
@@ -88,6 +94,7 @@ export function CreateApiKeyDialogContainer({
 				return;
 			}
 			setRevealKey(created.plaintextKey);
+			setResolvedServiceAccountId(saId);
 		} catch (error) {
 			toast.error(getErrorMessage(error, "Could not create API key."));
 		} finally {

--- a/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/CreateApiKeyDialogContainer.tsx
@@ -1,0 +1,178 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { Button } from "@/shared/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/shared/ui/field";
+import { Input } from "@/shared/ui/input";
+
+import { getErrorMessage } from "../business-logic/get-error-message";
+import {
+	apiKeyFormSchema,
+	type ApiKeyFormValues,
+} from "../business-logic/api-key-form-schema";
+import { apiKeyQueryKeys } from "../business-logic/api-key-queries";
+import { useCreateApiKey } from "../business-logic/use-create-api-key";
+import { findOrCreatePersonalServiceAccount } from "../domain/find-or-create-personal-service-account";
+import { personalServiceAccountQueryKeys } from "../business-logic/personal-service-account-queries";
+import { ApiKeyRevealPanel } from "../ui/ApiKeyRevealPanel";
+
+type CreateApiKeyDialogContainerProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	userId: string;
+	serviceAccountId: string | null;
+};
+
+export function CreateApiKeyDialogContainer({
+	open,
+	onOpenChange,
+	userId,
+	serviceAccountId,
+}: CreateApiKeyDialogContainerProps) {
+	const queryClient = useQueryClient();
+	const [revealKey, setRevealKey] = useState<string | null>(null);
+	const [isResolvingSa, setIsResolvingSa] = useState(false);
+
+	const form = useForm<ApiKeyFormValues>({
+		resolver: zodResolver(apiKeyFormSchema),
+		defaultValues: { name: "", description: "" },
+	});
+
+	const { createApiKeyAsync, isPending: isCreating } = useCreateApiKey({
+		onError: (error) =>
+			toast.error(getErrorMessage(error, "Could not create API key.")),
+	});
+
+	function handleClose(nextOpen: boolean) {
+		if (!nextOpen) {
+			form.reset({ name: "", description: "" });
+			setRevealKey(null);
+		}
+		onOpenChange(nextOpen);
+	}
+
+	async function onSubmit(values: ApiKeyFormValues) {
+		try {
+			let saId = serviceAccountId;
+			if (!saId) {
+				setIsResolvingSa(true);
+				const resolved = await findOrCreatePersonalServiceAccount(userId);
+				saId = resolved.id;
+				await queryClient.invalidateQueries({
+					queryKey: personalServiceAccountQueryKeys.resolve(userId),
+				});
+			}
+			const created = await createApiKeyAsync({
+				serviceAccountId: saId,
+				name: values.name,
+				description: values.description?.trim() || undefined,
+			});
+			await queryClient.invalidateQueries({
+				queryKey: apiKeyQueryKeys.list(saId),
+			});
+			if (!created.plaintextKey) {
+				toast.error(
+					"API key was created but the plaintext value was missing from the response."
+				);
+				handleClose(false);
+				return;
+			}
+			setRevealKey(created.plaintextKey);
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Could not create API key."));
+		} finally {
+			setIsResolvingSa(false);
+		}
+	}
+
+	const isSubmitting = isCreating || isResolvingSa;
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>
+						{revealKey ? "API key created" : "Create API key"}
+					</DialogTitle>
+				</DialogHeader>
+				{revealKey ? (
+					<>
+						<ApiKeyRevealPanel mode="create" plaintextKey={revealKey} />
+						<DialogFooter>
+							<Button onClick={() => handleClose(false)}>Done</Button>
+						</DialogFooter>
+					</>
+				) : (
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="flex flex-col gap-6"
+					>
+						<Controller
+							control={form.control}
+							name="name"
+							render={({ field, fieldState }) => (
+								<Field data-invalid={fieldState.invalid}>
+									<FieldLabel htmlFor="api-key-name">Name</FieldLabel>
+									<Input
+										{...field}
+										id="api-key-name"
+										placeholder="ci-production"
+										autoComplete="off"
+										aria-invalid={fieldState.invalid}
+									/>
+									{fieldState.error && (
+										<FieldError errors={[fieldState.error]} />
+									)}
+								</Field>
+							)}
+						/>
+						<Controller
+							control={form.control}
+							name="description"
+							render={({ field, fieldState }) => (
+								<Field data-invalid={fieldState.invalid}>
+									<FieldLabel htmlFor="api-key-description">
+										Description{" "}
+										<span className="text-muted-foreground">(optional)</span>
+									</FieldLabel>
+									<Input
+										{...field}
+										id="api-key-description"
+										placeholder="Used by the production CI pipeline"
+										autoComplete="off"
+										aria-invalid={fieldState.invalid}
+									/>
+									{fieldState.error && (
+										<FieldError errors={[fieldState.error]} />
+									)}
+								</Field>
+							)}
+						/>
+						<DialogFooter className="sm:justify-between">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleClose(false)}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isSubmitting}>
+								{isSubmitting ? "Creating..." : "Create API key"}
+							</Button>
+						</DialogFooter>
+					</form>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/modules/api-keys/feature/DeactivateApiKeyAlertDialogContainer.tsx
+++ b/src/modules/api-keys/feature/DeactivateApiKeyAlertDialogContainer.tsx
@@ -1,0 +1,53 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/shared/ui/alert-dialog";
+
+import type { ApiKey } from "../domain/api-key";
+
+type DeactivateApiKeyAlertDialogContainerProps = {
+	apiKey: ApiKey;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+	isPending?: boolean;
+};
+
+export function DeactivateApiKeyAlertDialogContainer({
+	apiKey,
+	open,
+	onOpenChange,
+	onConfirm,
+	isPending,
+}: DeactivateApiKeyAlertDialogContainerProps) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Deactivate API key</AlertDialogTitle>
+					<AlertDialogDescription>
+						Are you sure? You won&apos;t be able to use{" "}
+						<span className="text-foreground font-medium">{apiKey.name}</span>{" "}
+						to authenticate with the server anymore.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter className="sm:justify-between">
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						variant="destructive"
+						disabled={isPending}
+						onClick={onConfirm}
+					>
+						{isPending ? "Deactivating..." : "Deactivate"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/src/modules/api-keys/feature/DeleteApiKeyAlertDialogContainer.tsx
+++ b/src/modules/api-keys/feature/DeleteApiKeyAlertDialogContainer.tsx
@@ -1,0 +1,49 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { DeleteAlertDialog } from "@/shared/ui/DeleteAlertDialog";
+
+import { apiKeyQueryKeys } from "../business-logic/api-key-queries";
+import { getErrorMessage } from "../business-logic/get-error-message";
+import { useDeleteApiKey } from "../business-logic/use-delete-api-key";
+import type { ApiKey } from "../domain/api-key";
+
+type DeleteApiKeyAlertDialogContainerProps = {
+	serviceAccountId: string;
+	apiKey: ApiKey;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+};
+
+export function DeleteApiKeyAlertDialogContainer({
+	serviceAccountId,
+	apiKey,
+	open,
+	onOpenChange,
+}: DeleteApiKeyAlertDialogContainerProps) {
+	const queryClient = useQueryClient();
+	const { deleteApiKey, isPending } = useDeleteApiKey({
+		onSuccess: async () => {
+			await queryClient.invalidateQueries({
+				queryKey: apiKeyQueryKeys.list(serviceAccountId),
+			});
+			toast.success("API key deleted");
+			onOpenChange(false);
+		},
+		onError: (error) =>
+			toast.error(getErrorMessage(error, "Could not delete API key.")),
+	});
+
+	return (
+		<DeleteAlertDialog
+			title="Delete API key"
+			description={`Are you sure you want to delete "${apiKey.name}"? This action cannot be undone and will immediately revoke access.`}
+			open={open}
+			onOpenChange={onOpenChange}
+			onConfirm={() => deleteApiKey({ serviceAccountId, apiKeyId: apiKey.id })}
+			isPending={isPending}
+			actionLabel="Delete API key"
+			pendingLabel="Deleting..."
+		/>
+	);
+}

--- a/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
@@ -56,6 +56,11 @@ export function RotateApiKeyDialogContainer({
 
 	function handleClose(nextOpen: boolean) {
 		if (!nextOpen) {
+			if (revealKey) {
+				void queryClient.invalidateQueries({
+					queryKey: apiKeyQueryKeys.list(serviceAccountId),
+				});
+			}
 			form.reset({ enableRetention: false, retainPeriodMinutes: "" });
 			setRevealKey(null);
 		}
@@ -70,9 +75,6 @@ export function RotateApiKeyDialogContainer({
 				retainPeriodMinutes: values.enableRetention
 					? Number(values.retainPeriodMinutes)
 					: 0,
-			});
-			await queryClient.invalidateQueries({
-				queryKey: apiKeyQueryKeys.list(serviceAccountId),
 			});
 			if (!rotated.plaintextKey) {
 				toast.error(

--- a/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
@@ -1,6 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
-import { TriangleAlert } from "lucide-react";
 import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -16,6 +15,7 @@ import {
 import { Field, FieldError, FieldLabel } from "@/shared/ui/field";
 import { Input } from "@/shared/ui/input";
 import { Switch } from "@/shared/ui/switch";
+import { WarningBanner } from "@/shared/ui/WarningBanner";
 
 import { getErrorMessage } from "../business-logic/get-error-message";
 import {
@@ -89,7 +89,7 @@ export function RotateApiKeyDialogContainer({
 
 	return (
 		<Dialog open={open} onOpenChange={handleClose}>
-			<DialogContent className="sm:max-w-lg">
+			<DialogContent className="sm:max-w-2xl">
 				<DialogHeader>
 					<DialogTitle>
 						{revealKey ? "API key rotated" : `Rotate "${apiKey.name}"`}
@@ -107,14 +107,13 @@ export function RotateApiKeyDialogContainer({
 						onSubmit={form.handleSubmit(onSubmit)}
 						className="flex flex-col gap-6"
 					>
-						<div className="bg-warning/10 text-warning-foreground border-warning/40 flex items-start gap-2 rounded-md border p-3 text-sm">
-							<TriangleAlert className="text-warning mt-0.5 size-4 shrink-0" />
+						<WarningBanner>
 							<p>
 								Your current API key will be deactivated. Any processes or
 								integrations using the old key will no longer function once the
 								new key is generated.
 							</p>
-						</div>
+						</WarningBanner>
 						<Controller
 							control={form.control}
 							name="enableRetention"

--- a/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
+++ b/src/modules/api-keys/feature/RotateApiKeyDialogContainer.tsx
@@ -1,0 +1,184 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
+import { TriangleAlert } from "lucide-react";
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { toast } from "sonner";
+
+import { Button } from "@/shared/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/shared/ui/dialog";
+import { Field, FieldError, FieldLabel } from "@/shared/ui/field";
+import { Input } from "@/shared/ui/input";
+import { Switch } from "@/shared/ui/switch";
+
+import { getErrorMessage } from "../business-logic/get-error-message";
+import {
+	rotateApiKeyFormSchema,
+	type RotateApiKeyFormValues,
+} from "../business-logic/rotate-api-key-form-schema";
+import { apiKeyQueryKeys } from "../business-logic/api-key-queries";
+import { useRotateApiKey } from "../business-logic/use-rotate-api-key";
+import type { ApiKey } from "../domain/api-key";
+import { ApiKeyRevealPanel } from "../ui/ApiKeyRevealPanel";
+
+type RotateApiKeyDialogContainerProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	serviceAccountId: string;
+	apiKey: ApiKey;
+};
+
+export function RotateApiKeyDialogContainer({
+	open,
+	onOpenChange,
+	serviceAccountId,
+	apiKey,
+}: RotateApiKeyDialogContainerProps) {
+	const queryClient = useQueryClient();
+	const [revealKey, setRevealKey] = useState<string | null>(null);
+
+	const form = useForm<RotateApiKeyFormValues>({
+		resolver: zodResolver(rotateApiKeyFormSchema),
+		defaultValues: { enableRetention: false, retainPeriodMinutes: "" },
+	});
+	const enableRetention = form.watch("enableRetention");
+
+	const { rotateApiKeyAsync, isPending: isRotating } = useRotateApiKey({
+		onError: (error) =>
+			toast.error(getErrorMessage(error, "Could not rotate API key.")),
+	});
+
+	function handleClose(nextOpen: boolean) {
+		if (!nextOpen) {
+			form.reset({ enableRetention: false, retainPeriodMinutes: "" });
+			setRevealKey(null);
+		}
+		onOpenChange(nextOpen);
+	}
+
+	async function onSubmit(values: RotateApiKeyFormValues) {
+		try {
+			const rotated = await rotateApiKeyAsync({
+				serviceAccountId,
+				apiKeyId: apiKey.id,
+				retainPeriodMinutes: values.enableRetention
+					? Number(values.retainPeriodMinutes)
+					: 0,
+			});
+			await queryClient.invalidateQueries({
+				queryKey: apiKeyQueryKeys.list(serviceAccountId),
+			});
+			if (!rotated.plaintextKey) {
+				toast.error(
+					"API key was rotated but the plaintext value was missing from the response."
+				);
+				handleClose(false);
+				return;
+			}
+			setRevealKey(rotated.plaintextKey);
+		} catch (error) {
+			toast.error(getErrorMessage(error, "Could not rotate API key."));
+		}
+	}
+
+	return (
+		<Dialog open={open} onOpenChange={handleClose}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>
+						{revealKey ? "API key rotated" : `Rotate "${apiKey.name}"`}
+					</DialogTitle>
+				</DialogHeader>
+				{revealKey ? (
+					<>
+						<ApiKeyRevealPanel mode="rotate" plaintextKey={revealKey} />
+						<DialogFooter>
+							<Button onClick={() => handleClose(false)}>Done</Button>
+						</DialogFooter>
+					</>
+				) : (
+					<form
+						onSubmit={form.handleSubmit(onSubmit)}
+						className="flex flex-col gap-6"
+					>
+						<div className="bg-warning/10 text-warning-foreground border-warning/40 flex items-start gap-2 rounded-md border p-3 text-sm">
+							<TriangleAlert className="text-warning mt-0.5 size-4 shrink-0" />
+							<p>
+								Your current API key will be deactivated. Any processes or
+								integrations using the old key will no longer function once the
+								new key is generated.
+							</p>
+						</div>
+						<Controller
+							control={form.control}
+							name="enableRetention"
+							render={({ field }) => (
+								<Field>
+									<label className="flex items-start gap-3">
+										<Switch
+											checked={field.value}
+											onCheckedChange={field.onChange}
+										/>
+										<div>
+											<span className="text-sm font-medium">
+												Keep the old key active for a retention period
+											</span>
+											<p className="text-muted-foreground text-xs">
+												Minimize disruption by letting the old key remain valid
+												alongside the new one for a number of minutes.
+											</p>
+										</div>
+									</label>
+								</Field>
+							)}
+						/>
+						{enableRetention && (
+							<Controller
+								control={form.control}
+								name="retainPeriodMinutes"
+								render={({ field, fieldState }) => (
+									<Field data-invalid={fieldState.invalid}>
+										<FieldLabel htmlFor="api-key-retention">
+											Retention period (minutes)
+										</FieldLabel>
+										<Input
+											{...field}
+											id="api-key-retention"
+											type="number"
+											min={1}
+											step={1}
+											placeholder="15"
+											autoComplete="off"
+											aria-invalid={fieldState.invalid}
+										/>
+										{fieldState.error && (
+											<FieldError errors={[fieldState.error]} />
+										)}
+									</Field>
+								)}
+							/>
+						)}
+						<DialogFooter className="sm:justify-between">
+							<Button
+								type="button"
+								variant="outline"
+								onClick={() => handleClose(false)}
+							>
+								Cancel
+							</Button>
+							<Button type="submit" disabled={isRotating}>
+								{isRotating ? "Rotating..." : "Rotate key"}
+							</Button>
+						</DialogFooter>
+					</form>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
+++ b/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
@@ -1,0 +1,43 @@
+import { TriangleAlert } from "lucide-react";
+
+import { CopyCommand } from "@/shared/ui/CopyCommand";
+
+type ApiKeyRevealPanelProps = {
+	mode: "create" | "rotate";
+	plaintextKey: string;
+};
+
+export function ApiKeyRevealPanel({
+	mode,
+	plaintextKey,
+}: ApiKeyRevealPanelProps) {
+	return (
+		<div className="flex flex-col gap-4">
+			<div>
+				<p className="text-lg font-semibold">
+					{mode === "create"
+						? "Here is your new API key"
+						: "Here is your rotated API key"}
+				</p>
+				<p className="text-muted-foreground text-sm">
+					Your key was generated successfully.
+				</p>
+			</div>
+			<div className="bg-warning/10 text-warning-foreground border-warning/40 flex items-start gap-2 rounded-md border p-3 text-sm">
+				<TriangleAlert className="text-warning mt-0.5 size-4 shrink-0" />
+				<p>
+					<span className="font-semibold">Important:</span> this key cannot be
+					retrieved later. Please copy it now. Keep your keys private and never
+					share them.
+				</p>
+			</div>
+			<CopyCommand code={plaintextKey} className="text-sm" />
+			<div className="bg-muted/40 text-muted-foreground rounded-md p-3 text-xs">
+				<p className="text-foreground mb-1 font-medium">Example usage</p>
+				<code className="block font-mono break-all whitespace-pre-wrap">
+					curl -H &quot;Authorization: Bearer {plaintextKey}&quot; $ZENML_URL
+				</code>
+			</div>
+		</div>
+	);
+}

--- a/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
+++ b/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
@@ -1,6 +1,5 @@
-import { TriangleAlert } from "lucide-react";
-
 import { CopyCommand } from "@/shared/ui/CopyCommand";
+import { WarningBanner } from "@/shared/ui/WarningBanner";
 
 type ApiKeyRevealPanelProps = {
 	mode: "create" | "rotate";
@@ -12,7 +11,7 @@ export function ApiKeyRevealPanel({
 	plaintextKey,
 }: ApiKeyRevealPanelProps) {
 	return (
-		<div className="flex flex-col gap-4">
+		<div className="flex min-w-0 flex-col gap-4">
 			<div>
 				<p className="text-lg font-semibold">
 					{mode === "create"
@@ -23,14 +22,13 @@ export function ApiKeyRevealPanel({
 					Your key was generated successfully.
 				</p>
 			</div>
-			<div className="bg-warning/10 text-warning-foreground border-warning/40 flex items-start gap-2 rounded-md border p-3 text-sm">
-				<TriangleAlert className="text-warning mt-0.5 size-4 shrink-0" />
+			<WarningBanner>
 				<p>
 					<span className="font-semibold">Important:</span> this key cannot be
 					retrieved later. Please copy it now. Keep your keys private and never
 					share them.
 				</p>
-			</div>
+			</WarningBanner>
 			<CopyCommand code={plaintextKey} className="text-sm" />
 			<div className="bg-muted/40 text-muted-foreground rounded-md p-3 text-xs">
 				<p className="text-foreground mb-1 font-medium">Example usage</p>

--- a/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
+++ b/src/modules/api-keys/ui/ApiKeyRevealPanel.tsx
@@ -33,7 +33,8 @@ export function ApiKeyRevealPanel({
 			<div className="bg-muted/40 text-muted-foreground rounded-md p-3 text-xs">
 				<p className="text-foreground mb-1 font-medium">Example usage</p>
 				<code className="block font-mono break-all whitespace-pre-wrap">
-					curl -H &quot;Authorization: Bearer {plaintextKey}&quot; $ZENML_URL
+					curl -H &quot;Authorization: Bearer {plaintextKey}&quot;
+					$KITARU_SERVER_URL
 				</code>
 			</div>
 		</div>

--- a/src/modules/api-keys/ui/ApiKeysTable.tsx
+++ b/src/modules/api-keys/ui/ApiKeysTable.tsx
@@ -1,0 +1,158 @@
+import { KeyRound } from "lucide-react";
+import { useState } from "react";
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import {
+	flexRender,
+	getCoreRowModel,
+	getSortedRowModel,
+	useReactTable,
+} from "@tanstack/react-table";
+import type { ReactNode } from "react";
+
+import {
+	SortableHeader,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/shared/ui/Table";
+import { TextRenderer } from "@/shared/ui/Table/CellRenderer";
+
+import type { ApiKey } from "../domain/api-key";
+
+type ApiKeysTableProps = {
+	apiKeys: ApiKey[];
+	renderActions?: (apiKey: ApiKey) => ReactNode;
+	renderActiveCell?: (apiKey: ApiKey) => ReactNode;
+};
+
+function formatLastLogin(date?: Date) {
+	if (!date) return "Never";
+	return date.toLocaleString();
+}
+
+export function ApiKeysTable({
+	apiKeys,
+	renderActions,
+	renderActiveCell,
+}: ApiKeysTableProps) {
+	const [sorting, setSorting] = useState<SortingState>([
+		{ id: "createdAt", desc: true },
+	]);
+
+	const columns = createColumns({ renderActions, renderActiveCell });
+
+	const table = useReactTable({
+		data: apiKeys,
+		columns,
+		state: { sorting },
+		onSortingChange: setSorting,
+		getCoreRowModel: getCoreRowModel(),
+		getSortedRowModel: getSortedRowModel(),
+		getRowId: (row) => row.id,
+	});
+
+	return (
+		<Table>
+			<TableHeader>
+				{table.getHeaderGroups().map((headerGroup) => (
+					<TableRow key={headerGroup.id}>
+						{headerGroup.headers.map((header) => (
+							<TableHead key={header.id}>
+								{header.isPlaceholder
+									? null
+									: flexRender(
+											header.column.columnDef.header,
+											header.getContext()
+										)}
+							</TableHead>
+						))}
+					</TableRow>
+				))}
+			</TableHeader>
+			<TableBody>
+				{table.getRowModel().rows.length ? (
+					table.getRowModel().rows.map((row) => (
+						<TableRow key={row.id}>
+							{row.getVisibleCells().map((cell) => (
+								<TableCell key={cell.id}>
+									{flexRender(cell.column.columnDef.cell, cell.getContext())}
+								</TableCell>
+							))}
+						</TableRow>
+					))
+				) : (
+					<TableRow>
+						<TableCell colSpan={columns.length} className="h-24 text-center">
+							No API keys yet.
+						</TableCell>
+					</TableRow>
+				)}
+			</TableBody>
+		</Table>
+	);
+}
+
+function createColumns({
+	renderActions,
+	renderActiveCell,
+}: {
+	renderActions?: (apiKey: ApiKey) => ReactNode;
+	renderActiveCell?: (apiKey: ApiKey) => ReactNode;
+}): ColumnDef<ApiKey>[] {
+	const columns: ColumnDef<ApiKey>[] = [
+		{
+			accessorKey: "name",
+			header: ({ column }) => <SortableHeader column={column} label="Name" />,
+			cell: ({ row }) => {
+				const apiKey = row.original;
+				return (
+					<div className="flex items-start gap-2">
+						<KeyRound className="text-muted-foreground mt-0.5 size-4" />
+						<div className="flex flex-col text-sm">
+							<span className="text-foreground font-medium">{apiKey.name}</span>
+							{apiKey.description && (
+								<span className="text-muted-foreground text-xs">
+									{apiKey.description}
+								</span>
+							)}
+						</div>
+					</div>
+				);
+			},
+		},
+		{
+			accessorKey: "lastLogin",
+			header: ({ column }) => (
+				<SortableHeader column={column} label="Last used" />
+			),
+			cell: ({ row }) => (
+				<TextRenderer>{formatLastLogin(row.original.lastLogin)}</TextRenderer>
+			),
+		},
+	];
+
+	if (renderActiveCell) {
+		columns.push({
+			id: "active",
+			enableSorting: false,
+			header: () => <span>Active</span>,
+			cell: ({ row }) => renderActiveCell(row.original),
+		});
+	}
+
+	if (renderActions) {
+		columns.push({
+			id: "actions",
+			enableSorting: false,
+			header: () => <span className="sr-only">Actions</span>,
+			cell: ({ row }) => (
+				<div className="flex justify-end">{renderActions(row.original)}</div>
+			),
+		});
+	}
+
+	return columns;
+}

--- a/src/modules/api-keys/ui/ApiKeysTable.tsx
+++ b/src/modules/api-keys/ui/ApiKeysTable.tsx
@@ -38,9 +38,7 @@ export function ApiKeysTable({
 	renderActions,
 	renderActiveCell,
 }: ApiKeysTableProps) {
-	const [sorting, setSorting] = useState<SortingState>([
-		{ id: "createdAt", desc: true },
-	]);
+	const [sorting, setSorting] = useState<SortingState>([]);
 
 	const columns = createColumns({ renderActions, renderActiveCell });
 
@@ -73,23 +71,15 @@ export function ApiKeysTable({
 				))}
 			</TableHeader>
 			<TableBody>
-				{table.getRowModel().rows.length ? (
-					table.getRowModel().rows.map((row) => (
-						<TableRow key={row.id}>
-							{row.getVisibleCells().map((cell) => (
-								<TableCell key={cell.id}>
-									{flexRender(cell.column.columnDef.cell, cell.getContext())}
-								</TableCell>
-							))}
-						</TableRow>
-					))
-				) : (
-					<TableRow>
-						<TableCell colSpan={columns.length} className="h-24 text-center">
-							No API keys yet.
-						</TableCell>
+				{table.getRowModel().rows.map((row) => (
+					<TableRow key={row.id}>
+						{row.getVisibleCells().map((cell) => (
+							<TableCell key={cell.id}>
+								{flexRender(cell.column.columnDef.cell, cell.getContext())}
+							</TableCell>
+						))}
 					</TableRow>
-				)}
+				))}
 			</TableBody>
 		</Table>
 	);

--- a/src/modules/api-keys/ui/DeactivateApiKeyAlertDialog.tsx
+++ b/src/modules/api-keys/ui/DeactivateApiKeyAlertDialog.tsx
@@ -11,7 +11,7 @@ import {
 
 import type { ApiKey } from "../domain/api-key";
 
-type DeactivateApiKeyAlertDialogContainerProps = {
+type DeactivateApiKeyAlertDialogProps = {
 	apiKey: ApiKey;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -19,13 +19,13 @@ type DeactivateApiKeyAlertDialogContainerProps = {
 	isPending?: boolean;
 };
 
-export function DeactivateApiKeyAlertDialogContainer({
+export function DeactivateApiKeyAlertDialog({
 	apiKey,
 	open,
 	onOpenChange,
 	onConfirm,
 	isPending,
-}: DeactivateApiKeyAlertDialogContainerProps) {
+}: DeactivateApiKeyAlertDialogProps) {
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent>

--- a/src/modules/api-keys/ui/EmptyApiKeys.tsx
+++ b/src/modules/api-keys/ui/EmptyApiKeys.tsx
@@ -1,0 +1,28 @@
+import { KeyRound, Plus } from "lucide-react";
+
+import { Button } from "@/shared/ui/button";
+
+type EmptyApiKeysProps = {
+	onCreate: () => void;
+	isPending?: boolean;
+};
+
+export function EmptyApiKeys({ onCreate, isPending }: EmptyApiKeysProps) {
+	return (
+		<div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+			<div className="bg-muted flex size-12 items-center justify-center rounded-full">
+				<KeyRound className="text-muted-foreground size-6" />
+			</div>
+			<div className="space-y-1">
+				<p className="text-lg font-semibold">Create a new API key</p>
+				<p className="text-muted-foreground max-w-sm text-sm">
+					An API key is a private credential for your kitaru account. Use it for
+					secure automation with the API or SDK.
+				</p>
+			</div>
+			<Button onClick={onCreate} disabled={isPending}>
+				<Plus className="size-4" /> Create API key
+			</Button>
+		</div>
+	);
+}

--- a/src/modules/api-keys/ui/EmptyApiKeys.tsx
+++ b/src/modules/api-keys/ui/EmptyApiKeys.tsx
@@ -4,10 +4,9 @@ import { Button } from "@/shared/ui/button";
 
 type EmptyApiKeysProps = {
 	onCreate: () => void;
-	isPending?: boolean;
 };
 
-export function EmptyApiKeys({ onCreate, isPending }: EmptyApiKeysProps) {
+export function EmptyApiKeys({ onCreate }: EmptyApiKeysProps) {
 	return (
 		<div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
 			<div className="bg-muted flex size-12 items-center justify-center rounded-full">
@@ -20,7 +19,7 @@ export function EmptyApiKeys({ onCreate, isPending }: EmptyApiKeysProps) {
 					secure automation with the API or SDK.
 				</p>
 			</div>
-			<Button onClick={onCreate} disabled={isPending}>
+			<Button onClick={onCreate}>
 				<Plus className="size-4" /> Create API key
 			</Button>
 		</div>

--- a/src/modules/settings/ui/SettingsNavigation.tsx
+++ b/src/modules/settings/ui/SettingsNavigation.tsx
@@ -1,5 +1,5 @@
 import { Link, useRouter } from "@tanstack/react-router";
-import { KeyRound, User, Users } from "lucide-react";
+import { KeyRound, ShieldCheck, User, Users } from "lucide-react";
 
 export function SettingsNavigation() {
 	const { buildLocation } = useRouter();
@@ -19,6 +19,11 @@ export function SettingsNavigation() {
 			label: "Secrets",
 			to: buildLocation({ to: "/settings/secrets" }).pathname,
 			icon: KeyRound,
+		},
+		{
+			label: "API keys",
+			to: buildLocation({ to: "/settings/api-keys" }).pathname,
+			icon: ShieldCheck,
 		},
 	];
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as PrivateNavbarFlowsIndexRouteImport } from './routes/_private/_
 import { Route as PrivateNavbarSettingsSecretsRouteImport } from './routes/_private/_navbar/settings/secrets'
 import { Route as PrivateNavbarSettingsProfileRouteImport } from './routes/_private/_navbar/settings/profile'
 import { Route as PrivateNavbarSettingsMembersRouteImport } from './routes/_private/_navbar/settings/members'
+import { Route as PrivateNavbarSettingsApiKeysRouteImport } from './routes/_private/_navbar/settings/api-keys'
 import { Route as PrivateNavbarFlowsFlowIdRouteRouteImport } from './routes/_private/_navbar/flows/$flowId/route'
 import { Route as PrivateNavbarSettingsSecretsIndexRouteImport } from './routes/_private/_navbar/settings/secrets/index'
 import { Route as PrivateNavbarFlowsFlowIdIndexRouteImport } from './routes/_private/_navbar/flows/$flowId/index'
@@ -110,6 +111,12 @@ const PrivateNavbarSettingsMembersRoute =
     path: '/members',
     getParentRoute: () => PrivateNavbarSettingsRouteRoute,
   } as any)
+const PrivateNavbarSettingsApiKeysRoute =
+  PrivateNavbarSettingsApiKeysRouteImport.update({
+    id: '/api-keys',
+    path: '/api-keys',
+    getParentRoute: () => PrivateNavbarSettingsRouteRoute,
+  } as any)
 const PrivateNavbarFlowsFlowIdRouteRoute =
   PrivateNavbarFlowsFlowIdRouteRouteImport.update({
     id: '/$flowId',
@@ -162,6 +169,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof publicMeshLoginRoute
   '/devices/verify': typeof PrivateDevicesVerifyRoute
   '/flows/$flowId': typeof PrivateNavbarFlowsFlowIdRouteRouteWithChildren
+  '/settings/api-keys': typeof PrivateNavbarSettingsApiKeysRoute
   '/settings/members': typeof PrivateNavbarSettingsMembersRoute
   '/settings/profile': typeof PrivateNavbarSettingsProfileRoute
   '/settings/secrets': typeof PrivateNavbarSettingsSecretsRouteWithChildren
@@ -180,6 +188,7 @@ export interface FileRoutesByTo {
   '/activate-user': typeof publicMeshActivateUserRoute
   '/login': typeof publicMeshLoginRoute
   '/devices/verify': typeof PrivateDevicesVerifyRoute
+  '/settings/api-keys': typeof PrivateNavbarSettingsApiKeysRoute
   '/settings/members': typeof PrivateNavbarSettingsMembersRoute
   '/settings/profile': typeof PrivateNavbarSettingsProfileRoute
   '/flows': typeof PrivateNavbarFlowsIndexRoute
@@ -204,6 +213,7 @@ export interface FileRoutesById {
   '/(public)/_mesh/login': typeof publicMeshLoginRoute
   '/_private/devices/verify': typeof PrivateDevicesVerifyRoute
   '/_private/_navbar/flows/$flowId': typeof PrivateNavbarFlowsFlowIdRouteRouteWithChildren
+  '/_private/_navbar/settings/api-keys': typeof PrivateNavbarSettingsApiKeysRoute
   '/_private/_navbar/settings/members': typeof PrivateNavbarSettingsMembersRoute
   '/_private/_navbar/settings/profile': typeof PrivateNavbarSettingsProfileRoute
   '/_private/_navbar/settings/secrets': typeof PrivateNavbarSettingsSecretsRouteWithChildren
@@ -227,6 +237,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/devices/verify'
     | '/flows/$flowId'
+    | '/settings/api-keys'
     | '/settings/members'
     | '/settings/profile'
     | '/settings/secrets'
@@ -245,6 +256,7 @@ export interface FileRouteTypes {
     | '/activate-user'
     | '/login'
     | '/devices/verify'
+    | '/settings/api-keys'
     | '/settings/members'
     | '/settings/profile'
     | '/flows'
@@ -268,6 +280,7 @@ export interface FileRouteTypes {
     | '/(public)/_mesh/login'
     | '/_private/devices/verify'
     | '/_private/_navbar/flows/$flowId'
+    | '/_private/_navbar/settings/api-keys'
     | '/_private/_navbar/settings/members'
     | '/_private/_navbar/settings/profile'
     | '/_private/_navbar/settings/secrets'
@@ -393,6 +406,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof PrivateNavbarSettingsMembersRouteImport
       parentRoute: typeof PrivateNavbarSettingsRouteRoute
     }
+    '/_private/_navbar/settings/api-keys': {
+      id: '/_private/_navbar/settings/api-keys'
+      path: '/api-keys'
+      fullPath: '/settings/api-keys'
+      preLoaderRoute: typeof PrivateNavbarSettingsApiKeysRouteImport
+      parentRoute: typeof PrivateNavbarSettingsRouteRoute
+    }
     '/_private/_navbar/flows/$flowId': {
       id: '/_private/_navbar/flows/$flowId'
       path: '/$flowId'
@@ -503,6 +523,7 @@ const PrivateNavbarSettingsSecretsRouteWithChildren =
   )
 
 interface PrivateNavbarSettingsRouteRouteChildren {
+  PrivateNavbarSettingsApiKeysRoute: typeof PrivateNavbarSettingsApiKeysRoute
   PrivateNavbarSettingsMembersRoute: typeof PrivateNavbarSettingsMembersRoute
   PrivateNavbarSettingsProfileRoute: typeof PrivateNavbarSettingsProfileRoute
   PrivateNavbarSettingsSecretsRoute: typeof PrivateNavbarSettingsSecretsRouteWithChildren
@@ -511,6 +532,7 @@ interface PrivateNavbarSettingsRouteRouteChildren {
 
 const PrivateNavbarSettingsRouteRouteChildren: PrivateNavbarSettingsRouteRouteChildren =
   {
+    PrivateNavbarSettingsApiKeysRoute: PrivateNavbarSettingsApiKeysRoute,
     PrivateNavbarSettingsMembersRoute: PrivateNavbarSettingsMembersRoute,
     PrivateNavbarSettingsProfileRoute: PrivateNavbarSettingsProfileRoute,
     PrivateNavbarSettingsSecretsRoute:

--- a/src/routes/_private/_navbar/settings/api-keys.tsx
+++ b/src/routes/_private/_navbar/settings/api-keys.tsx
@@ -1,0 +1,28 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { apiKeyQueries } from "@/modules/api-keys/business-logic/api-key-queries";
+import { personalServiceAccountQueries } from "@/modules/api-keys/business-logic/personal-service-account-queries";
+import { ApiKeysPageContainer } from "@/modules/api-keys/feature/ApiKeysPageContainer";
+import { userQueries } from "@/modules/users/business-logic/user-queries";
+import { buildPageTitles } from "@/shared/utils/build-page-titles";
+
+export const Route = createFileRoute("/_private/_navbar/settings/api-keys")({
+	component: ApiKeysPageContainer,
+	loader: async ({ context }) => {
+		const user = await context.queryClient.ensureQueryData(
+			userQueries.currentUser()
+		);
+		const sa = await context.queryClient.ensureQueryData(
+			personalServiceAccountQueries.resolve(user.id)
+		);
+		if (sa) {
+			await context.queryClient.ensureQueryData(apiKeyQueries.list(sa.id));
+		}
+		return {
+			crumb: { label: "API keys", disabled: false },
+		};
+	},
+	head: () => ({
+		meta: [{ title: buildPageTitles("API keys") }],
+	}),
+});

--- a/src/shared/ui/WarningBanner.tsx
+++ b/src/shared/ui/WarningBanner.tsx
@@ -1,0 +1,23 @@
+import { TriangleAlert } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "../utils/styles";
+
+type WarningBannerProps = {
+	children: ReactNode;
+	className?: string;
+};
+
+export function WarningBanner({ children, className }: WarningBannerProps) {
+	return (
+		<div
+			className={cn(
+				"bg-warning/10 text-foreground border-warning/40 flex items-start gap-2 rounded-md border p-3 text-sm",
+				className
+			)}
+		>
+			<TriangleAlert className="text-warning mt-0.5 size-4 shrink-0" />
+			<div className="min-w-0 flex-1">{children}</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- Adds `Settings → API keys` with create / rotate / deactivate / revoke flows, mirroring the cloud-ui PAT UX (issue #133).
- Hides the backend `service_account` requirement behind a lazily-created `pat-${userId}` service account resolved on first create; invisible to the user.
- Extracts a shared `WarningBanner` primitive in `src/shared/ui` (used by the reveal panel and rotate dialog).

## What's included
- Full `modules/api-keys/` module: domain mappers, transport wrappers, query/mutation layer, Zod form schemas, error helper.
- Two-step create and rotate dialogs with one-time reveal panel (key + curl example + Copy).
- Active toggle with deactivate-confirmation; reactivation instant.
- Type-to-confirm delete using shared `DeleteAlertDialog`.
- Table, row actions, empty state, page container + route + sidebar link.
- E2E fixtures and 5 Playwright specs covering empty / list / create / rotate-with-retention / delete.

## Out of scope (documented in spec)
- RBAC gating, audit log, expires-in-minutes, cross-SA key visibility, in-place name/description edits.

## Test plan
- [ ] `pnpm check:types` passes
- [ ] `pnpm lint` passes (6 pre-existing `react-hooks/incompatible-library` warnings on TanStack Table / RHF only)
- [ ] `pnpm test:unit` green (276/276)
- [ ] `pnpm test:e2e` green (13/13 — includes 5 new api-keys specs)
- [ ] Manually verified create → reveal → copy → done loop in dev

## Follow-ups (not in this PR)
- Rotate dialog's reveal panel unmounts fast enough in E2E that Playwright can't see it; the spec asserts on the captured PUT body instead. Likely fix: lift the rotate dialog out of the row into a page-level host (create dialog is already page-level and works fine).
- Backend follow-ups: `expires_in_minutes` on `APIKeyRequest`, per-SA last-used summary.