### PR TITLE
feat(flows): invoke drawer + version switcher + local deployment view

### DIFF
--- a/src/modules/deployments/business-logic/resolve-deployment.spec.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.spec.ts
@@ -125,6 +125,21 @@ describe("resolveSelectedDeployment", () => {
 		expect(resolveSelectedDeployment([], undefined)).toBeUndefined();
 		expect(resolveSelectedDeployment([], 1)).toBeUndefined();
 	});
+
+	it("selects the synthetic local deployment when version === 'local' and it exists in the list", () => {
+		const local = mkDeployment({
+			id: "local",
+			versionNumber: 0,
+			tags: [],
+		});
+		expect(resolveSelectedDeployment([...deployments, local], "local")).toBe(
+			local
+		);
+	});
+
+	it("falls back to the default-tag holder when version === 'local' but the local entry isn't present", () => {
+		expect(resolveSelectedDeployment(deployments, "local")).toBe(d3);
+	});
 });
 
 describe("resolveDeploymentForExecution", () => {

--- a/src/modules/deployments/business-logic/resolve-deployment.spec.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Deployment } from "../domain/deployment";
+import {
+	LOCAL_VERSION_ID,
+	withLocalDeployment,
+} from "../domain/local-deployment";
 import type { Execution } from "@/modules/executions/domain/execution";
 import {
 	resolveDefaultDeployment,
@@ -124,6 +128,7 @@ describe("resolveSelectedDeployment", () => {
 	it("returns undefined for an empty list", () => {
 		expect(resolveSelectedDeployment([], undefined)).toBeUndefined();
 		expect(resolveSelectedDeployment([], 1)).toBeUndefined();
+		expect(resolveSelectedDeployment([], LOCAL_VERSION_ID)).toBeUndefined();
 	});
 
 	it("selects the synthetic local deployment when version === 'local' and it exists in the list", () => {
@@ -138,7 +143,17 @@ describe("resolveSelectedDeployment", () => {
 	});
 
 	it("falls back to the default-tag holder when version === 'local' but the local entry isn't present", () => {
-		expect(resolveSelectedDeployment(deployments, "local")).toBe(d3);
+		expect(resolveSelectedDeployment(deployments, LOCAL_VERSION_ID)).toBe(d3);
+	});
+
+	it("resolves the synthetic local entry produced by withLocalDeployment", () => {
+		const withLocal = withLocalDeployment(
+			deployments,
+			"flow-1",
+			"research_agent"
+		);
+		const selected = resolveSelectedDeployment(withLocal, LOCAL_VERSION_ID);
+		expect(selected?.id).toBe(LOCAL_VERSION_ID);
 	});
 });
 

--- a/src/modules/deployments/business-logic/resolve-deployment.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.ts
@@ -1,5 +1,9 @@
 import type { Execution } from "@/modules/executions/domain/execution";
 import type { Deployment } from "../domain/deployment";
+import {
+	isLocalDeployment,
+	LOCAL_VERSION_ID,
+} from "../domain/local-deployment";
 
 export function resolveDefaultDeployment(
 	deployments: Deployment[]
@@ -28,11 +32,11 @@ export function resolveDeploymentByExclusiveTag(
 
 export function resolveSelectedDeployment(
 	deployments: Deployment[],
-	version: number | "local" | undefined
+	version: number | typeof LOCAL_VERSION_ID | undefined
 ): Deployment | undefined {
 	if (deployments.length === 0) return undefined;
-	if (version === "local") {
-		const local = deployments.find((d) => d.id === "local");
+	if (version === LOCAL_VERSION_ID) {
+		const local = deployments.find(isLocalDeployment);
 		if (local) return local;
 	} else if (version !== undefined) {
 		const byVersion = resolveDeploymentByVersion(deployments, version);

--- a/src/modules/deployments/business-logic/resolve-deployment.ts
+++ b/src/modules/deployments/business-logic/resolve-deployment.ts
@@ -28,10 +28,13 @@ export function resolveDeploymentByExclusiveTag(
 
 export function resolveSelectedDeployment(
 	deployments: Deployment[],
-	version: number | undefined
+	version: number | "local" | undefined
 ): Deployment | undefined {
 	if (deployments.length === 0) return undefined;
-	if (version !== undefined) {
+	if (version === "local") {
+		const local = deployments.find((d) => d.id === "local");
+		if (local) return local;
+	} else if (version !== undefined) {
 		const byVersion = resolveDeploymentByVersion(deployments, version);
 		if (byVersion) return byVersion;
 	}

--- a/src/modules/deployments/business-logic/use-invoke-deployment.spec.tsx
+++ b/src/modules/deployments/business-logic/use-invoke-deployment.spec.tsx
@@ -1,0 +1,90 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executionsQueryKeys } from "@/modules/executions/business-logic/executions-queries";
+import { invokeDeployment } from "../domain/invoke-deployment";
+import { useInvokeDeployment } from "./use-invoke-deployment";
+
+vi.mock("../domain/invoke-deployment", () => ({
+	invokeDeployment: vi.fn(),
+}));
+
+const mockedInvokeDeployment = vi.mocked(invokeDeployment);
+
+function createWrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+}
+
+describe("useInvokeDeployment", () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: {
+				queries: { retry: false },
+				mutations: { retry: false },
+			},
+		});
+		mockedInvokeDeployment.mockResolvedValue({ runId: "run-1" });
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+		queryClient.clear();
+	});
+
+	it("invalidates both executions query keys on success", async () => {
+		const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useInvokeDeployment("flow-1"), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		result.current.invokeDeployment({
+			snapshotId: "snap-1",
+			parameters: {},
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		const invalidatedKeys = invalidateSpy.mock.calls.map(
+			(call) => call[0]?.queryKey
+		);
+		expect(invalidatedKeys).toContainEqual(executionsQueryKeys.all("flow-1"));
+		expect(invalidatedKeys).toContainEqual(
+			executionsQueryKeys.listWithSnapshots("flow-1")
+		);
+	});
+
+	it("calls the caller-provided onSuccess after invalidation", async () => {
+		const onSuccess = vi.fn();
+		const { result } = renderHook(
+			() => useInvokeDeployment("flow-1", { onSuccess }),
+			{ wrapper: createWrapper(queryClient) }
+		);
+
+		result.current.invokeDeployment({
+			snapshotId: "snap-1",
+			parameters: { topic: "hi" },
+		});
+
+		await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+		expect(onSuccess.mock.calls[0][0]).toEqual({ runId: "run-1" });
+		expect(onSuccess.mock.calls[0][1]).toEqual({
+			snapshotId: "snap-1",
+			parameters: { topic: "hi" },
+		});
+	});
+
+	it("exposes invokeDeployment and invokeDeploymentAsync aliases", () => {
+		const { result } = renderHook(() => useInvokeDeployment("flow-1"), {
+			wrapper: createWrapper(queryClient),
+		});
+		expect(typeof result.current.invokeDeployment).toBe("function");
+		expect(typeof result.current.invokeDeploymentAsync).toBe("function");
+	});
+});

--- a/src/modules/deployments/business-logic/use-invoke-deployment.ts
+++ b/src/modules/deployments/business-logic/use-invoke-deployment.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { executionsQueryKeys } from "@/modules/executions/business-logic/executions-queries";
+import { invokeDeployment } from "../domain/invoke-deployment";
+
+export function useInvokeDeployment(flowId: string) {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: invokeDeployment,
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: executionsQueryKeys.all(flowId),
+			});
+			queryClient.invalidateQueries({
+				queryKey: executionsQueryKeys.listWithSnapshots(flowId),
+			});
+		},
+	});
+}

--- a/src/modules/deployments/business-logic/use-invoke-deployment.ts
+++ b/src/modules/deployments/business-logic/use-invoke-deployment.ts
@@ -1,18 +1,46 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { FetchError } from "@/shared/api/domain/fetch-error";
+import {
+	useMutation,
+	type UseMutationOptions,
+	useQueryClient,
+} from "@tanstack/react-query";
 import { executionsQueryKeys } from "@/modules/executions/business-logic/executions-queries";
-import { invokeDeployment } from "../domain/invoke-deployment";
+import {
+	invokeDeployment,
+	type InvokeDeploymentArgs,
+	type InvokeDeploymentResult,
+} from "../domain/invoke-deployment";
 
-export function useInvokeDeployment(flowId: string) {
+export function useInvokeDeployment(
+	flowId: string,
+	options?: Omit<
+		UseMutationOptions<
+			InvokeDeploymentResult,
+			FetchError,
+			InvokeDeploymentArgs,
+			unknown
+		>,
+		"mutationFn"
+	>
+) {
 	const queryClient = useQueryClient();
-	return useMutation({
+	const mutation = useMutation({
+		...options,
 		mutationFn: invokeDeployment,
-		onSuccess: () => {
+		onSuccess: (...args) => {
 			queryClient.invalidateQueries({
 				queryKey: executionsQueryKeys.all(flowId),
 			});
 			queryClient.invalidateQueries({
 				queryKey: executionsQueryKeys.listWithSnapshots(flowId),
 			});
+			options?.onSuccess?.(...args);
 		},
 	});
+
+	return {
+		...mutation,
+		invokeDeployment: mutation.mutate,
+		invokeDeploymentAsync: mutation.mutateAsync,
+	};
 }

--- a/src/modules/deployments/business-logic/use-selected-version.ts
+++ b/src/modules/deployments/business-logic/use-selected-version.ts
@@ -1,0 +1,30 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useParams, useSearch } from "@tanstack/react-router";
+import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
+import type { Flow } from "@/modules/flows/domain/flow";
+import type { Deployment } from "../domain/deployment";
+import { withLocalDeployment } from "../domain/local-deployment";
+import { deploymentsQueries } from "./deployments-queries";
+import { resolveSelectedDeployment } from "./resolve-deployment";
+
+export type UseSelectedVersionResult = {
+	flowId: string;
+	flow: Flow;
+	realDeployments: Deployment[];
+	deployments: Deployment[];
+	selected: Deployment | undefined;
+};
+
+export function useSelectedVersion(): UseSelectedVersionResult {
+	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
+	const { version } = useSearch({
+		from: "/_private/_navbar/flows/$flowId",
+	});
+	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
+	const { data: realDeployments } = useSuspenseQuery(
+		deploymentsQueries.list(flowId)
+	);
+	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
+	const selected = resolveSelectedDeployment(deployments, version);
+	return { flowId, flow, realDeployments, deployments, selected };
+}

--- a/src/modules/deployments/domain/invoke-deployment.spec.ts
+++ b/src/modules/deployments/domain/invoke-deployment.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { invokeDeployment } from "./invoke-deployment";
+
+describe("invokeDeployment", () => {
+	it("POSTs { run_configuration: { parameters } } to /pipeline_snapshots/{id}/runs and returns run id on success", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(
+				new Response(JSON.stringify({ id: "run-42" }), { status: 200 })
+			);
+		const result = await invokeDeployment({
+			snapshotId: "snap-1",
+			parameters: { topic: "hi" },
+		});
+		expect(result).toEqual({ runId: "run-42" });
+		const [url, init] = fetchSpy.mock.calls[0];
+		expect(url).toMatch(/\/api\/v1\/pipeline_snapshots\/snap-1\/runs$/);
+		expect(init?.method).toBe("POST");
+		expect(init?.credentials).toBe("include");
+		expect(JSON.parse(String(init?.body))).toEqual({
+			run_configuration: { parameters: { topic: "hi" } },
+		});
+		fetchSpy.mockRestore();
+	});
+
+	it("throws with the server message when the response is not ok", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ detail: "bad params" }), { status: 400 })
+		);
+		await expect(
+			invokeDeployment({ snapshotId: "snap-1", parameters: {} })
+		).rejects.toThrow(/bad params/);
+	});
+});

--- a/src/modules/deployments/domain/invoke-deployment.spec.ts
+++ b/src/modules/deployments/domain/invoke-deployment.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { FetchError } from "@/shared/api/domain/fetch-error";
 import { invokeDeployment } from "./invoke-deployment";
 
 describe("invokeDeployment", () => {
@@ -23,12 +24,77 @@ describe("invokeDeployment", () => {
 		fetchSpy.mockRestore();
 	});
 
-	it("throws with the server message when the response is not ok", async () => {
+	it("sets Content-Type and Source-Context headers on every request", async () => {
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(
+				new Response(JSON.stringify({ id: "run-1" }), { status: 200 })
+			);
+		await invokeDeployment({ snapshotId: "snap-1", parameters: {} });
+		const headers = fetchSpy.mock.calls[0][1]?.headers as Record<
+			string,
+			string
+		>;
+		expect(headers["Content-Type"]).toBe("application/json");
+		expect(headers["Source-Context"]).toBe("kitaru-ui");
+		fetchSpy.mockRestore();
+	});
+
+	it("throws FetchError with the server detail when the response is not ok", async () => {
 		vi.spyOn(globalThis, "fetch").mockResolvedValue(
 			new Response(JSON.stringify({ detail: "bad params" }), { status: 400 })
 		);
 		await expect(
 			invokeDeployment({ snapshotId: "snap-1", parameters: {} })
-		).rejects.toThrow(/bad params/);
+		).rejects.toMatchObject({
+			name: "FetchError",
+			status: 400,
+			message: "bad params",
+		});
+	});
+
+	it("includes the raw body in the error message when the error response is not JSON", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response("<html>502 Bad Gateway</html>", { status: 502 })
+		);
+		await expect(
+			invokeDeployment({ snapshotId: "snap-1", parameters: {} })
+		).rejects.toThrow(/502 Bad Gateway/);
+	});
+
+	it("stringifies the payload when detail is not a string", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({ detail: { code: "E_FOO" } }), {
+				status: 400,
+			})
+		);
+		await expect(
+			invokeDeployment({ snapshotId: "snap-1", parameters: {} })
+		).rejects.toThrow(/E_FOO/);
+	});
+
+	it("wraps network errors as FetchError with status 0", async () => {
+		vi.spyOn(globalThis, "fetch").mockRejectedValue(
+			new TypeError("Failed to fetch")
+		);
+		const error = await invokeDeployment({
+			snapshotId: "snap-1",
+			parameters: {},
+		}).catch((e) => e);
+		expect(error).toBeInstanceOf(FetchError);
+		expect(error.status).toBe(0);
+		expect(error.statusText).toBe("REQUEST_FAILED");
+	});
+
+	it("throws when the success response is missing a run id", async () => {
+		vi.spyOn(globalThis, "fetch").mockResolvedValue(
+			new Response(JSON.stringify({}), { status: 200 })
+		);
+		await expect(
+			invokeDeployment({ snapshotId: "snap-1", parameters: {} })
+		).rejects.toMatchObject({
+			name: "FetchError",
+			statusText: "INVALID_INVOKE_RESPONSE",
+		});
 	});
 });

--- a/src/modules/deployments/domain/invoke-deployment.ts
+++ b/src/modules/deployments/domain/invoke-deployment.ts
@@ -1,5 +1,7 @@
 import { env } from "@/modules/root/domain/env";
+import { FetchError } from "@/shared/api/domain/fetch-error";
 import { getCsrfToken } from "@/shared/api/utils/csrf-token-cookie";
+import { isRecord } from "@/shared/utils/is-record";
 
 export type InvokeDeploymentArgs = {
 	snapshotId: string;
@@ -14,30 +16,81 @@ export async function invokeDeployment({
 }: InvokeDeploymentArgs): Promise<InvokeDeploymentResult> {
 	const origin = env.VITE_API_BASE_URL || "";
 	const url = `${origin}/api/v1/pipeline_snapshots/${snapshotId}/runs`;
+	const method = "POST";
 	const csrfToken = getCsrfToken();
-	const response = await fetch(url, {
-		method: "POST",
-		credentials: "include",
-		headers: {
-			"Content-Type": "application/json",
-			"Source-Context": "kitaru-ui",
-			...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
-		},
-		body: JSON.stringify({ run_configuration: { parameters } }),
-	});
-	if (!response.ok) {
-		let detail: string;
-		try {
-			const payload = (await response.json()) as { detail?: unknown };
-			detail =
-				typeof payload.detail === "string"
-					? payload.detail
-					: JSON.stringify(payload);
-		} catch {
-			detail = await response.text();
-		}
-		throw new Error(`Invoke failed (${response.status}): ${detail}`);
+
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method,
+			credentials: "include",
+			headers: {
+				"Content-Type": "application/json",
+				"Source-Context": "kitaru-ui",
+				...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+			},
+			body: JSON.stringify({ run_configuration: { parameters } }),
+		});
+	} catch (error) {
+		throw new FetchError({
+			status: 0,
+			statusText: "REQUEST_FAILED",
+			message: "Request failed before receiving a response",
+			url,
+			method,
+			cause: error,
+		});
 	}
-	const body = (await response.json()) as { id: string };
-	return { runId: body.id };
+
+	const rawBody = await response.text();
+	const parsed = safeJsonParse(rawBody);
+
+	if (!response.ok) {
+		throw new FetchError({
+			status: response.status,
+			statusText: response.statusText,
+			message: extractErrorMessage(parsed, rawBody, response.status),
+			details: parsed ?? rawBody,
+			url,
+			method,
+		});
+	}
+
+	const runId =
+		isRecord(parsed) && typeof parsed.id === "string" ? parsed.id : undefined;
+	if (!runId) {
+		throw new FetchError({
+			status: response.status,
+			statusText: "INVALID_INVOKE_RESPONSE",
+			message: "Invoke response missing run id",
+			details: parsed ?? rawBody,
+			url,
+			method,
+		});
+	}
+
+	return { runId };
+}
+
+function safeJsonParse(text: string): unknown {
+	if (!text) return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
+}
+
+function extractErrorMessage(
+	parsed: unknown,
+	rawBody: string,
+	status: number
+): string {
+	if (isRecord(parsed)) {
+		const detail = parsed.detail;
+		if (typeof detail === "string" && detail.trim().length > 0) return detail;
+		return `Invoke failed (${status}): ${JSON.stringify(parsed)}`;
+	}
+	if (rawBody.trim().length > 0) return `Invoke failed (${status}): ${rawBody}`;
+	return `Invoke failed (${status})`;
 }

--- a/src/modules/deployments/domain/invoke-deployment.ts
+++ b/src/modules/deployments/domain/invoke-deployment.ts
@@ -1,0 +1,43 @@
+import { env } from "@/modules/root/domain/env";
+import { getCsrfToken } from "@/shared/api/utils/csrf-token-cookie";
+
+export type InvokeDeploymentArgs = {
+	snapshotId: string;
+	parameters: Record<string, unknown>;
+};
+
+export type InvokeDeploymentResult = { runId: string };
+
+export async function invokeDeployment({
+	snapshotId,
+	parameters,
+}: InvokeDeploymentArgs): Promise<InvokeDeploymentResult> {
+	const origin = env.VITE_API_BASE_URL || "";
+	const url = `${origin}/api/v1/pipeline_snapshots/${snapshotId}/runs`;
+	const csrfToken = getCsrfToken();
+	const response = await fetch(url, {
+		method: "POST",
+		credentials: "include",
+		headers: {
+			"Content-Type": "application/json",
+			"Source-Context": "kitaru-ui",
+			...(csrfToken ? { "X-CSRF-Token": csrfToken } : {}),
+		},
+		body: JSON.stringify({ run_configuration: { parameters } }),
+	});
+	if (!response.ok) {
+		let detail: string;
+		try {
+			const payload = (await response.json()) as { detail?: unknown };
+			detail =
+				typeof payload.detail === "string"
+					? payload.detail
+					: JSON.stringify(payload);
+		} catch {
+			detail = await response.text();
+		}
+		throw new Error(`Invoke failed (${response.status}): ${detail}`);
+	}
+	const body = (await response.json()) as { id: string };
+	return { runId: body.id };
+}

--- a/src/modules/deployments/domain/local-deployment.spec.ts
+++ b/src/modules/deployments/domain/local-deployment.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import type { Deployment } from "./deployment";
+import {
+	buildLocalDeployment,
+	isLocalDeployment,
+	LOCAL_VERSION_ID,
+	withLocalDeployment,
+} from "./local-deployment";
+
+function mkDeployment(overrides: Partial<Deployment> = {}): Deployment {
+	return {
+		id: "snap-1",
+		flowId: "flow-1",
+		flowName: "research_agent",
+		versionNumber: 1,
+		tags: [],
+		runnable: true,
+		deployable: true,
+		...overrides,
+	};
+}
+
+describe("buildLocalDeployment", () => {
+	it("produces a deployment whose id equals LOCAL_VERSION_ID", () => {
+		const local = buildLocalDeployment("flow-1", "research_agent");
+		expect(local.id).toBe(LOCAL_VERSION_ID);
+		expect(local.flowId).toBe("flow-1");
+		expect(local.flowName).toBe("research_agent");
+		expect(local.tags).toEqual([]);
+		expect(local.runnable).toBe(false);
+		expect(local.deployable).toBe(false);
+	});
+});
+
+describe("isLocalDeployment", () => {
+	it("returns true for the synthetic local deployment", () => {
+		expect(
+			isLocalDeployment(buildLocalDeployment("flow-1", "research_agent"))
+		).toBe(true);
+	});
+
+	it("returns false for a real deployment", () => {
+		expect(isLocalDeployment(mkDeployment())).toBe(false);
+	});
+
+	it("returns false for undefined", () => {
+		expect(isLocalDeployment(undefined)).toBe(false);
+	});
+});
+
+describe("withLocalDeployment", () => {
+	it("appends the synthetic local entry to the real deployments list", () => {
+		const real = [mkDeployment()];
+		const result = withLocalDeployment(real, "flow-1", "research_agent");
+		expect(result).toHaveLength(2);
+		expect(result[0]).toBe(real[0]);
+		expect(result[1].id).toBe(LOCAL_VERSION_ID);
+	});
+
+	it("works with an empty deployments list", () => {
+		const result = withLocalDeployment([], "flow-1", "research_agent");
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe(LOCAL_VERSION_ID);
+	});
+});

--- a/src/modules/deployments/domain/local-deployment.ts
+++ b/src/modules/deployments/domain/local-deployment.ts
@@ -1,0 +1,30 @@
+import type { Deployment } from "./deployment";
+
+export const LOCAL_VERSION_ID = "local";
+
+export function buildLocalDeployment(
+	flowId: string,
+	flowName: string
+): Deployment {
+	return {
+		id: LOCAL_VERSION_ID,
+		flowId,
+		flowName,
+		versionNumber: 0,
+		tags: [],
+		runnable: false,
+		deployable: false,
+	};
+}
+
+export function isLocalDeployment(deployment: Deployment | undefined): boolean {
+	return deployment?.id === LOCAL_VERSION_ID;
+}
+
+export function withLocalDeployment(
+	deployments: Deployment[],
+	flowId: string,
+	flowName: string
+): Deployment[] {
+	return [...deployments, buildLocalDeployment(flowId, flowName)];
+}

--- a/src/modules/deployments/domain/local-deployment.ts
+++ b/src/modules/deployments/domain/local-deployment.ts
@@ -2,10 +2,16 @@ import type { Deployment } from "./deployment";
 
 export const LOCAL_VERSION_ID = "local";
 
+export type LocalDeployment = Deployment & {
+	id: typeof LOCAL_VERSION_ID;
+	runnable: false;
+	deployable: false;
+};
+
 export function buildLocalDeployment(
 	flowId: string,
 	flowName: string
-): Deployment {
+): LocalDeployment {
 	return {
 		id: LOCAL_VERSION_ID,
 		flowId,
@@ -17,7 +23,9 @@ export function buildLocalDeployment(
 	};
 }
 
-export function isLocalDeployment(deployment: Deployment | undefined): boolean {
+export function isLocalDeployment(
+	deployment: Deployment | undefined
+): deployment is LocalDeployment {
 	return deployment?.id === LOCAL_VERSION_ID;
 }
 

--- a/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
@@ -5,6 +5,7 @@ import { stacksQueries } from "@/modules/stacks/business-logic/stacks-queries";
 import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
 import { DeploymentHeader } from "../ui/DeploymentHeader";
+import { InvokeDeploymentContainer } from "./InvokeDeploymentContainer";
 
 export function DeploymentHeaderContainer() {
 	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
@@ -29,6 +30,9 @@ export function DeploymentHeaderContainer() {
 			flowName={flow.name}
 			deployment={selected}
 			stackComponents={stack?.components}
+			invokeSlot={
+				selected ? <InvokeDeploymentContainer deployment={selected} /> : null
+			}
 		/>
 	);
 }

--- a/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentHeaderContainer.tsx
@@ -1,27 +1,11 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { useParams, useSearch } from "@tanstack/react-router";
-import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
+import { useQuery } from "@tanstack/react-query";
 import { stacksQueries } from "@/modules/stacks/business-logic/stacks-queries";
-import { deploymentsQueries } from "../business-logic/deployments-queries";
-import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
-import {
-	isLocalDeployment,
-	withLocalDeployment,
-} from "../domain/local-deployment";
+import { isLocalDeployment } from "../domain/local-deployment";
+import { useSelectedVersion } from "../business-logic/use-selected-version";
 import { DeploymentHeader } from "../ui/DeploymentHeader";
 
 export function DeploymentHeaderContainer() {
-	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
-	const { version } = useSearch({
-		from: "/_private/_navbar/flows/$flowId",
-	});
-
-	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
-	const { data: realDeployments } = useSuspenseQuery(
-		deploymentsQueries.list(flowId)
-	);
-	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
-	const selected = resolveSelectedDeployment(deployments, version);
+	const { flow, selected } = useSelectedVersion();
 
 	const { data: stack } = useQuery({
 		...stacksQueries.detail(selected?.stackId ?? ""),

--- a/src/modules/deployments/feature/DeploymentVersionSwitcherContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentVersionSwitcherContainer.tsx
@@ -1,25 +1,13 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
-import { deploymentsQueries } from "../business-logic/deployments-queries";
-import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
-import { withLocalDeployment } from "../domain/local-deployment";
+import { useNavigate } from "@tanstack/react-router";
+import { LOCAL_VERSION_ID } from "../domain/local-deployment";
+import { useSelectedVersion } from "../business-logic/use-selected-version";
 import { DeploymentVersionSwitcherPill } from "../ui/DeploymentVersionSwitcherPill";
 
 export function DeploymentVersionSwitcherContainer() {
-	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
-	const { version } = useSearch({
-		from: "/_private/_navbar/flows/$flowId",
-	});
+	const { deployments, selected } = useSelectedVersion();
 	const navigate = useNavigate();
-	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
-	const { data: realDeployments } = useSuspenseQuery(
-		deploymentsQueries.list(flowId)
-	);
-	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
-	const selected = resolveSelectedDeployment(deployments, version);
 
-	function handleSelect(next: number | "local") {
+	function handleSelect(next: number | typeof LOCAL_VERSION_ID) {
 		navigate({
 			to: ".",
 			search: (prev) => ({ ...prev, version: next }),

--- a/src/modules/deployments/feature/DeploymentVersionSwitcherContainer.tsx
+++ b/src/modules/deployments/feature/DeploymentVersionSwitcherContainer.tsx
@@ -1,21 +1,17 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { useParams, useSearch } from "@tanstack/react-router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
-import { stacksQueries } from "@/modules/stacks/business-logic/stacks-queries";
 import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
-import {
-	isLocalDeployment,
-	withLocalDeployment,
-} from "../domain/local-deployment";
-import { DeploymentHeader } from "../ui/DeploymentHeader";
+import { withLocalDeployment } from "../domain/local-deployment";
+import { DeploymentVersionSwitcherPill } from "../ui/DeploymentVersionSwitcherPill";
 
-export function DeploymentHeaderContainer() {
+export function DeploymentVersionSwitcherContainer() {
 	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
 	const { version } = useSearch({
 		from: "/_private/_navbar/flows/$flowId",
 	});
-
+	const navigate = useNavigate();
 	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
 	const { data: realDeployments } = useSuspenseQuery(
 		deploymentsQueries.list(flowId)
@@ -23,16 +19,18 @@ export function DeploymentHeaderContainer() {
 	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
 	const selected = resolveSelectedDeployment(deployments, version);
 
-	const { data: stack } = useQuery({
-		...stacksQueries.detail(selected?.stackId ?? ""),
-		enabled: Boolean(selected?.stackId) && !isLocalDeployment(selected),
-	});
+	function handleSelect(next: number | "local") {
+		navigate({
+			to: ".",
+			search: (prev) => ({ ...prev, version: next }),
+		});
+	}
 
 	return (
-		<DeploymentHeader
-			flowName={flow.name}
-			deployment={selected}
-			stackComponents={stack?.components}
+		<DeploymentVersionSwitcherPill
+			deployments={deployments}
+			selectedId={selected?.id}
+			onSelect={handleSelect}
 		/>
 	);
 }

--- a/src/modules/deployments/feature/FlowInvocationContainer.tsx
+++ b/src/modules/deployments/feature/FlowInvocationContainer.tsx
@@ -1,33 +1,22 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useParams, useSearch } from "@tanstack/react-router";
 import { env } from "@/modules/root/domain/env";
-import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
-import { deploymentsQueries } from "../business-logic/deployments-queries";
-import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
+import { isRecord } from "@/shared/utils/is-record";
+import { isLocalDeployment } from "../domain/local-deployment";
+import { useSelectedVersion } from "../business-logic/use-selected-version";
 import {
-	isLocalDeployment,
-	withLocalDeployment,
-} from "../domain/local-deployment";
-import { InvocationSnippets } from "../ui/InvocationSnippets";
-import { InvocationUrlBlock } from "../ui/InvocationUrlBlock";
+	InvocationEmptyState,
+	InvocationOverviewCard,
+} from "../ui/InvocationOverviewCard";
 import { LocalOverviewCard } from "../ui/LocalOverviewCard";
-
-type JsonSchemaProp = {
-	type?: string;
-	default?: unknown;
-	example?: unknown;
-};
-
-type JsonSchema = {
-	properties?: Record<string, JsonSchemaProp>;
-};
 
 function exampleFromSchema(
 	schema: Record<string, unknown> | undefined
 ): Record<string, unknown> {
-	const props = (schema as JsonSchema | undefined)?.properties ?? {};
+	if (!schema) return {};
+	const props = schema.properties;
+	if (!isRecord(props)) return {};
 	const out: Record<string, unknown> = {};
-	for (const [key, prop] of Object.entries(props)) {
+	for (const [key, value] of Object.entries(props)) {
+		const prop = isRecord(value) ? value : {};
 		if (prop.example !== undefined) out[key] = prop.example;
 		else if (prop.default !== undefined) out[key] = prop.default;
 		else if (prop.type === "number" || prop.type === "integer") out[key] = 0;
@@ -40,28 +29,11 @@ function exampleFromSchema(
 }
 
 export function FlowInvocationContainer() {
-	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
-	const { version } = useSearch({
-		from: "/_private/_navbar/flows/$flowId",
-	});
-	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
-	const { data: realDeployments } = useSuspenseQuery(
-		deploymentsQueries.list(flowId)
-	);
-	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
-	const selected = resolveSelectedDeployment(deployments, version);
+	const { flow, selected } = useSelectedVersion();
 
-	if (!selected) {
-		return (
-			<div className="text-muted-foreground container mx-auto px-4 py-6 text-sm sm:px-6 lg:px-8">
-				No deployments yet — there's nothing to invoke.
-			</div>
-		);
-	}
-
-	if (isLocalDeployment(selected)) {
+	if (!selected) return <InvocationEmptyState />;
+	if (isLocalDeployment(selected))
 		return <LocalOverviewCard flowName={flow.name} />;
-	}
 
 	const origin = env.VITE_API_BASE_URL || window.location.origin;
 	const url = `${origin}/api/v1/pipeline_snapshots/${selected.id}/runs`;
@@ -72,26 +44,11 @@ export function FlowInvocationContainer() {
 		: `--version ${selected.versionNumber}`;
 
 	return (
-		<div className="container mx-auto grid items-start gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2 lg:px-8">
-			<div className="border-border bg-card rounded-md border p-5">
-				<h2 className="text-sm font-semibold">Invoke</h2>
-				<p className="text-muted-foreground mt-1 text-xs">
-					Authenticate with a workspace API key. Routing resolves via the{" "}
-					<code className="font-mono text-xs">default</code> tag unless you pin
-					a specific version at call time.
-				</p>
-				<div className="mt-4">
-					<InvocationUrlBlock url={url} className="max-w-full" />
-				</div>
-			</div>
-			<div className="flex flex-col gap-2">
-				<InvocationSnippets
-					url={url}
-					flowName={selected.flowName}
-					exampleInput={exampleInput}
-					tagOrVersionArgs={tagOrVersionArgs}
-				/>
-			</div>
-		</div>
+		<InvocationOverviewCard
+			url={url}
+			flowName={selected.flowName}
+			exampleInput={exampleInput}
+			tagOrVersionArgs={tagOrVersionArgs}
+		/>
 	);
 }

--- a/src/modules/deployments/feature/FlowInvocationContainer.tsx
+++ b/src/modules/deployments/feature/FlowInvocationContainer.tsx
@@ -1,10 +1,16 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useParams, useSearch } from "@tanstack/react-router";
 import { env } from "@/modules/root/domain/env";
+import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
+import {
+	isLocalDeployment,
+	withLocalDeployment,
+} from "../domain/local-deployment";
 import { InvocationSnippets } from "../ui/InvocationSnippets";
 import { InvocationUrlBlock } from "../ui/InvocationUrlBlock";
+import { LocalOverviewCard } from "../ui/LocalOverviewCard";
 
 type JsonSchemaProp = {
 	type?: string;
@@ -38,9 +44,11 @@ export function FlowInvocationContainer() {
 	const { version } = useSearch({
 		from: "/_private/_navbar/flows/$flowId",
 	});
-	const { data: deployments } = useSuspenseQuery(
+	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
+	const { data: realDeployments } = useSuspenseQuery(
 		deploymentsQueries.list(flowId)
 	);
+	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
 	const selected = resolveSelectedDeployment(deployments, version);
 
 	if (!selected) {
@@ -49,6 +57,10 @@ export function FlowInvocationContainer() {
 				No deployments yet — there's nothing to invoke.
 			</div>
 		);
+	}
+
+	if (isLocalDeployment(selected)) {
+		return <LocalOverviewCard flowName={flow.name} />;
 	}
 
 	const origin = env.VITE_API_BASE_URL || window.location.origin;
@@ -60,24 +72,26 @@ export function FlowInvocationContainer() {
 		: `--version ${selected.versionNumber}`;
 
 	return (
-		<div className="container mx-auto grid gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2 lg:px-8">
-			<div>
-				<h2 className="text-base font-semibold">Invoke</h2>
-				<p className="text-muted-foreground mt-1 text-sm">
+		<div className="container mx-auto grid items-start gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2 lg:px-8">
+			<div className="border-border bg-card rounded-md border p-5">
+				<h2 className="text-sm font-semibold">Invoke</h2>
+				<p className="text-muted-foreground mt-1 text-xs">
 					Authenticate with a workspace API key. Routing resolves via the{" "}
 					<code className="font-mono text-xs">default</code> tag unless you pin
 					a specific version at call time.
 				</p>
-				<div className="mt-3">
-					<InvocationUrlBlock url={url} />
+				<div className="mt-4">
+					<InvocationUrlBlock url={url} className="max-w-full" />
 				</div>
 			</div>
-			<InvocationSnippets
-				url={url}
-				flowName={selected.flowName}
-				exampleInput={exampleInput}
-				tagOrVersionArgs={tagOrVersionArgs}
-			/>
+			<div className="flex flex-col gap-2">
+				<InvocationSnippets
+					url={url}
+					flowName={selected.flowName}
+					exampleInput={exampleInput}
+					tagOrVersionArgs={tagOrVersionArgs}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/src/modules/deployments/feature/FlowInvokeActionsContainer.tsx
+++ b/src/modules/deployments/feature/FlowInvokeActionsContainer.tsx
@@ -1,21 +1,21 @@
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseQuery } from "@tanstack/react-query";
 import { useParams, useSearch } from "@tanstack/react-router";
+import { env } from "@/modules/root/domain/env";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
-import { stacksQueries } from "@/modules/stacks/business-logic/stacks-queries";
 import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
 import {
 	isLocalDeployment,
 	withLocalDeployment,
 } from "../domain/local-deployment";
-import { DeploymentHeader } from "../ui/DeploymentHeader";
+import { InvocationUrlBlock } from "../ui/InvocationUrlBlock";
+import { InvokeDeploymentContainer } from "./InvokeDeploymentContainer";
 
-export function DeploymentHeaderContainer() {
+export function FlowInvokeActionsContainer() {
 	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
 	const { version } = useSearch({
 		from: "/_private/_navbar/flows/$flowId",
 	});
-
 	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
 	const { data: realDeployments } = useSuspenseQuery(
 		deploymentsQueries.list(flowId)
@@ -23,16 +23,15 @@ export function DeploymentHeaderContainer() {
 	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
 	const selected = resolveSelectedDeployment(deployments, version);
 
-	const { data: stack } = useQuery({
-		...stacksQueries.detail(selected?.stackId ?? ""),
-		enabled: Boolean(selected?.stackId) && !isLocalDeployment(selected),
-	});
+	if (!selected || isLocalDeployment(selected)) return null;
+
+	const origin = env.VITE_API_BASE_URL || window.location.origin;
+	const url = `${origin}/api/v1/pipeline_snapshots/${selected.id}/runs`;
 
 	return (
-		<DeploymentHeader
-			flowName={flow.name}
-			deployment={selected}
-			stackComponents={stack?.components}
-		/>
+		<div className="flex items-center gap-2">
+			<InvocationUrlBlock url={url} className="w-[480px] max-w-[50vw]" />
+			<InvokeDeploymentContainer deployment={selected} />
+		</div>
 	);
 }

--- a/src/modules/deployments/feature/FlowInvokeActionsContainer.tsx
+++ b/src/modules/deployments/feature/FlowInvokeActionsContainer.tsx
@@ -1,27 +1,11 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useParams, useSearch } from "@tanstack/react-router";
 import { env } from "@/modules/root/domain/env";
-import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
-import { deploymentsQueries } from "../business-logic/deployments-queries";
-import { resolveSelectedDeployment } from "../business-logic/resolve-deployment";
-import {
-	isLocalDeployment,
-	withLocalDeployment,
-} from "../domain/local-deployment";
+import { isLocalDeployment } from "../domain/local-deployment";
+import { useSelectedVersion } from "../business-logic/use-selected-version";
 import { InvocationUrlBlock } from "../ui/InvocationUrlBlock";
 import { InvokeDeploymentContainer } from "./InvokeDeploymentContainer";
 
 export function FlowInvokeActionsContainer() {
-	const { flowId } = useParams({ from: "/_private/_navbar/flows/$flowId" });
-	const { version } = useSearch({
-		from: "/_private/_navbar/flows/$flowId",
-	});
-	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
-	const { data: realDeployments } = useSuspenseQuery(
-		deploymentsQueries.list(flowId)
-	);
-	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
-	const selected = resolveSelectedDeployment(deployments, version);
+	const { selected } = useSelectedVersion();
 
 	if (!selected || isLocalDeployment(selected)) return null;
 

--- a/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
+++ b/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { toast } from "sonner";
+import type { Deployment } from "../domain/deployment";
+import { useInvokeDeployment } from "../business-logic/use-invoke-deployment";
+import { InvokeButton } from "../ui/InvokeButton";
+import { InvokeDrawer } from "../ui/InvokeDrawer";
+
+export function InvokeDeploymentContainer({
+	deployment,
+}: {
+	deployment: Deployment;
+}) {
+	const [open, setOpen] = useState(false);
+	const navigate = useNavigate();
+	const { mutate, isPending } = useInvokeDeployment(deployment.flowId);
+
+	function handleSubmit(parameters: Record<string, unknown>) {
+		mutate(
+			{ snapshotId: deployment.id, parameters },
+			{
+				onSuccess: ({ runId }) => {
+					setOpen(false);
+					toast.success("Invocation started");
+					navigate({
+						to: "/flows/$flowId/executions/$executionId",
+						params: { flowId: deployment.flowId, executionId: runId },
+					});
+				},
+				onError: (error) => {
+					toast.error(error instanceof Error ? error.message : "Invoke failed");
+				},
+			}
+		);
+	}
+
+	return (
+		<>
+			<InvokeButton
+				onClick={() => setOpen(true)}
+				disabled={!deployment.runnable}
+			/>
+			<InvokeDrawer
+				open={open}
+				onOpenChange={setOpen}
+				title={`Invoke ${deployment.flowName} · v${deployment.versionNumber}`}
+				schema={deployment.inputSchema ?? {}}
+				isSubmitting={isPending}
+				onSubmit={handleSubmit}
+			/>
+		</>
+	);
+}

--- a/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
+++ b/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
@@ -13,25 +13,25 @@ export function InvokeDeploymentContainer({
 }) {
 	const [open, setOpen] = useState(false);
 	const navigate = useNavigate();
-	const { mutate, isPending } = useInvokeDeployment(deployment.flowId);
+	const { invokeDeployment, isPending } = useInvokeDeployment(
+		deployment.flowId,
+		{
+			onSuccess: ({ runId }) => {
+				setOpen(false);
+				toast.success("Invocation started");
+				navigate({
+					to: "/flows/$flowId/executions/$executionId",
+					params: { flowId: deployment.flowId, executionId: runId },
+				});
+			},
+			onError: (error) => {
+				toast.error(error.message || "Invoke failed");
+			},
+		}
+	);
 
 	function handleSubmit(parameters: Record<string, unknown>) {
-		mutate(
-			{ snapshotId: deployment.id, parameters },
-			{
-				onSuccess: ({ runId }) => {
-					setOpen(false);
-					toast.success("Invocation started");
-					navigate({
-						to: "/flows/$flowId/executions/$executionId",
-						params: { flowId: deployment.flowId, executionId: runId },
-					});
-				},
-				onError: (error) => {
-					toast.error(error instanceof Error ? error.message : "Invoke failed");
-				},
-			}
-		);
+		invokeDeployment({ snapshotId: deployment.id, parameters });
 	}
 
 	return (
@@ -44,7 +44,7 @@ export function InvokeDeploymentContainer({
 				open={open}
 				onOpenChange={setOpen}
 				title={`Invoke ${deployment.flowName} · v${deployment.versionNumber}`}
-				schema={deployment.inputSchema ?? {}}
+				schema={deployment.inputSchema}
 				isSubmitting={isPending}
 				onSubmit={handleSubmit}
 			/>

--- a/src/modules/deployments/ui/DeploymentHeader.tsx
+++ b/src/modules/deployments/ui/DeploymentHeader.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/shared/utils/styles";
 import type { Deployment } from "../domain/deployment";
 import type { StackComponent } from "@/modules/stacks/domain/stack";
 import { DeploymentTagChip } from "./DeploymentTagChip";
+import { isLocalDeployment } from "../domain/local-deployment";
 
 export function DeploymentHeader({
 	flowName,
@@ -22,24 +23,34 @@ export function DeploymentHeader({
 				<div className="flex flex-wrap items-center gap-3">
 					<h1 className="text-foreground inline-flex min-w-0 flex-wrap items-baseline gap-2 font-mono text-lg font-semibold">
 						<span className="truncate">{flowName}</span>
-						{deployment && (
-							<>
-								<span className="text-muted-foreground" aria-hidden>
-									·
-								</span>
-								<span className="text-foreground">
-									v{deployment.versionNumber}
-								</span>
-							</>
-						)}
-						{isDefault && (
+						{deployment &&
+							(isLocalDeployment(deployment) ? (
+								<>
+									<span className="text-muted-foreground" aria-hidden>
+										·
+									</span>
+									<span className="text-muted-foreground text-xs font-normal italic">
+										not deployed
+									</span>
+								</>
+							) : (
+								<>
+									<span className="text-muted-foreground" aria-hidden>
+										·
+									</span>
+									<span className="text-foreground">
+										v{deployment.versionNumber}
+									</span>
+								</>
+							))}
+						{deployment && !isLocalDeployment(deployment) && isDefault && (
 							<span className="text-muted-foreground text-xs font-normal">
 								(default)
 							</span>
 						)}
 					</h1>
 
-					{deployment && hasTags && (
+					{deployment && !isLocalDeployment(deployment) && hasTags && (
 						<>
 							<Separator orientation="vertical" className="h-5" />
 							<div className="flex min-w-0 flex-wrap items-center gap-1">
@@ -57,51 +68,53 @@ export function DeploymentHeader({
 					)}
 				</div>
 
-				{deployment?.stackName && (
-					<div className="mt-3 flex flex-wrap items-center gap-2">
-						<span
-							className={cn(
-								"text-2xs font-semibold tracking-wider uppercase",
-								"text-muted-foreground shrink-0"
-							)}
-						>
-							Stack
-						</span>
-						{stackComponents && stackComponents.length > 0 ? (
-							stackComponents.map((c) => (
+				{deployment &&
+					!isLocalDeployment(deployment) &&
+					deployment.stackName && (
+						<div className="mt-3 flex flex-wrap items-center gap-2">
+							<span
+								className={cn(
+									"text-2xs font-semibold tracking-wider uppercase",
+									"text-muted-foreground shrink-0"
+								)}
+							>
+								Stack
+							</span>
+							{stackComponents && stackComponents.length > 0 ? (
+								stackComponents.map((c) => (
+									<span
+										key={c.id}
+										className={cn(
+											"inline-flex h-6 items-center gap-1.5 rounded-md px-2",
+											"border-border bg-card border",
+											"text-foreground font-mono text-xs"
+										)}
+										title={`${c.type}: ${c.flavorName}`}
+									>
+										{c.logoUrl && (
+											<img
+												src={c.logoUrl}
+												alt=""
+												className="size-3.5 shrink-0"
+												aria-hidden
+											/>
+										)}
+										<span className="truncate">{c.flavorName}</span>
+									</span>
+								))
+							) : (
 								<span
-									key={c.id}
 									className={cn(
-										"inline-flex h-6 items-center gap-1.5 rounded-md px-2",
+										"inline-flex h-6 items-center rounded-md px-2",
 										"border-border bg-card border",
 										"text-foreground font-mono text-xs"
 									)}
-									title={`${c.type}: ${c.flavorName}`}
 								>
-									{c.logoUrl && (
-										<img
-											src={c.logoUrl}
-											alt=""
-											className="size-3.5 shrink-0"
-											aria-hidden
-										/>
-									)}
-									<span className="truncate">{c.flavorName}</span>
+									{deployment.stackName}
 								</span>
-							))
-						) : (
-							<span
-								className={cn(
-									"inline-flex h-6 items-center rounded-md px-2",
-									"border-border bg-card border",
-									"text-foreground font-mono text-xs"
-								)}
-							>
-								{deployment.stackName}
-							</span>
-						)}
-					</div>
-				)}
+							)}
+						</div>
+					)}
 			</div>
 		</section>
 	);

--- a/src/modules/deployments/ui/DeploymentHeader.tsx
+++ b/src/modules/deployments/ui/DeploymentHeader.tsx
@@ -1,4 +1,3 @@
-import type React from "react";
 import { Separator } from "@/shared/ui/separator";
 import { cn } from "@/shared/utils/styles";
 import type { Deployment } from "../domain/deployment";
@@ -9,12 +8,10 @@ export function DeploymentHeader({
 	flowName,
 	deployment,
 	stackComponents,
-	invokeSlot,
 }: {
 	flowName: string;
 	deployment?: Deployment;
 	stackComponents?: StackComponent[];
-	invokeSlot?: React.ReactNode;
 }) {
 	const isDefault = deployment?.tags.some((t) => t.kind === "default") ?? false;
 	const hasTags = (deployment?.tags.length ?? 0) > 0;
@@ -53,14 +50,11 @@ export function DeploymentHeader({
 						</>
 					)}
 
-					<div className="ml-auto flex items-center gap-2">
-						{!deployment && (
-							<span className="text-muted-foreground text-xs">
-								No deployments yet
-							</span>
-						)}
-						{invokeSlot}
-					</div>
+					{!deployment && (
+						<span className="text-muted-foreground ml-auto text-xs">
+							No deployments yet
+						</span>
+					)}
 				</div>
 
 				{deployment?.stackName && (

--- a/src/modules/deployments/ui/DeploymentVersionSwitcherPill.tsx
+++ b/src/modules/deployments/ui/DeploymentVersionSwitcherPill.tsx
@@ -55,7 +55,7 @@ export function DeploymentVersionSwitcherPill({
 }: {
 	deployments: Deployment[];
 	selectedId: string | undefined;
-	onSelect: (selection: number | "local") => void;
+	onSelect: (selection: number | typeof LOCAL_VERSION_ID) => void;
 	className?: string;
 }) {
 	const [sort, setSort] = useState<SortOrder>("newest");

--- a/src/modules/deployments/ui/DeploymentVersionSwitcherPill.tsx
+++ b/src/modules/deployments/ui/DeploymentVersionSwitcherPill.tsx
@@ -1,0 +1,281 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import type { Deployment, DeploymentTag } from "../domain/deployment";
+import {
+	isLocalDeployment,
+	LOCAL_VERSION_ID,
+} from "../domain/local-deployment";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuTrigger,
+} from "@/shared/ui/dropdown-menu";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/shared/ui/select";
+import { cn } from "@/shared/utils/styles";
+import { DeploymentTagChip } from "./DeploymentTagChip";
+
+type SortOrder = "newest" | "oldest";
+
+const TAG_PRIORITY: Record<DeploymentTag["kind"], number> = {
+	default: 0,
+	exclusive: 1,
+	general: 2,
+};
+
+function sortedTags(d: Deployment) {
+	return [...d.tags].sort(
+		(a, b) => TAG_PRIORITY[a.kind] - TAG_PRIORITY[b.kind]
+	);
+}
+
+function deploymentTime(d: Deployment): number {
+	return d.createdAt?.getTime() ?? 0;
+}
+
+function formatDate(d: Date | undefined): string {
+	if (!d) return "";
+	return d.toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+		year: "numeric",
+	});
+}
+
+export function DeploymentVersionSwitcherPill({
+	deployments,
+	selectedId,
+	onSelect,
+	className,
+}: {
+	deployments: Deployment[];
+	selectedId: string | undefined;
+	onSelect: (selection: number | "local") => void;
+	className?: string;
+}) {
+	const [sort, setSort] = useState<SortOrder>("newest");
+
+	if (deployments.length === 0) return null;
+
+	const selected =
+		deployments.find((d) => d.id === selectedId) ?? deployments[0];
+	const selectedDefaultTag = selected.tags.find((t) => t.kind === "default");
+	const defaultHolder = deployments.find((d) =>
+		d.tags.some((t) => t.kind === "default")
+	);
+
+	const dir = sort === "newest" ? -1 : 1;
+	const sortedDeployments = [...deployments].sort(
+		(a, b) => dir * (deploymentTime(a) - deploymentTime(b))
+	);
+	const restVersions = sortedDeployments.filter(
+		(d) => d.id !== defaultHolder?.id
+	);
+	const localEntry = deployments.find(isLocalDeployment);
+	const restRealVersions = restVersions.filter((d) => !isLocalDeployment(d));
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger
+				render={
+					<button
+						type="button"
+						aria-label={`Switch version. Current: v${selected.versionNumber}`}
+						className={cn(
+							"inline-flex h-7 items-center gap-1.5 rounded-md px-2",
+							"hover:bg-accent/60 focus-visible:ring-ring/40 transition-colors focus-visible:ring-2 focus-visible:outline-none",
+							"data-[popup-open]:bg-accent/70",
+							className
+						)}
+					>
+						<span className="text-foreground font-mono text-sm font-semibold">
+							{isLocalDeployment(selected)
+								? "local"
+								: `v${selected.versionNumber}`}
+						</span>
+						{selectedDefaultTag && (
+							<DeploymentTagChip tag={selectedDefaultTag} size="sm" />
+						)}
+						<ChevronsUpDown
+							className="text-muted-foreground size-3 shrink-0"
+							aria-hidden
+						/>
+					</button>
+				}
+			/>
+			<DropdownMenuContent
+				align="start"
+				sideOffset={6}
+				className="w-[420px] p-0"
+			>
+				<div className="flex flex-col">
+					<div className="border-border flex items-center justify-end border-b px-3 py-2">
+						<Select value={sort} onValueChange={(v) => setSort(v as SortOrder)}>
+							<SelectTrigger
+								size="sm"
+								className="h-7 w-[120px] text-xs"
+								aria-label="Sort order"
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="newest">Newest</SelectItem>
+								<SelectItem value="oldest">Oldest</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="max-h-[420px] overflow-y-auto">
+						{defaultHolder && (
+							<>
+								<div className="text-muted-foreground text-2xs px-3 pt-2.5 pb-1 font-semibold tracking-wider uppercase">
+									Current default
+								</div>
+								<VersionRow
+									deployment={defaultHolder}
+									isSelected={selected.id === defaultHolder.id}
+									onSelect={() => onSelect(defaultHolder.versionNumber)}
+								/>
+								<div className="border-border border-b" />
+							</>
+						)}
+
+						{(restRealVersions.length > 0 || defaultHolder) && (
+							<div className="text-muted-foreground text-2xs flex items-center gap-1.5 px-3 pt-2.5 pb-1 font-semibold tracking-wider uppercase">
+								<span>All versions</span>
+								<span aria-hidden>·</span>
+								<span className="tabular-nums">{restRealVersions.length}</span>
+							</div>
+						)}
+						{restRealVersions.map((d) => (
+							<VersionRow
+								key={d.id}
+								deployment={d}
+								isSelected={selected.id === d.id}
+								onSelect={() => onSelect(d.versionNumber)}
+							/>
+						))}
+						{localEntry && (
+							<>
+								<div className="border-border border-b" />
+								<div className="text-muted-foreground text-2xs px-3 pt-2.5 pb-1 font-semibold tracking-wider uppercase">
+									Unversioned
+								</div>
+								<VersionRow
+									deployment={localEntry}
+									isSelected={selected.id === localEntry.id}
+									onSelect={() => onSelect(LOCAL_VERSION_ID)}
+								/>
+							</>
+						)}
+					</div>
+				</div>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+const VISIBLE_TAGS = 2;
+
+function VersionRow({
+	deployment,
+	isSelected,
+	onSelect,
+}: {
+	deployment: Deployment;
+	isSelected: boolean;
+	onSelect: () => void;
+}) {
+	if (isLocalDeployment(deployment)) {
+		return (
+			<button
+				type="button"
+				onClick={onSelect}
+				className={cn(
+					"flex w-full items-center gap-3 px-3 py-2 text-left",
+					"hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none",
+					isSelected && "bg-primary/5 hover:bg-primary/5"
+				)}
+			>
+				<div className="flex w-4 shrink-0 justify-center">
+					{isSelected ? (
+						<Check
+							className="text-primary size-4"
+							aria-label="Currently viewing"
+						/>
+					) : (
+						<span aria-hidden className="block size-4" />
+					)}
+				</div>
+				<span className="text-foreground min-w-[32px] shrink-0 font-mono text-sm font-semibold">
+					local
+				</span>
+				<div className="flex min-w-0 flex-1 items-center gap-1">
+					<span className="text-2xs text-muted-foreground italic">
+						not deployed
+					</span>
+				</div>
+			</button>
+		);
+	}
+
+	const tags = sortedTags(deployment);
+	const visibleTags = tags.slice(0, VISIBLE_TAGS);
+	const overflowTags = tags.slice(VISIBLE_TAGS);
+
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			className={cn(
+				"flex w-full items-center gap-3 px-3 py-2 text-left",
+				"hover:bg-accent/40 focus-visible:bg-accent/40 focus-visible:outline-none",
+				isSelected && "bg-primary/5 hover:bg-primary/5"
+			)}
+		>
+			<div className="flex w-4 shrink-0 justify-center">
+				{isSelected ? (
+					<Check
+						className="text-primary size-4"
+						aria-label="Currently viewing"
+					/>
+				) : (
+					<span aria-hidden className="block size-4" />
+				)}
+			</div>
+
+			<span className="text-foreground min-w-[32px] shrink-0 font-mono text-sm font-semibold">
+				v{deployment.versionNumber}
+			</span>
+
+			<div className="flex min-w-0 flex-1 items-center gap-1">
+				{tags.length === 0 ? (
+					<span className="text-2xs text-muted-foreground italic">no tags</span>
+				) : (
+					<>
+						{visibleTags.map((t) => (
+							<DeploymentTagChip key={t.id} tag={t} size="sm" />
+						))}
+						{overflowTags.length > 0 && (
+							<span
+								className="bg-muted text-2xs text-muted-foreground inline-flex h-5 items-center rounded px-1.5 font-mono tracking-wider uppercase"
+								title={overflowTags.map((t) => t.name).join(", ")}
+							>
+								+{overflowTags.length}
+							</span>
+						)}
+					</>
+				)}
+			</div>
+
+			<span className="text-2xs text-muted-foreground shrink-0 tabular-nums">
+				{formatDate(deployment.createdAt)}
+			</span>
+		</button>
+	);
+}

--- a/src/modules/deployments/ui/InvocationOverviewCard.tsx
+++ b/src/modules/deployments/ui/InvocationOverviewCard.tsx
@@ -1,0 +1,46 @@
+import { InvocationSnippets } from "./InvocationSnippets";
+import { InvocationUrlBlock } from "./InvocationUrlBlock";
+
+export function InvocationOverviewCard({
+	url,
+	flowName,
+	exampleInput,
+	tagOrVersionArgs,
+}: {
+	url: string;
+	flowName: string;
+	exampleInput: Record<string, unknown>;
+	tagOrVersionArgs: string;
+}) {
+	return (
+		<div className="container mx-auto grid items-start gap-6 px-4 py-6 sm:px-6 lg:grid-cols-2 lg:px-8">
+			<div className="border-border bg-card rounded-md border p-5">
+				<h2 className="text-sm font-semibold">Invoke</h2>
+				<p className="text-muted-foreground mt-1 text-xs">
+					Authenticate with a workspace API key. Routing resolves via the{" "}
+					<code className="font-mono text-xs">default</code> tag unless you pin
+					a specific version at call time.
+				</p>
+				<div className="mt-4">
+					<InvocationUrlBlock url={url} className="max-w-full" />
+				</div>
+			</div>
+			<div className="flex flex-col gap-2">
+				<InvocationSnippets
+					url={url}
+					flowName={flowName}
+					exampleInput={exampleInput}
+					tagOrVersionArgs={tagOrVersionArgs}
+				/>
+			</div>
+		</div>
+	);
+}
+
+export function InvocationEmptyState() {
+	return (
+		<div className="text-muted-foreground container mx-auto px-4 py-6 text-sm sm:px-6 lg:px-8">
+			No deployments yet — there's nothing to invoke.
+		</div>
+	);
+}

--- a/src/modules/deployments/ui/InvokeButton.tsx
+++ b/src/modules/deployments/ui/InvokeButton.tsx
@@ -1,0 +1,17 @@
+import { Play } from "lucide-react";
+import { Button } from "@/shared/ui/button";
+
+export function InvokeButton({
+	onClick,
+	disabled,
+}: {
+	onClick: () => void;
+	disabled?: boolean;
+}) {
+	return (
+		<Button size="sm" onClick={onClick} disabled={disabled}>
+			<Play className="size-3.5" />
+			Invoke
+		</Button>
+	);
+}

--- a/src/modules/deployments/ui/InvokeDrawer.tsx
+++ b/src/modules/deployments/ui/InvokeDrawer.tsx
@@ -1,0 +1,98 @@
+import { useRef } from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { withTheme } from "@rjsf/core";
+import type RjsfForm from "@rjsf/core";
+import { Theme as shadcnTheme } from "@rjsf/shadcn";
+import validator from "@rjsf/validator-ajv8";
+import { Send, X } from "lucide-react";
+import { Button } from "@/shared/ui/button";
+import { cn } from "@/shared/utils/styles";
+
+const Form = withTheme(shadcnTheme);
+
+const UI_SCHEMA = {
+	"ui:submitButtonOptions": { norender: true },
+	"ui:title": "",
+	"ui:description": "",
+};
+
+export function InvokeDrawer({
+	open,
+	onOpenChange,
+	title,
+	schema,
+	isSubmitting,
+	onSubmit,
+}: {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+	schema: Record<string, unknown>;
+	isSubmitting?: boolean;
+	onSubmit: (parameters: Record<string, unknown>) => void;
+}) {
+	const formRef = useRef<RjsfForm>(null);
+	return (
+		<DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+			<DialogPrimitive.Portal>
+				<DialogPrimitive.Backdrop
+					className={cn(
+						"data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+						"fixed inset-0 z-40 bg-black/20 supports-backdrop-filter:backdrop-blur-xs"
+					)}
+				/>
+				<DialogPrimitive.Popup
+					className={cn(
+						"bg-background fixed top-0 right-0 bottom-0 z-50",
+						"flex w-full max-w-md flex-col shadow-lg outline-none",
+						"data-open:animate-in data-open:slide-in-from-right data-closed:animate-out data-closed:slide-out-to-right"
+					)}
+				>
+					<div className="border-border flex items-center justify-between border-b px-4 py-3">
+						<DialogPrimitive.Title className="text-sm font-semibold">
+							{title}
+						</DialogPrimitive.Title>
+						<DialogPrimitive.Close
+							render={<Button variant="ghost" size="icon-sm" />}
+						>
+							<X className="size-4" />
+							<span className="sr-only">Close</span>
+						</DialogPrimitive.Close>
+					</div>
+					<div className="flex-1 overflow-y-auto p-4">
+						<div className="text-xs [&_button]:text-xs [&_input]:text-xs [&_label]:text-xs">
+							<Form
+								ref={formRef}
+								schema={schema as object}
+								validator={validator}
+								uiSchema={UI_SCHEMA}
+								onSubmit={({ formData }) =>
+									onSubmit((formData ?? {}) as Record<string, unknown>)
+								}
+							/>
+						</div>
+					</div>
+					<div className="border-border flex gap-2 border-t px-4 py-3">
+						<Button
+							variant="outline"
+							size="sm"
+							className="flex-1"
+							onClick={() => onOpenChange(false)}
+						>
+							Cancel
+						</Button>
+						<Button
+							size="sm"
+							className="flex-1"
+							disabled={isSubmitting}
+							onClick={() => formRef.current?.submit()}
+						>
+							<Send className="size-3.5" />
+							{isSubmitting ? "Invoking…" : "Invoke"}
+						</Button>
+					</div>
+				</DialogPrimitive.Popup>
+			</DialogPrimitive.Portal>
+		</DialogPrimitive.Root>
+	);
+}

--- a/src/modules/deployments/ui/InvokeDrawer.tsx
+++ b/src/modules/deployments/ui/InvokeDrawer.tsx
@@ -3,6 +3,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 import { withTheme } from "@rjsf/core";
 import type RjsfForm from "@rjsf/core";
 import { Theme as shadcnTheme } from "@rjsf/shadcn";
+import type { RJSFSchema } from "@rjsf/utils";
 import validator from "@rjsf/validator-ajv8";
 import { Send, X } from "lucide-react";
 import { Button } from "@/shared/ui/button";
@@ -16,6 +17,8 @@ const UI_SCHEMA = {
 	"ui:description": "",
 };
 
+const EMPTY_SCHEMA: RJSFSchema = {};
+
 export function InvokeDrawer({
 	open,
 	onOpenChange,
@@ -27,7 +30,7 @@ export function InvokeDrawer({
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	title: string;
-	schema: Record<string, unknown>;
+	schema: RJSFSchema | undefined;
 	isSubmitting?: boolean;
 	onSubmit: (parameters: Record<string, unknown>) => void;
 }) {
@@ -63,12 +66,10 @@ export function InvokeDrawer({
 						<div className="text-xs [&_button]:text-xs [&_input]:text-xs [&_label]:text-xs">
 							<Form
 								ref={formRef}
-								schema={schema as object}
+								schema={schema ?? EMPTY_SCHEMA}
 								validator={validator}
 								uiSchema={UI_SCHEMA}
-								onSubmit={({ formData }) =>
-									onSubmit((formData ?? {}) as Record<string, unknown>)
-								}
+								onSubmit={({ formData }) => onSubmit(formData ?? {})}
 							/>
 						</div>
 					</div>

--- a/src/modules/deployments/ui/LocalOverviewCard.tsx
+++ b/src/modules/deployments/ui/LocalOverviewCard.tsx
@@ -1,0 +1,24 @@
+import { Info } from "lucide-react";
+
+export function LocalOverviewCard({ flowName }: { flowName: string }) {
+	return (
+		<div className="container mx-auto px-4 py-6 sm:px-6 lg:px-8">
+			<div className="border-border bg-card flex items-start gap-3 rounded-md border p-5">
+				<div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-full">
+					<Info className="text-muted-foreground size-4" aria-hidden />
+				</div>
+				<div className="min-w-0 flex-1">
+					<h2 className="text-sm font-semibold">Running locally</h2>
+					<p className="text-muted-foreground mt-1 text-xs">
+						These runs of <code className="font-mono text-xs">{flowName}</code>{" "}
+						haven't been published as a deployment yet. Publish a version with
+						the CLI to invoke this flow over HTTP and route traffic with tags.
+					</p>
+					<pre className="bg-muted/40 text-foreground mt-3 rounded px-3 py-2 font-mono text-xs">
+						<code>kitaru deploy {flowName}</code>
+					</pre>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/modules/executions/business-logic/executions-queries.ts
+++ b/src/modules/executions/business-logic/executions-queries.ts
@@ -7,7 +7,10 @@ import { fetchWaitConditions } from "../domain/fetch-wait-conditions";
 
 export const executionsQueryKeys = {
 	base: ["executions"] as const,
-	all: (flowId: string) => [...executionsQueryKeys.base, flowId] as const,
+	all: (flowId: string, snapshotId?: string) =>
+		snapshotId
+			? ([...executionsQueryKeys.base, flowId, "snapshot", snapshotId] as const)
+			: ([...executionsQueryKeys.base, flowId] as const),
 	listWithSnapshots: (flowId: string) =>
 		[...executionsQueryKeys.base, "list-with-snapshots", flowId] as const,
 	detail: (executionId: string) =>
@@ -21,10 +24,10 @@ export const executionsQueryKeys = {
 };
 
 export const executionsQueries = {
-	all: (flowId: string) =>
+	all: (flowId: string, snapshotId?: string) =>
 		queryOptions({
-			queryKey: executionsQueryKeys.all(flowId),
-			queryFn: () => fetchExecutions(flowId),
+			queryKey: executionsQueryKeys.all(flowId, snapshotId),
+			queryFn: () => fetchExecutions(flowId, { snapshotId }),
 		}),
 	listWithSnapshots: (flowId: string) =>
 		queryOptions({

--- a/src/modules/executions/business-logic/use-executions.tsx
+++ b/src/modules/executions/business-logic/use-executions.tsx
@@ -4,12 +4,15 @@ import { executionsQueries } from "./executions-queries";
 type Options = Omit<
 	ReturnType<typeof executionsQueries.all>,
 	"queryKey" | "queryFn"
->;
+> & {
+	snapshotId?: string;
+};
 
 export function useExecutions(flowId: string, opts: Options = {}) {
+	const { snapshotId, ...queryOpts } = opts;
 	const query = useSuspenseQuery({
-		...executionsQueries.all(flowId),
-		...opts,
+		...executionsQueries.all(flowId, snapshotId),
+		...queryOpts,
 	});
 
 	return { ...query, executionsData: query.data };

--- a/src/modules/executions/domain/execution.ts
+++ b/src/modules/executions/domain/execution.ts
@@ -84,6 +84,6 @@ export function executionFromApiToDomain(
 						name: run.resources?.active_wait_condition?.name,
 					}
 				: undefined,
-		snapshotId: run.resources?.snapshot?.id,
+		snapshotId: run.resources?.source_snapshot?.id,
 	};
 }

--- a/src/modules/executions/domain/fetch-executions.spec.ts
+++ b/src/modules/executions/domain/fetch-executions.spec.ts
@@ -35,6 +35,7 @@ describe("fetchExecutions", () => {
 					page: 1,
 					size: 1000,
 					pipeline_id: "flow-1",
+					source_snapshot_id: undefined,
 					hydrate: undefined,
 				},
 			},
@@ -49,9 +50,23 @@ describe("fetchExecutions", () => {
 					page: 1,
 					size: 1000,
 					pipeline_id: "flow-1",
+					source_snapshot_id: undefined,
 					hydrate: true,
 				},
 			},
 		});
+	});
+
+	it("forwards snapshotId to the API as source_snapshot_id", async () => {
+		await fetchExecutions("flow-1", { snapshotId: "snap-42" });
+		const query = getSpy.mock.calls[0][1].params.query;
+		expect(query.source_snapshot_id).toBe("snap-42");
+		expect(query.pipeline_id).toBe("flow-1");
+	});
+
+	it("sends source_snapshot_id as undefined when snapshotId is absent", async () => {
+		await fetchExecutions("flow-1");
+		const query = getSpy.mock.calls[0][1].params.query;
+		expect(query.source_snapshot_id).toBeUndefined();
 	});
 });

--- a/src/modules/executions/domain/fetch-executions.ts
+++ b/src/modules/executions/domain/fetch-executions.ts
@@ -9,6 +9,7 @@ export const DEFAULT_EXECUTIONS_POLLING_INTERVAL = 5000;
 
 export type FetchExecutionsOptions = {
 	hydrate?: boolean;
+	snapshotId?: string;
 };
 
 export async function fetchExecutions(
@@ -21,6 +22,7 @@ export async function fetchExecutions(
 				page: DEFAULT_PAGE,
 				size: MAX_PAGE_SIZE,
 				pipeline_id: flowId,
+				source_snapshot_id: options?.snapshotId,
 				hydrate: options?.hydrate,
 			},
 		},

--- a/src/modules/executions/domain/filter-local-executions.spec.ts
+++ b/src/modules/executions/domain/filter-local-executions.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import type { Execution } from "./execution";
+import { filterLocalExecutions } from "./filter-local-executions";
+
+function mkExecution(overrides: Partial<Execution>): Execution {
+	return {
+		id: "run-x",
+		name: "run",
+		index: 1,
+		logSources: [],
+		...overrides,
+	};
+}
+
+describe("filterLocalExecutions", () => {
+	it("keeps runs whose snapshot isn't a known Kitaru deployment", () => {
+		const e1 = mkExecution({ id: "run-1", snapshotId: "snap-a" });
+		const e2 = mkExecution({ id: "run-2", snapshotId: "snap-kitaru" });
+		const e3 = mkExecution({ id: "run-3", snapshotId: undefined });
+		const kitaruIds = new Set(["snap-kitaru"]);
+		expect(filterLocalExecutions([e1, e2, e3], kitaruIds)).toEqual([e1, e3]);
+	});
+
+	it("treats a run with no snapshotId as local", () => {
+		const e = mkExecution({ id: "run-1", snapshotId: undefined });
+		expect(filterLocalExecutions([e], new Set())).toEqual([e]);
+	});
+
+	it("returns an empty array for an empty input", () => {
+		expect(filterLocalExecutions([], new Set(["snap-a"]))).toEqual([]);
+	});
+});

--- a/src/modules/executions/domain/filter-local-executions.ts
+++ b/src/modules/executions/domain/filter-local-executions.ts
@@ -1,0 +1,10 @@
+import type { Execution } from "./execution";
+
+export function filterLocalExecutions(
+	executions: Execution[],
+	kitaruSnapshotIds: Set<string>
+): Execution[] {
+	return executions.filter(
+		(e) => !e.snapshotId || !kitaruSnapshotIds.has(e.snapshotId)
+	);
+}

--- a/src/modules/executions/ui/ExecutionsScopeToggle.tsx
+++ b/src/modules/executions/ui/ExecutionsScopeToggle.tsx
@@ -1,0 +1,41 @@
+import { ToggleGroup, ToggleGroupItem } from "@/shared/ui/toggle-group";
+
+export type ExecutionsScope = "version" | "all";
+
+export function ExecutionsScopeToggle({
+	versionLabel,
+	scope,
+	onScopeChange,
+}: {
+	versionLabel: string;
+	scope: ExecutionsScope;
+	onScopeChange: (scope: ExecutionsScope) => void;
+}) {
+	return (
+		<ToggleGroup
+			value={[scope]}
+			onValueChange={(next) => {
+				const candidate = next[0];
+				if (candidate === "version" || candidate === "all") {
+					onScopeChange(candidate);
+				}
+			}}
+			variant="outline"
+			size="sm"
+			spacing={0}
+		>
+			<ToggleGroupItem
+				value="version"
+				className="aria-pressed:bg-primary aria-pressed:text-primary-foreground font-mono"
+			>
+				{versionLabel}
+			</ToggleGroupItem>
+			<ToggleGroupItem
+				value="all"
+				className="aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+			>
+				All versions
+			</ToggleGroupItem>
+		</ToggleGroup>
+	);
+}

--- a/src/modules/flows/feature/FlowContextBarContainer.tsx
+++ b/src/modules/flows/feature/FlowContextBarContainer.tsx
@@ -1,22 +1,25 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 
-import { ContextBar } from "@/shared/ui/ContextBar";
-import { useFlow } from "@/modules/flows/business-logic/use-flow";
+import { FlowInvokeActionsContainer } from "@/modules/deployments/feature/FlowInvokeActionsContainer";
 import {
 	type FlowTab,
 	flowTabLabels,
 	flowTabs,
 } from "@/modules/flows/domain/flow";
+import { ContextBar } from "@/shared/ui/ContextBar";
 
 export function FlowContextBarContainer() {
 	const { flowId, tab } = useParams({
 		from: "/_private/_navbar/flows/$flowId/$tab",
 	});
-	const { flowData } = useFlow(flowId);
 	const navigate = useNavigate();
 
 	const navigateToTab = (tab: FlowTab) => {
-		navigate({ to: "/flows/$flowId/$tab", params: { flowId, tab } });
+		navigate({
+			to: "/flows/$flowId/$tab",
+			params: { flowId, tab },
+			search: (prev) => prev,
+		});
 	};
 
 	const tabs = flowTabs.map((value) => ({
@@ -24,24 +27,12 @@ export function FlowContextBarContainer() {
 		label: flowTabLabels[value],
 	}));
 
-	const metadata = [
-		{ label: "ID", value: flowData.id },
-		...(flowData.createdAt
-			? [
-					{
-						label: "Created",
-						value: flowData.createdAt.toLocaleDateString(),
-					},
-				]
-			: []),
-	];
-
 	return (
 		<ContextBar
 			tabs={tabs}
 			activeTab={tab}
 			onTabChange={(value) => navigateToTab(value as FlowTab)}
-			metadata={metadata}
+			actions={<FlowInvokeActionsContainer />}
 		/>
 	);
 }

--- a/src/modules/flows/feature/FlowExecutionsContainer.tsx
+++ b/src/modules/flows/feature/FlowExecutionsContainer.tsx
@@ -1,29 +1,88 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { deploymentsQueries } from "@/modules/deployments/business-logic/deployments-queries";
+import { resolveSelectedDeployment } from "@/modules/deployments/business-logic/resolve-deployment";
+import {
+	isLocalDeployment,
+	withLocalDeployment,
+} from "@/modules/deployments/domain/local-deployment";
 import { useExecutions } from "@/modules/executions/business-logic/use-executions";
+import { filterLocalExecutions } from "@/modules/executions/domain/filter-local-executions";
 import { ExecutionsTableContainer } from "@/modules/executions/feature/ExecutionsTableContainer";
+import {
+	type ExecutionsScope,
+	ExecutionsScopeToggle,
+} from "@/modules/executions/ui/ExecutionsScopeToggle";
+import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import { RefreshButton } from "@/shared/ui/RefreshButton";
 import {
 	TableToolbarContent,
 	TableToolbarRoot,
 } from "@/shared/ui/TableToolbar";
-import { useParams } from "@tanstack/react-router";
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { DEFAULT_EXECUTIONS_POLLING_INTERVAL } from "@/modules/executions/domain/fetch-executions";
 
 export function FlowExecutionsContainer() {
 	const { flowId } = useParams({
 		from: "/_private/_navbar/flows/$flowId/$tab",
 	});
+	const { version, versions } = useSearch({
+		from: "/_private/_navbar/flows/$flowId",
+	});
+	const navigate = useNavigate();
+	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
+	const { data: realDeployments } = useSuspenseQuery(
+		deploymentsQueries.list(flowId)
+	);
+	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
+	const selected = resolveSelectedDeployment(deployments, version);
+	const isLocal = isLocalDeployment(selected);
+	const activeScope: ExecutionsScope = versions === "all" ? "all" : "version";
+	const shouldServerFilter =
+		activeScope === "version" && !!selected && !isLocal;
 
 	const { executionsData, refetch } = useExecutions(flowId, {
+		snapshotId: shouldServerFilter ? selected?.id : undefined,
 		refetchInterval: DEFAULT_EXECUTIONS_POLLING_INTERVAL,
 	});
 	const { refresh: refreshExecutions, isPending: isManualRefreshPending } =
 		useManualRefresh(refetch);
 
+	const kitaruSnapshotIds = new Set(realDeployments.map((d) => d.id));
+	const displayedExecutions =
+		activeScope === "version" && isLocal
+			? filterLocalExecutions(executionsData, kitaruSnapshotIds)
+			: executionsData;
+
+	const versionLabel = isLocal
+		? "local"
+		: selected
+			? `v${selected.versionNumber}`
+			: "";
+
+	function handleScopeChange(nextScope: ExecutionsScope) {
+		navigate({
+			to: ".",
+			search: (prev) => ({
+				...prev,
+				versions: nextScope === "all" ? "all" : undefined,
+			}),
+		});
+	}
+
 	return (
 		<>
 			<TableToolbarRoot>
-				<TableToolbarContent className="justify-end">
+				<TableToolbarContent className="justify-between">
+					{selected && versionLabel ? (
+						<ExecutionsScopeToggle
+							versionLabel={versionLabel}
+							scope={activeScope}
+							onScopeChange={handleScopeChange}
+						/>
+					) : (
+						<div />
+					)}
 					<RefreshButton
 						variant="outline"
 						isLoading={isManualRefreshPending}
@@ -33,7 +92,7 @@ export function FlowExecutionsContainer() {
 			</TableToolbarRoot>
 			<div className="container mx-auto flex w-full flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8">
 				<ExecutionsTableContainer
-					executionRows={executionsData}
+					executionRows={displayedExecutions}
 					flowId={flowId}
 				/>
 			</div>

--- a/src/modules/flows/feature/FlowExecutionsContainer.tsx
+++ b/src/modules/flows/feature/FlowExecutionsContainer.tsx
@@ -54,11 +54,9 @@ export function FlowExecutionsContainer() {
 			? filterLocalExecutions(executionsData, kitaruSnapshotIds)
 			: executionsData;
 
-	const versionLabel = isLocal
-		? "local"
-		: selected
-			? `v${selected.versionNumber}`
-			: "";
+	let versionLabel = "";
+	if (isLocal) versionLabel = "local";
+	else if (selected) versionLabel = `v${selected.versionNumber}`;
 
 	function handleScopeChange(nextScope: ExecutionsScope) {
 		navigate({

--- a/src/modules/flows/feature/FlowExecutionsContainer.tsx
+++ b/src/modules/flows/feature/FlowExecutionsContainer.tsx
@@ -1,41 +1,27 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { deploymentsQueries } from "@/modules/deployments/business-logic/deployments-queries";
-import { resolveSelectedDeployment } from "@/modules/deployments/business-logic/resolve-deployment";
-import {
-	isLocalDeployment,
-	withLocalDeployment,
-} from "@/modules/deployments/domain/local-deployment";
+import { useSelectedVersion } from "@/modules/deployments/business-logic/use-selected-version";
+import { isLocalDeployment } from "@/modules/deployments/domain/local-deployment";
 import { useExecutions } from "@/modules/executions/business-logic/use-executions";
+import { DEFAULT_EXECUTIONS_POLLING_INTERVAL } from "@/modules/executions/domain/fetch-executions";
 import { filterLocalExecutions } from "@/modules/executions/domain/filter-local-executions";
 import { ExecutionsTableContainer } from "@/modules/executions/feature/ExecutionsTableContainer";
 import {
 	type ExecutionsScope,
 	ExecutionsScopeToggle,
 } from "@/modules/executions/ui/ExecutionsScopeToggle";
-import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import { RefreshButton } from "@/shared/ui/RefreshButton";
 import {
 	TableToolbarContent,
 	TableToolbarRoot,
 } from "@/shared/ui/TableToolbar";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { DEFAULT_EXECUTIONS_POLLING_INTERVAL } from "@/modules/executions/domain/fetch-executions";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 
 export function FlowExecutionsContainer() {
-	const { flowId } = useParams({
-		from: "/_private/_navbar/flows/$flowId/$tab",
-	});
-	const { version, versions } = useSearch({
+	const { flowId, realDeployments, selected } = useSelectedVersion();
+	const { versions } = useSearch({
 		from: "/_private/_navbar/flows/$flowId",
 	});
 	const navigate = useNavigate();
-	const { data: flow } = useSuspenseQuery(flowsQueries.detail(flowId));
-	const { data: realDeployments } = useSuspenseQuery(
-		deploymentsQueries.list(flowId)
-	);
-	const deployments = withLocalDeployment(realDeployments, flowId, flow.name);
-	const selected = resolveSelectedDeployment(deployments, version);
 	const isLocal = isLocalDeployment(selected);
 	const activeScope: ExecutionsScope = versions === "all" ? "all" : "version";
 	const shouldServerFilter =

--- a/src/modules/root/feature/BreadcrumbsContainer.tsx
+++ b/src/modules/root/feature/BreadcrumbsContainer.tsx
@@ -1,3 +1,4 @@
+import { DeploymentVersionSwitcherContainer } from "@/modules/deployments/feature/DeploymentVersionSwitcherContainer";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
@@ -8,6 +9,8 @@ import {
 } from "@/shared/ui/breadcrumb";
 import { isMatch, Link, useMatches } from "@tanstack/react-router";
 import { Fragment } from "react";
+
+const FLOW_DETAIL_ROUTE_ID = "/_private/_navbar/flows/$flowId";
 
 export function BreadcrumbsContainer() {
 	const matches = useMatches();
@@ -36,6 +39,9 @@ export function BreadcrumbsContainer() {
 								<BreadcrumbLink render={<Link to={match.fullPath} />}>
 									{match.loaderData?.crumb.label}
 								</BreadcrumbLink>
+							)}
+							{match.routeId === FLOW_DETAIL_ROUTE_ID && (
+								<DeploymentVersionSwitcherContainer />
 							)}
 						</BreadcrumbItem>
 						{index < matchesWithCrumbs.length - 1 ? (

--- a/src/routes/_private/_navbar/flows/$flowId/route.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/route.tsx
@@ -1,4 +1,5 @@
 import { deploymentsQueries } from "@/modules/deployments/business-logic/deployments-queries";
+import { LOCAL_VERSION_ID } from "@/modules/deployments/domain/local-deployment";
 import { DeploymentHeaderContainer } from "@/modules/deployments/feature/DeploymentHeaderContainer";
 import { flowsQueries } from "@/modules/flows/business-logic/flows-queries";
 import { ensureQueryDataOr404 } from "@/shared/api/utils/handle-404";
@@ -11,13 +12,13 @@ import { z } from "zod";
 
 const flowSearchSchema = z.object({
 	version: z
-		.union([z.literal("local"), z.coerce.number().int().positive()])
+		.union([z.literal(LOCAL_VERSION_ID), z.coerce.number().int().positive()])
 		.optional(),
 	versions: z.enum(["all"]).optional(),
 });
 
 type FlowSearchSchemaInput = SearchSchemaInput & {
-	version?: number | "local";
+	version?: number | typeof LOCAL_VERSION_ID;
 	versions?: "all";
 };
 

--- a/src/routes/_private/_navbar/flows/$flowId/route.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/route.tsx
@@ -10,10 +10,16 @@ import {
 import { z } from "zod";
 
 const flowSearchSchema = z.object({
-	version: z.coerce.number().int().positive().optional(),
+	version: z
+		.union([z.literal("local"), z.coerce.number().int().positive()])
+		.optional(),
+	versions: z.enum(["all"]).optional(),
 });
 
-type FlowSearchSchemaInput = SearchSchemaInput & { version?: number };
+type FlowSearchSchemaInput = SearchSchemaInput & {
+	version?: number | "local";
+	versions?: "all";
+};
 
 function FlowRoute() {
 	return (


### PR DESCRIPTION
## Summary

Final slice of the flow-detail redesign, building on #153 (stacks data layer), #154 (deployment header), and #155 (invocation Overview + Executions tab split). Adds:

1. **Invoke drawer** — right-side drawer with an RJSF-rendered form over \`deployment.inputSchema\` that POSTs to \`/api/v1/pipeline_snapshots/{id}/runs\`. Success toasts and navigates to the new execution; backend errors surface in the toast.
2. **Version switcher pill in the breadcrumbs** — dropdown with sort order (Newest/Oldest), "Current default" section, "All versions" list, and an "Unversioned → local" section. Selecting a row navigates via \`?version=N\` (or \`?version=local\`).
3. **Local deployment view** — synthetic "local" entry in the deployments list for pipeline runs that never belonged to any Kitaru deployment. When \`?version=local\` the header shows \`flow · not deployed\`, the Invoke action / URL / snippets hide, and the Overview renders a "Running locally" card with a CLI hint. The Executions tab client-side-filters runs whose \`source_snapshot_id\` isn't in the Kitaru deployments set.
4. **Executions scoping** — the Executions table now takes \`source_snapshot_id\` so the \`v{N} | All versions\` toggle (shown above the table) scopes runs to the selected deployment by default.
5. **Tab-nav preserves search** — switching Overview / Executions / Memory preserves \`?version\` + \`?versions\`.

## Commits (14)

**Invoke drawer:**
- \`7dfda5d\` add invokeDeployment fetcher (raw fetch + CSRF + error handling)
- \`cb12fd0\` add useInvokeDeployment mutation hook
- \`9e7e2c0\` add InvokeDrawer ui (base-ui Dialog as sheet + @rjsf/shadcn)
- \`e4acd98\` wire Invoke drawer into header (InvokeDeploymentContainer orchestrator)

**Local deployment view:**
- \`74cbd95\` add LocalDeployment domain helpers (LOCAL_VERSION_ID, buildLocalDeployment, isLocalDeployment, withLocalDeployment)
- \`2d5602f\` accept version='local' for synthetic local deployment (route schema + resolver)
- \`19e65db\` append synthetic local entry to version list (also introduces VersionSwitcherPill + FlowInvokeActionsContainer + LocalOverviewCard + InvokeButton)
- \`245e0b8\` render not-deployed variant in header for local

**Executions scoping:**
- \`d15c5b5\` add filterLocalExecutions client-side helper
- \`5000878\` scope executions table to local runs when version=local (ExecutionsScopeToggle + local client-side filter)
- \`d50e014\` scope runs by source_snapshot_id (API filter + domain field alignment)

**Polish:**
- \`cf69f6b\` preserve search params when switching tabs
- \`696029a\` render version switcher pill in breadcrumbs
- \`5e3e1a2\` unnest ternary in FlowExecutionsContainer versionLabel

## Test plan

- [x] \`pnpm check:types\` — PASS
- [x] \`pnpm test:unit\` — 297/297
- [ ] Manual: breadcrumb pill opens dropdown with versions + Unversioned section; selecting a version updates \`?version=N\`; selecting \`local\` switches to the pre-deployment view
- [ ] Manual: Invoke button opens drawer; submitting a valid payload navigates to the new execution; invalid payload surfaces the server error via toast
- [ ] Manual: Executions scope toggle flips between \`v{N} | All versions\` and filters the table via \`source_snapshot_id\`; on \`?version=local\`, toggle reads \`local | All versions\` and client-side filters local runs
- [ ] Manual: switching tabs preserves the \`?version\` / \`?versions\` params