### PR TITLE
feat(stacks): add stacks data layer (domain + fetch + queries)

### DIFF
--- a/src/modules/stacks/business-logic/stacks-queries.ts
+++ b/src/modules/stacks/business-logic/stacks-queries.ts
@@ -1,0 +1,16 @@
+import { queryOptions } from "@tanstack/react-query";
+import { fetchStack } from "../domain/fetch-stack";
+
+export const stacksQueryKeys = {
+	base: ["stacks"] as const,
+	detail: (stackId: string) =>
+		[...stacksQueryKeys.base, "detail", stackId] as const,
+};
+
+export const stacksQueries = {
+	detail: (stackId: string) =>
+		queryOptions({
+			queryKey: stacksQueryKeys.detail(stackId),
+			queryFn: () => fetchStack(stackId),
+		}),
+};

--- a/src/modules/stacks/domain/fetch-stack.ts
+++ b/src/modules/stacks/domain/fetch-stack.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "@/shared/api/domain/api-client";
+import { expectData } from "@/shared/api/utils/unwrap-api-result";
+import { type Stack, stackFromApiToDomain } from "./stack";
+
+export async function fetchStack(stackId: string): Promise<Stack> {
+	const response = await apiClient.GET("/api/v1/stacks/{stack_id}", {
+		params: {
+			path: { stack_id: stackId },
+			query: { hydrate: true },
+		},
+	});
+	return stackFromApiToDomain(expectData(response));
+}

--- a/src/modules/stacks/domain/stack.spec.ts
+++ b/src/modules/stacks/domain/stack.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { components } from "@/shared/api/openapi";
+import { stackFromApiToDomain } from "./stack";
+
+type StackResponse = components["schemas"]["StackResponse"];
+
+describe("stackFromApiToDomain", () => {
+	it("maps id, name, and components grouped by type", () => {
+		const api = {
+			id: "stack-1",
+			name: "prod-stack",
+			body: {
+				created: "2026-04-22T10:00:00Z",
+				updated: "2026-04-22T10:00:00Z",
+				user_id: null,
+			},
+			metadata: {
+				components: {
+					orchestrator: [
+						{
+							id: "c-orch",
+							name: "k8s-primary",
+							body: {
+								type: "orchestrator",
+								flavor_name: "kubernetes",
+								integration: "kubernetes",
+								logo_url: "https://example/k8s.png",
+							},
+						},
+					],
+					artifact_store: [
+						{
+							id: "c-store",
+							name: "s3-bucket",
+							body: {
+								type: "artifact_store",
+								flavor_name: "s3",
+								integration: "aws",
+								logo_url: null,
+							},
+						},
+					],
+				},
+			},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any as StackResponse;
+
+		const result = stackFromApiToDomain(api);
+		expect(result.id).toBe("stack-1");
+		expect(result.name).toBe("prod-stack");
+		expect(result.components).toEqual([
+			{
+				id: "c-orch",
+				name: "k8s-primary",
+				type: "orchestrator",
+				flavorName: "kubernetes",
+				integration: "kubernetes",
+				logoUrl: "https://example/k8s.png",
+			},
+			{
+				id: "c-store",
+				name: "s3-bucket",
+				type: "artifact_store",
+				flavorName: "s3",
+				integration: "aws",
+				logoUrl: undefined,
+			},
+		]);
+	});
+
+	it("returns an empty components array when metadata is null", () => {
+		const api = {
+			id: "stack-2",
+			name: "minimal",
+			body: {},
+			metadata: null,
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any as StackResponse;
+		expect(stackFromApiToDomain(api).components).toEqual([]);
+	});
+
+	it("skips components whose body is missing (permission-denied shells)", () => {
+		const api = {
+			id: "stack-3",
+			name: "partial",
+			body: {},
+			metadata: {
+				components: {
+					orchestrator: [
+						{
+							id: "c-visible",
+							name: "visible",
+							body: {
+								type: "orchestrator",
+								flavor_name: "kubernetes",
+								integration: "kubernetes",
+								logo_url: null,
+							},
+						},
+						{
+							id: "c-hidden",
+							name: "hidden",
+							body: null,
+						},
+					],
+				},
+			},
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		} as any as StackResponse;
+		expect(stackFromApiToDomain(api).components.map((c) => c.id)).toEqual([
+			"c-visible",
+		]);
+	});
+});

--- a/src/modules/stacks/domain/stack.ts
+++ b/src/modules/stacks/domain/stack.ts
@@ -1,0 +1,43 @@
+import type { components } from "@/shared/api/openapi";
+
+type ComponentResponse = components["schemas"]["ComponentResponse"];
+
+export type StackComponent = {
+	id: string;
+	name: string;
+	type: string;
+	flavorName: string;
+	integration?: string;
+	logoUrl?: string;
+};
+
+export type Stack = {
+	id: string;
+	name: string;
+	components: StackComponent[];
+};
+
+export function stackFromApiToDomain(
+	stack: components["schemas"]["StackResponse"]
+): Stack {
+	const componentsMap = stack.metadata?.components ?? {};
+	const stackComponents: StackComponent[] = [];
+	for (const list of Object.values(componentsMap) as ComponentResponse[][]) {
+		for (const c of list) {
+			if (!c.body) continue;
+			stackComponents.push({
+				id: c.id,
+				name: c.name,
+				type: c.body.type,
+				flavorName: c.body.flavor_name,
+				integration: c.body.integration ?? undefined,
+				logoUrl: c.body.logo_url ?? undefined,
+			});
+		}
+	}
+	return {
+		id: stack.id,
+		name: stack.name,
+		components: stackComponents,
+	};
+}


### PR DESCRIPTION
## Summary

Adds a read-only \`stacks\` module so callers can hydrate \`Stack\` + \`StackComponent\` data from \`GET /api/v1/stacks/{stack_id}?hydrate=true\`. No UI consumers in this PR — this is plumbing for a follow-up PR that renders per-component chips in the flow detail header.

## What's in

- \`src/modules/stacks/domain/stack.ts\` — \`Stack\` + \`StackComponent\` domain types and \`stackFromApiToDomain(stack)\` mapper that flattens \`metadata.components\` (dict grouped by component type) into a single array. Skips permission-denied component shells (no \`body\`).
- \`src/modules/stacks/domain/fetch-stack.ts\` — \`fetchStack(stackId)\` using the openapi-fetch client.
- \`src/modules/stacks/business-logic/stacks-queries.ts\` — \`stacksQueries.detail(stackId)\` TanStack Query options factory.
- Tests: 3 for the mapper (happy path, null metadata, permission-denied skip).

## Test plan

- [x] \`pnpm check:types\` — PASS
- [x] \`pnpm test:unit src/modules/stacks/\` — 3/3