### PR TITLE
refactor(stacks): narrow StackComponent.type to OpenAPI union

### DIFF
--- a/src/modules/stacks/domain/stack.ts
+++ b/src/modules/stacks/domain/stack.ts
@@ -1,11 +1,12 @@
 import type { components } from "@/shared/api/openapi";
 
 type ComponentResponse = components["schemas"]["ComponentResponse"];
+export type StackComponentType = components["schemas"]["StackComponentType"];
 
 export type StackComponent = {
 	id: string;
 	name: string;
-	type: string;
+	type: StackComponentType;
 	flavorName: string;
 	integration?: string;
 	logoUrl?: string;


### PR DESCRIPTION
Follow-up to #153 addressing the highest-leverage type review finding.

## Summary

Narrow `StackComponent.type` from plain `string` to the `StackComponentType` OpenAPI string-literal union (14 known component kinds). The mapper already received the narrow type at `c.body.type` — we were widening it for no reason. Brings this module in line with `Checkpoint.type` and `DeploymentTag.color`, which both preserve their OpenAPI unions.

Also exports `StackComponentType` so consumers can import it without reaching into the OpenAPI tree.

## Test plan

- [x] `pnpm check:types` — PASS
- [x] `pnpm test:unit src/modules/stacks/` — 3/3