### PR TITLE
feat(flows): deployment-aware header on flow detail page

### DIFF
--- a/src/modules/deployments/business-logic/resolve-deployment.spec.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.spec.ts
@@ -35,17 +35,17 @@ function mkExecution(overrides: Partial<Execution>): Execution {
 const d3 = mkDeployment({
 	id: "snap-3",
 	versionNumber: 3,
-	tags: [{ id: "t1", name: "default", exclusive: true }],
+	tags: [{ id: "t1", name: "default", kind: "default" }],
 });
 const d2 = mkDeployment({
 	id: "snap-2",
 	versionNumber: 2,
-	tags: [{ id: "t2", name: "beta", exclusive: false }],
+	tags: [{ id: "t2", name: "beta", kind: "general" }],
 });
 const d1 = mkDeployment({
 	id: "snap-1",
 	versionNumber: 1,
-	tags: [{ id: "t2", name: "beta", exclusive: false }],
+	tags: [{ id: "t2", name: "beta", kind: "general" }],
 });
 const deployments: Deployment[] = [d1, d3, d2];
 
@@ -74,8 +74,19 @@ describe("resolveDeploymentByVersion", () => {
 });
 
 describe("resolveDeploymentByExclusiveTag", () => {
-	it("returns the deployment whose tag matches by name and is exclusive", () => {
+	it("treats the reserved 'default' tag as exclusive", () => {
 		expect(resolveDeploymentByExclusiveTag(deployments, "default")).toBe(d3);
+	});
+
+	it("resolves a non-default exclusive tag holder", () => {
+		const dCanary = mkDeployment({
+			id: "snap-canary",
+			versionNumber: 4,
+			tags: [{ id: "t3", name: "canary", kind: "exclusive" }],
+		});
+		expect(
+			resolveDeploymentByExclusiveTag([...deployments, dCanary], "canary")
+		).toBe(dCanary);
 	});
 
 	it("returns undefined when the named tag exists but is not exclusive", () => {

--- a/src/modules/deployments/business-logic/resolve-deployment.spec.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.spec.ts
@@ -6,6 +6,7 @@ import {
 	resolveDeploymentByExclusiveTag,
 	resolveDeploymentByVersion,
 	resolveDeploymentForExecution,
+	resolveSelectedDeployment,
 } from "./resolve-deployment";
 
 function mkDeployment(overrides: Partial<Deployment>): Deployment {
@@ -99,6 +100,30 @@ describe("resolveDeploymentByExclusiveTag", () => {
 		expect(
 			resolveDeploymentByExclusiveTag(deployments, "no-such-tag")
 		).toBeUndefined();
+	});
+});
+
+describe("resolveSelectedDeployment", () => {
+	it("returns the deployment matching ?version=N when present", () => {
+		expect(resolveSelectedDeployment(deployments, 2)).toBe(d2);
+	});
+
+	it("falls back to the default-tag holder when ?version=N is not given", () => {
+		expect(resolveSelectedDeployment(deployments, undefined)).toBe(d3);
+	});
+
+	it("falls back to the default-tag holder when ?version=N does not match", () => {
+		expect(resolveSelectedDeployment(deployments, 99)).toBe(d3);
+	});
+
+	it("falls back to the first deployment when no default tag exists", () => {
+		const noDefault = [d1, d2];
+		expect(resolveSelectedDeployment(noDefault, undefined)).toBe(d1);
+	});
+
+	it("returns undefined for an empty list", () => {
+		expect(resolveSelectedDeployment([], undefined)).toBeUndefined();
+		expect(resolveSelectedDeployment([], 1)).toBeUndefined();
 	});
 });
 

--- a/src/modules/deployments/business-logic/resolve-deployment.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.ts
@@ -19,7 +19,10 @@ export function resolveDeploymentByExclusiveTag(
 	tagName: string
 ): Deployment | undefined {
 	return deployments.find((d) =>
-		d.tags.some((t) => t.name === tagName && t.exclusive)
+		d.tags.some(
+			(t) =>
+				t.name === tagName && (t.kind === "exclusive" || t.kind === "default")
+		)
 	);
 }
 

--- a/src/modules/deployments/business-logic/resolve-deployment.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.ts
@@ -26,6 +26,18 @@ export function resolveDeploymentByExclusiveTag(
 	);
 }
 
+export function resolveSelectedDeployment(
+	deployments: Deployment[],
+	version: number | undefined
+): Deployment | undefined {
+	if (deployments.length === 0) return undefined;
+	if (version !== undefined) {
+		const byVersion = resolveDeploymentByVersion(deployments, version);
+		if (byVersion) return byVersion;
+	}
+	return resolveDefaultDeployment(deployments) ?? deployments[0];
+}
+
 export function resolveDeploymentForExecution(
 	execution: Execution,
 	deployments: Deployment[]

--- a/src/modules/deployments/domain/deployment.spec.ts
+++ b/src/modules/deployments/domain/deployment.spec.ts
@@ -84,7 +84,7 @@ describe("deploymentFromApiToDomain", () => {
 		expect(result?.createdAt).toEqual(new Date("2026-04-22T10:00:00Z"));
 	});
 
-	it("derives tag kind: default / exclusive / general", () => {
+	it("decodes kitaru tag names and drops marker + non-kitaru tags", () => {
 		const snapshot = mkSnapshot({
 			resources: {
 				pipeline: {
@@ -98,8 +98,8 @@ describe("deploymentFromApiToDomain", () => {
 				},
 				tags: [
 					{
-						id: "tag-default",
-						name: "default",
+						id: "tag-marker",
+						name: "kitaru:deployment",
 						body: {
 							created: "2026-04-22T10:00:00Z",
 							updated: "2026-04-22T10:00:00Z",
@@ -107,8 +107,17 @@ describe("deploymentFromApiToDomain", () => {
 						},
 					},
 					{
+						id: "tag-default",
+						name: "kitaru:deployment:tag:default:exclusive",
+						body: {
+							created: "2026-04-22T10:00:00Z",
+							updated: "2026-04-22T10:00:00Z",
+							exclusive: true,
+						},
+					},
+					{
 						id: "tag-canary",
-						name: "canary",
+						name: "kitaru:deployment:tag:canary:exclusive",
 						body: {
 							created: "2026-04-22T10:00:00Z",
 							updated: "2026-04-22T10:00:00Z",
@@ -117,7 +126,16 @@ describe("deploymentFromApiToDomain", () => {
 					},
 					{
 						id: "tag-beta",
-						name: "beta",
+						name: "kitaru:deployment:tag:beta:shared",
+						body: {
+							created: "2026-04-22T10:00:00Z",
+							updated: "2026-04-22T10:00:00Z",
+							exclusive: false,
+						},
+					},
+					{
+						id: "tag-foreign",
+						name: "some-zenml-project-tag",
 						body: {
 							created: "2026-04-22T10:00:00Z",
 							updated: "2026-04-22T10:00:00Z",
@@ -171,6 +189,7 @@ describe("deploymentFromApiToDomain", () => {
 			} as any,
 		});
 		const result = deploymentFromApiToDomain(snapshot);
+		expect(result?.stackId).toBe("stack-1");
 		expect(result?.stackName).toBe("prod-stack");
 		expect(result?.latestRunId).toBe("run-99");
 		expect(result?.latestRunStatus).toBe("completed");

--- a/src/modules/deployments/domain/deployment.spec.ts
+++ b/src/modules/deployments/domain/deployment.spec.ts
@@ -84,7 +84,7 @@ describe("deploymentFromApiToDomain", () => {
 		expect(result?.createdAt).toEqual(new Date("2026-04-22T10:00:00Z"));
 	});
 
-	it("maps tags with exclusive flag preserved", () => {
+	it("derives tag kind: default / exclusive / general", () => {
 		const snapshot = mkSnapshot({
 			resources: {
 				pipeline: {
@@ -100,6 +100,15 @@ describe("deploymentFromApiToDomain", () => {
 					{
 						id: "tag-default",
 						name: "default",
+						body: {
+							created: "2026-04-22T10:00:00Z",
+							updated: "2026-04-22T10:00:00Z",
+							exclusive: false,
+						},
+					},
+					{
+						id: "tag-canary",
+						name: "canary",
 						body: {
 							created: "2026-04-22T10:00:00Z",
 							updated: "2026-04-22T10:00:00Z",
@@ -121,8 +130,9 @@ describe("deploymentFromApiToDomain", () => {
 		});
 		const result = deploymentFromApiToDomain(snapshot);
 		expect(result?.tags).toEqual([
-			{ id: "tag-default", name: "default", exclusive: true, color: undefined },
-			{ id: "tag-beta", name: "beta", exclusive: false, color: undefined },
+			{ id: "tag-default", name: "default", kind: "default", color: undefined },
+			{ id: "tag-canary", name: "canary", kind: "exclusive", color: undefined },
+			{ id: "tag-beta", name: "beta", kind: "general", color: undefined },
 		]);
 	});
 

--- a/src/modules/deployments/domain/deployment.ts
+++ b/src/modules/deployments/domain/deployment.ts
@@ -4,10 +4,12 @@ import { parseBackendTimestamp } from "@/shared/utils/time";
 
 export const KITARU_SNAPSHOT_NAME = /^kitaru::(.+)::v(\d+)$/;
 
+export type TagKind = "default" | "exclusive" | "general";
+
 export type DeploymentTag = {
 	id: string;
 	name: string;
-	exclusive: boolean;
+	kind: TagKind;
 	color?: components["schemas"]["ColorVariants"];
 };
 
@@ -37,10 +39,16 @@ export class NotAKitaruDeploymentError extends Error {
 function tagFromApiToDomain(
 	tag: components["schemas"]["TagResponse"]
 ): DeploymentTag {
+	const kind: TagKind =
+		tag.name === "default"
+			? "default"
+			: tag.body?.exclusive
+				? "exclusive"
+				: "general";
 	return {
 		id: tag.id,
 		name: tag.name,
-		exclusive: tag.body?.exclusive ?? false,
+		kind,
 		color: tag.body?.color,
 	};
 }

--- a/src/modules/deployments/domain/deployment.ts
+++ b/src/modules/deployments/domain/deployment.ts
@@ -4,6 +4,9 @@ import { parseBackendTimestamp } from "@/shared/utils/time";
 
 export const KITARU_SNAPSHOT_NAME = /^kitaru::(.+)::v(\d+)$/;
 
+const KITARU_DEPLOYMENT_MARKER_TAG = "kitaru:deployment";
+const KITARU_DEPLOYMENT_TAG = /^kitaru:deployment:tag:(.+):(exclusive|shared)$/;
+
 export type TagKind = "default" | "exclusive" | "general";
 
 export type DeploymentTag = {
@@ -21,6 +24,7 @@ export type Deployment = {
 	tags: DeploymentTag[];
 	createdAt?: Date;
 	updatedAt?: Date;
+	stackId?: string;
 	stackName?: string;
 	inputSchema?: Record<string, unknown>;
 	latestRunId?: string;
@@ -38,16 +42,20 @@ export class NotAKitaruDeploymentError extends Error {
 
 function tagFromApiToDomain(
 	tag: components["schemas"]["TagResponse"]
-): DeploymentTag {
+): DeploymentTag | null {
+	if (tag.name === KITARU_DEPLOYMENT_MARKER_TAG) return null;
+	const match = tag.name.match(KITARU_DEPLOYMENT_TAG);
+	if (!match) return null;
+	const [, userFacingName, mode] = match;
 	const kind: TagKind =
-		tag.name === "default"
+		userFacingName === "default"
 			? "default"
-			: tag.body?.exclusive
+			: mode === "exclusive"
 				? "exclusive"
 				: "general";
 	return {
 		id: tag.id,
-		name: tag.name,
+		name: userFacingName,
 		kind,
 		color: tag.body?.color,
 	};
@@ -69,13 +77,16 @@ export function deploymentFromApiToDomain(
 		flowId: pipeline.id,
 		flowName: pipeline.name,
 		versionNumber,
-		tags: (snapshot.resources?.tags ?? []).map(tagFromApiToDomain),
+		tags: (snapshot.resources?.tags ?? [])
+			.map(tagFromApiToDomain)
+			.filter((t): t is DeploymentTag => t !== null),
 		createdAt: snapshot.body?.created
 			? parseBackendTimestamp(snapshot.body.created)
 			: undefined,
 		updatedAt: snapshot.body?.updated
 			? parseBackendTimestamp(snapshot.body.updated)
 			: undefined,
+		stackId: snapshot.resources?.stack?.id,
 		stackName: snapshot.resources?.stack?.name,
 		inputSchema: snapshot.metadata?.config_schema ?? undefined,
 		latestRunId: snapshot.resources?.latest_run_id ?? undefined,

--- a/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
@@ -1,0 +1,22 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useParams, useSearch } from "@tanstack/react-router";
+import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
+import { deploymentsQueries } from "../business-logic/deployments-queries";
+import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
+import { DeploymentHeader } from "../ui/DeploymentHeader";
+
+export function DeploymentHeaderContainer() {
+	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
+	const { version } = useSearch({
+		from: "/_private/_navbar/flows/$flowId",
+	});
+
+	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
+	const { data: deployments } = useSuspenseQuery(
+		deploymentsQueries.list(flowId)
+	);
+
+	const selected = resolveSelectedDeployment(deployments, version);
+
+	return <DeploymentHeader flowName={flow.name} deployment={selected} />;
+}

--- a/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
@@ -1,6 +1,7 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { useParams, useSearch } from "@tanstack/react-router";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
+import { stacksQueries } from "@/modules/stacks/business-logic/stacks-queries";
 import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
 import { DeploymentHeader } from "../ui/DeploymentHeader";
@@ -18,5 +19,16 @@ export function DeploymentHeaderContainer() {
 
 	const selected = resolveSelectedDeployment(deployments, version);
 
-	return <DeploymentHeader flowName={flow.name} deployment={selected} />;
+	const { data: stack } = useQuery({
+		...stacksQueries.detail(selected?.stackId ?? ""),
+		enabled: Boolean(selected?.stackId),
+	});
+
+	return (
+		<DeploymentHeader
+			flowName={flow.name}
+			deployment={selected}
+			stackComponents={stack?.components}
+		/>
+	);
 }

--- a/src/modules/deployments/ui/DeploymentHeader.tsx
+++ b/src/modules/deployments/ui/DeploymentHeader.tsx
@@ -1,14 +1,20 @@
+import type React from "react";
 import { Separator } from "@/shared/ui/separator";
 import { cn } from "@/shared/utils/styles";
 import type { Deployment } from "../domain/deployment";
+import type { StackComponent } from "@/modules/stacks/domain/stack";
 import { DeploymentTagChip } from "./DeploymentTagChip";
 
 export function DeploymentHeader({
 	flowName,
 	deployment,
+	stackComponents,
+	invokeSlot,
 }: {
 	flowName: string;
 	deployment?: Deployment;
+	stackComponents?: StackComponent[];
+	invokeSlot?: React.ReactNode;
 }) {
 	const isDefault = deployment?.tags.some((t) => t.kind === "default") ?? false;
 	const hasTags = (deployment?.tags.length ?? 0) > 0;
@@ -47,15 +53,18 @@ export function DeploymentHeader({
 						</>
 					)}
 
-					{!deployment && (
-						<span className="text-muted-foreground ml-auto text-xs">
-							No deployments yet
-						</span>
-					)}
+					<div className="ml-auto flex items-center gap-2">
+						{!deployment && (
+							<span className="text-muted-foreground text-xs">
+								No deployments yet
+							</span>
+						)}
+						{invokeSlot}
+					</div>
 				</div>
 
 				{deployment?.stackName && (
-					<div className="mt-3 flex items-center gap-2">
+					<div className="mt-3 flex flex-wrap items-center gap-2">
 						<span
 							className={cn(
 								"text-2xs font-semibold tracking-wider uppercase",
@@ -64,15 +73,39 @@ export function DeploymentHeader({
 						>
 							Stack
 						</span>
-						<span
-							className={cn(
-								"inline-flex h-6 items-center rounded-md px-2",
-								"border-border bg-card border",
-								"text-foreground font-mono text-xs"
-							)}
-						>
-							{deployment.stackName}
-						</span>
+						{stackComponents && stackComponents.length > 0 ? (
+							stackComponents.map((c) => (
+								<span
+									key={c.id}
+									className={cn(
+										"inline-flex h-6 items-center gap-1.5 rounded-md px-2",
+										"border-border bg-card border",
+										"text-foreground font-mono text-xs"
+									)}
+									title={`${c.type}: ${c.flavorName}`}
+								>
+									{c.logoUrl && (
+										<img
+											src={c.logoUrl}
+											alt=""
+											className="size-3.5 shrink-0"
+											aria-hidden
+										/>
+									)}
+									<span className="truncate">{c.flavorName}</span>
+								</span>
+							))
+						) : (
+							<span
+								className={cn(
+									"inline-flex h-6 items-center rounded-md px-2",
+									"border-border bg-card border",
+									"text-foreground font-mono text-xs"
+								)}
+							>
+								{deployment.stackName}
+							</span>
+						)}
 					</div>
 				)}
 			</div>

--- a/src/modules/deployments/ui/DeploymentHeader.tsx
+++ b/src/modules/deployments/ui/DeploymentHeader.tsx
@@ -1,0 +1,81 @@
+import { Separator } from "@/shared/ui/separator";
+import { cn } from "@/shared/utils/styles";
+import type { Deployment } from "../domain/deployment";
+import { DeploymentTagChip } from "./DeploymentTagChip";
+
+export function DeploymentHeader({
+	flowName,
+	deployment,
+}: {
+	flowName: string;
+	deployment?: Deployment;
+}) {
+	const isDefault = deployment?.tags.some((t) => t.kind === "default") ?? false;
+	const hasTags = (deployment?.tags.length ?? 0) > 0;
+
+	return (
+		<section className="bg-secondary border-border border-b">
+			<div className="px-8 pt-5 pb-4">
+				<div className="flex flex-wrap items-center gap-3">
+					<h1 className="text-foreground inline-flex min-w-0 flex-wrap items-baseline gap-2 font-mono text-lg font-semibold">
+						<span className="truncate">{flowName}</span>
+						{deployment && (
+							<>
+								<span className="text-muted-foreground" aria-hidden>
+									·
+								</span>
+								<span className="text-foreground">
+									v{deployment.versionNumber}
+								</span>
+							</>
+						)}
+						{isDefault && (
+							<span className="text-muted-foreground text-xs font-normal">
+								(default)
+							</span>
+						)}
+					</h1>
+
+					{deployment && hasTags && (
+						<>
+							<Separator orientation="vertical" className="h-5" />
+							<div className="flex min-w-0 flex-wrap items-center gap-1">
+								{deployment.tags.map((t) => (
+									<DeploymentTagChip key={t.id} tag={t} size="sm" />
+								))}
+							</div>
+						</>
+					)}
+
+					{!deployment && (
+						<span className="text-muted-foreground ml-auto text-xs">
+							No deployments yet
+						</span>
+					)}
+				</div>
+
+				{deployment?.stackName && (
+					<div className="mt-3 flex items-center gap-2">
+						<span
+							className={cn(
+								"text-2xs font-semibold tracking-wider uppercase",
+								"text-muted-foreground shrink-0"
+							)}
+						>
+							Stack
+						</span>
+						<span
+							className={cn(
+								"inline-flex h-6 items-center rounded-md px-2",
+								"border-border bg-card border",
+								"text-foreground font-mono text-xs"
+							)}
+						>
+							{deployment.stackName}
+						</span>
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/src/modules/deployments/ui/DeploymentTagChip.tsx
+++ b/src/modules/deployments/ui/DeploymentTagChip.tsx
@@ -1,0 +1,53 @@
+import { Lock, Pin, Tag } from "lucide-react";
+import { cn } from "@/shared/utils/styles";
+import type { DeploymentTag, TagKind } from "../domain/deployment";
+
+type Size = "sm" | "md";
+
+const kindStyles: Record<TagKind, { shell: string; icon: typeof Lock }> = {
+	default: {
+		shell: "bg-primary/15 text-primary font-semibold",
+		icon: Lock,
+	},
+	exclusive: {
+		shell: "bg-accent text-accent-foreground border border-border",
+		icon: Pin,
+	},
+	general: {
+		shell: "bg-transparent text-muted-foreground border border-border",
+		icon: Tag,
+	},
+};
+
+const sizeStyles: Record<Size, { shell: string; icon: string }> = {
+	sm: { shell: "h-5 text-2xs", icon: "size-2.5" },
+	md: { shell: "h-[22px] text-2xs", icon: "size-3" },
+};
+
+const shellBase =
+	"inline-flex items-center gap-1 px-1.5 rounded font-mono uppercase tracking-wider";
+
+export function DeploymentTagChip({
+	tag,
+	size = "md",
+	className,
+}: {
+	tag: DeploymentTag;
+	size?: Size;
+	className?: string;
+}) {
+	const Icon = kindStyles[tag.kind].icon;
+	return (
+		<span
+			className={cn(
+				shellBase,
+				kindStyles[tag.kind].shell,
+				sizeStyles[size].shell,
+				className
+			)}
+		>
+			<Icon className={cn("shrink-0", sizeStyles[size].icon)} aria-hidden />
+			<span className="leading-none">{tag.name}</span>
+		</span>
+	);
+}

--- a/src/routes/_private/_navbar/flows/$flowId/route.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/route.tsx
@@ -1,13 +1,38 @@
+import { deploymentsQueries } from "@/modules/deployments/business-logic/deployments-queries";
+import { DeploymentHeaderContainer } from "@/modules/deployments/feature/DeploymentHeaderContainer";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { ensureQueryDataOr404 } from "@/shared/api/utils/handle-404";
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import {
+	createFileRoute,
+	Outlet,
+	type SearchSchemaInput,
+} from "@tanstack/react-router";
+import { z } from "zod";
+
+const flowSearchSchema = z.object({
+	version: z.coerce.number().int().positive().optional(),
+});
+
+type FlowSearchSchemaInput = SearchSchemaInput & { version?: number };
+
+function FlowRoute() {
+	return (
+		<>
+			<DeploymentHeaderContainer />
+			<Outlet />
+		</>
+	);
+}
 
 export const Route = createFileRoute("/_private/_navbar/flows/$flowId")({
-	component: () => <Outlet />,
+	validateSearch: (search: FlowSearchSchemaInput) =>
+		flowSearchSchema.parse(search),
+	component: FlowRoute,
 	loader: async ({ context, params }) => {
 		const flow = await ensureQueryDataOr404(
 			context.queryClient.ensureQueryData(flowsQueries.detail(params.flowId))
 		);
+		context.queryClient.ensureQueryData(deploymentsQueries.list(params.flowId));
 
 		return {
 			flowName: flow.name,


### PR DESCRIPTION
## Summary

Renders a deployment-aware header at the top of the Flow detail page: **flow name · v{N}** with optional default marker, decoded tag chips (default/exclusive/general with Lock/Pin/Tag icons), and a stack-components row (uses the \`stacks\` data layer from #153). The selected deployment is driven by an optional \`?version=N\` URL search param with a deterministic fallback chain (version match → default tag holder → first deployment).

## What's in

**Domain:**
- \`TagKind = "default" | "exclusive" | "general"\` discriminator on \`DeploymentTag\`. Mapper decodes the backend's \`kitaru:deployment:tag:<name>:<mode>\` tag-name encoding into a user-facing name + kind, and filters out the \`kitaru:deployment\` marker tag.
- \`stackId\` added to the \`Deployment\` domain (for the stack fetch below).

**Business logic:**
- \`resolveSelectedDeployment(deployments, version)\` selector with the fallback chain.
- \`resolveDeploymentByExclusiveTag\` updated to use the new \`kind\` discriminator (default tag is always treated as exclusive).

**Routing:**
- \`$flowId\` route gains \`validateSearch\` for \`version?: number\` and fire-and-forget prewarms the deployments list so the header doesn't wait in the loader.

**UI:**
- \`DeploymentTagChip\` — read-only chip with Lock/Pin/Tag icon per kind, size sm|md.
- \`DeploymentHeader\` — layout primitive: \`<flowName> · v{N} [(default)] · tag chips · stack-components row\`.
- \`DeploymentHeaderContainer\` feature — orchestrates flow + deployments + stack queries and renders the header. Stack fetch is non-suspense so it never blocks the header.

## Non-goals

- No URL / snippets / Invoke button yet — that's the next slice.
- No Executions tab split; Overview is still the executions table.

## Commits (6)

- \`d98b0d1\` replace exclusive boolean with TagKind discriminator
- \`3eff32e\` expose stackId on Deployment (the "Stack domain" portion of the original commit is already upstream via #153; this PR's diff for this commit is only the Deployment.stackId addition)
- \`13bcbaf\` add resolveSelectedDeployment + header UI primitives (DeploymentTagChip, DeploymentHeader)
- \`9793d3c\` render deployment header with ?version on flow detail (route schema + DeploymentHeaderContainer)
- \`e00ea2d\` render stack-component chips in header
- \`307dbb4\` load stack components for header chips (DeploymentHeaderContainer fetches via stacksQueries)

## Test plan

- [x] \`pnpm check:types\` — PASS
- [x] \`pnpm test:unit\` — 284/284
- [ ] Manual: open a flow with a Kitaru deployment — header shows flow · v{N} (default) with decoded tag chips (e.g. \`default\` with Lock icon)
- [ ] Manual: append \`?version=2\` to the URL — header switches to v2 and renders v2's tags
- [ ] Manual: flow with no Kitaru deployments — header shows flow name + "No deployments yet"
- [ ] Manual: flow where the deployment's stack is hydrated — stack row renders per-component chips with their logos/flavors