### PR TITLE
fix(flows): preserve version param in navigation and scope execution list

### DIFF
--- a/src/modules/deployments/feature/FlowInvocationContainer.tsx
+++ b/src/modules/deployments/feature/FlowInvocationContainer.tsx
@@ -29,11 +29,17 @@ function exampleFromSchema(
 }
 
 export function FlowInvocationContainer() {
-	const { flow, selected } = useSelectedVersion();
+	const { flowId, flow, realDeployments, selected } = useSelectedVersion();
 
 	if (!selected) return <InvocationEmptyState />;
 	if (isLocalDeployment(selected))
-		return <LocalOverviewCard flowName={flow.name} />;
+		return (
+			<LocalOverviewCard
+				flowName={flow.name}
+				flowId={flowId}
+				hasDeployments={realDeployments.length > 0}
+			/>
+		);
 
 	const origin = env.VITE_API_BASE_URL || window.location.origin;
 	const url = `${origin}/api/v1/pipeline_snapshots/${selected.id}/runs`;

--- a/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
+++ b/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
@@ -22,6 +22,7 @@ export function InvokeDeploymentContainer({
 				navigate({
 					to: "/flows/$flowId/executions/$executionId",
 					params: { flowId: deployment.flowId, executionId: runId },
+					search: { version: deployment.versionNumber },
 				});
 			},
 			onError: (error) => {

--- a/src/modules/deployments/ui/LocalOverviewCard.tsx
+++ b/src/modules/deployments/ui/LocalOverviewCard.tsx
@@ -1,6 +1,16 @@
-import { Info } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Info } from "lucide-react";
+import { Button } from "@/shared/ui/button";
 
-export function LocalOverviewCard({ flowName }: { flowName: string }) {
+export function LocalOverviewCard({
+	flowName,
+	flowId,
+	hasDeployments,
+}: {
+	flowName: string;
+	flowId: string;
+	hasDeployments: boolean;
+}) {
 	return (
 		<div className="container mx-auto px-4 py-6 sm:px-6 lg:px-8">
 			<div className="border-border bg-card flex items-start gap-3 rounded-md border p-5">
@@ -8,17 +18,59 @@ export function LocalOverviewCard({ flowName }: { flowName: string }) {
 					<Info className="text-muted-foreground size-4" aria-hidden />
 				</div>
 				<div className="min-w-0 flex-1">
-					<h2 className="text-sm font-semibold">Running locally</h2>
-					<p className="text-muted-foreground mt-1 text-xs">
-						These runs of <code className="font-mono text-xs">{flowName}</code>{" "}
-						haven't been published as a deployment yet. Publish a version with
-						the CLI to invoke this flow over HTTP and route traffic with tags.
-					</p>
-					<pre className="bg-muted/40 text-foreground mt-3 rounded px-3 py-2 font-mono text-xs">
-						<code>kitaru deploy {flowName}</code>
-					</pre>
+					{hasDeployments ? (
+						<LocalWithDeployments flowName={flowName} />
+					) : (
+						<LocalWithoutDeployments flowName={flowName} />
+					)}
+					<div className="mt-4">
+						<Button
+							nativeButton={false}
+							size="sm"
+							variant="outline"
+							render={
+								<Link
+									to="/flows/$flowId/$tab"
+									params={{ flowId, tab: "executions" }}
+									search={(prev) => prev}
+								/>
+							}
+						>
+							View executions
+							<ArrowRight />
+						</Button>
+					</div>
 				</div>
 			</div>
 		</div>
+	);
+}
+
+function LocalWithoutDeployments({ flowName }: { flowName: string }) {
+	return (
+		<>
+			<h2 className="text-sm font-semibold">Running locally</h2>
+			<p className="text-muted-foreground mt-1 text-xs">
+				<code className="font-mono text-xs">{flowName}</code> hasn't been
+				published as a deployment yet. Publish a version with the CLI to invoke
+				this flow over HTTP and route traffic with tags.
+			</p>
+			<pre className="bg-muted/40 text-foreground mt-3 rounded px-3 py-2 font-mono text-xs">
+				<code>kitaru deploy path/to/file.py:{flowName}</code>
+			</pre>
+		</>
+	);
+}
+
+function LocalWithDeployments({ flowName }: { flowName: string }) {
+	return (
+		<>
+			<h2 className="text-sm font-semibold">Viewing local runs</h2>
+			<p className="text-muted-foreground mt-1 text-xs">
+				You're viewing local runs of{" "}
+				<code className="font-mono text-xs">{flowName}</code>. Switch to a
+				deployed version in the version selector to invoke this flow over HTTP.
+			</p>
+		</>
 	);
 }

--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -4,6 +4,8 @@ import {
 } from "@/modules/checkpoints/business-logic/use-checkpoints";
 import { CheckpointDetailPanelContainer } from "@/modules/checkpoints/feature/CheckpointDetailPanelContainer";
 import type { PanelTab } from "@/modules/checkpoints/ui/CheckpointDetailPanelTabs";
+import { useSelectedVersion } from "@/modules/deployments/business-logic/use-selected-version";
+import { isLocalDeployment } from "@/modules/deployments/domain/local-deployment";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
 import { RefreshButton } from "@/shared/ui/RefreshButton";
 import { ThreePanelLayout } from "@/shared/ui/ThreePanelLayout";
@@ -14,6 +16,7 @@ import { useExecution } from "../business-logic/use-execution";
 import { useExecutions } from "../business-logic/use-executions";
 import { useSyncExecutionStatus } from "../business-logic/use-sync-execution-status";
 import { DEFAULT_EXECUTIONS_POLLING_INTERVAL } from "../domain/fetch-executions";
+import { filterLocalExecutions } from "../domain/filter-local-executions";
 import { ExecutionActionsDropdown } from "../ui/ExecutionActionsDropdown";
 import type { ExecutionLogsScope } from "./ExecutionLogsScopeSidebarContainer";
 import { ExecutionsList } from "../ui/ExecutionsList";
@@ -33,9 +36,16 @@ export function ExecutionContainer() {
 }
 
 function ExecutionContainerBody() {
-	const { flowId, executionId } = useParams({ from: ROUTE_ID });
+	const { executionId } = useParams({ from: ROUTE_ID });
+	const { flowId, realDeployments, selected } = useSelectedVersion();
+	const { versions } = useSearch({ from: "/_private/_navbar/flows/$flowId" });
 	const search = useSearch({ from: ROUTE_ID });
 	const navigate = useNavigate({ from: ROUTE_PATH });
+
+	const isLocal = isLocalDeployment(selected);
+	const activeScope = versions === "all" ? "all" : "version";
+	const shouldServerFilter =
+		activeScope === "version" && !!selected && !isLocal;
 
 	const activeTab: ExecutionTab = search.tab === "logs" ? "logs" : "execution";
 	const isLogsTab = activeTab === "logs";
@@ -62,6 +72,7 @@ function ExecutionContainerBody() {
 	};
 
 	const { executionsData, refetch: refetchExecutions } = useExecutions(flowId, {
+		snapshotId: shouldServerFilter ? selected?.id : undefined,
 		refetchInterval: DEFAULT_EXECUTIONS_POLLING_INTERVAL,
 	});
 	const { executionData, refetch: refetchExecution } =
@@ -93,9 +104,17 @@ function ExecutionContainerBody() {
 	const [activeCheckpointTab, setActiveCheckpointTab] =
 		useState<PanelTab>("logs");
 
-	const executionsSortedByCreatedAtDesc = [...executionsData].sort((a, b) => {
-		return (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0);
-	});
+	const kitaruSnapshotIds = new Set(realDeployments.map((d) => d.id));
+	const displayedExecutions =
+		activeScope === "version" && isLocal
+			? filterLocalExecutions(executionsData, kitaruSnapshotIds)
+			: executionsData;
+
+	const executionsSortedByCreatedAtDesc = [...displayedExecutions].sort(
+		(a, b) => {
+			return (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0);
+		}
+	);
 
 	return (
 		<div className="flex flex-1 flex-col overflow-hidden">

--- a/src/modules/executions/feature/ExecutionsTableContainer.tsx
+++ b/src/modules/executions/feature/ExecutionsTableContainer.tsx
@@ -1,3 +1,5 @@
+import type { Deployment } from "@/modules/deployments/domain/deployment";
+import { LOCAL_VERSION_ID } from "@/modules/deployments/domain/local-deployment";
 import {
 	StatusRenderer,
 	TextRenderer,
@@ -28,15 +30,20 @@ import { ExecutionActionsDropdown } from "../ui/ExecutionActionsDropdown";
 export function ExecutionsTableContainer({
 	executionRows,
 	flowId,
+	realDeployments,
 }: {
 	executionRows: Execution[];
 	flowId: string;
+	realDeployments: Deployment[];
 }) {
 	const [sorting, setSorting] = useState<SortingState>([
 		{ id: "createdAt", desc: true },
 	]);
 
-	const columns = useMemo(() => buildExecutionColumns(flowId), [flowId]);
+	const columns = useMemo(
+		() => buildExecutionColumns(flowId, realDeployments),
+		[flowId, realDeployments]
+	);
 
 	const table = useReactTable({
 		data: executionRows,
@@ -105,7 +112,11 @@ export function ExecutionsTableContainer({
 	);
 }
 
-function buildExecutionColumns(flowId: string): ColumnDef<Execution>[] {
+function buildExecutionColumns(
+	flowId: string,
+	realDeployments: Deployment[]
+): ColumnDef<Execution>[] {
+	const deploymentBySnapshotId = new Map(realDeployments.map((d) => [d.id, d]));
 	return [
 		{
 			accessorKey: "execution",
@@ -113,15 +124,24 @@ function buildExecutionColumns(flowId: string): ColumnDef<Execution>[] {
 			header: ({ column }) => (
 				<SortableHeader column={column} label="Execution" />
 			),
-			cell: ({ row }) => (
-				<Link
-					to="/flows/$flowId/executions/$executionId"
-					params={{ flowId, executionId: row.original.id }}
-					className="block px-2 py-3.5 hover:underline"
-				>
-					<ExecutionName index={row.original.index} />
-				</Link>
-			),
+			cell: ({ row }) => {
+				const deployment = row.original.snapshotId
+					? deploymentBySnapshotId.get(row.original.snapshotId)
+					: undefined;
+				const version: number | typeof LOCAL_VERSION_ID = deployment
+					? deployment.versionNumber
+					: LOCAL_VERSION_ID;
+				return (
+					<Link
+						to="/flows/$flowId/executions/$executionId"
+						params={{ flowId, executionId: row.original.id }}
+						search={{ version }}
+						className="block px-2 py-3.5 hover:underline"
+					>
+						<ExecutionName index={row.original.index} />
+					</Link>
+				);
+			},
 		},
 		{
 			accessorKey: "status",

--- a/src/modules/executions/ui/ExecutionsList.tsx
+++ b/src/modules/executions/ui/ExecutionsList.tsx
@@ -26,7 +26,12 @@ export function ExecutionsList({
 					key={execution.id}
 					to="/flows/$flowId/executions/$executionId"
 					params={{ flowId, executionId: execution.id }}
-					search={(prev) => (prev.tab === "logs" ? { tab: "logs" } : {})}
+					search={(prev) => {
+						const next: { tab?: "logs"; version?: typeof prev.version } = {};
+						if (prev.tab === "logs") next.tab = "logs";
+						if (prev.version !== undefined) next.version = prev.version;
+						return next;
+					}}
 					className={cn(
 						"flex items-center justify-between gap-2 px-3 py-1.5 text-sm transition-colors",
 						execution.id === activeexecutionId

--- a/src/modules/flows/feature/FlowExecutionsContainer.tsx
+++ b/src/modules/flows/feature/FlowExecutionsContainer.tsx
@@ -78,6 +78,7 @@ export function FlowExecutionsContainer() {
 				<ExecutionsTableContainer
 					executionRows={displayedExecutions}
 					flowId={flowId}
+					realDeployments={realDeployments}
 				/>
 			</div>
 		</>

--- a/src/modules/root/feature/BreadcrumbsContainer.tsx
+++ b/src/modules/root/feature/BreadcrumbsContainer.tsx
@@ -36,7 +36,9 @@ export function BreadcrumbsContainer() {
 							) : match.loaderData?.crumb.disabled ? (
 								<BreadcrumbPage>{match.loaderData?.crumb.label}</BreadcrumbPage>
 							) : (
-								<BreadcrumbLink render={<Link to={match.fullPath} />}>
+								<BreadcrumbLink
+									render={<Link to={match.fullPath} search={(prev) => prev} />}
+								>
 									{match.loaderData?.crumb.label}
 								</BreadcrumbLink>
 							)}

--- a/src/routes/_private/_navbar/flows/$flowId/executions/$executionId/route.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/executions/$executionId/route.tsx
@@ -57,7 +57,7 @@ export const Route = createFileRoute(
 		return {
 			executionIndex: formatExecutionIndex(execution.index),
 			crumb: {
-				label: `${formatExecutionIndex(execution.index)}#`,
+				label: `#${formatExecutionIndex(execution.index)}`,
 				disabled: false,
 			},
 		};

--- a/src/routes/_private/_navbar/flows/$flowId/index.tsx
+++ b/src/routes/_private/_navbar/flows/$flowId/index.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/_private/_navbar/flows/$flowId/")({
-	beforeLoad: ({ params: { flowId } }) => {
+	beforeLoad: ({ params: { flowId }, search }) => {
 		throw redirect({
 			to: "/flows/$flowId/$tab",
 			params: { flowId: flowId, tab: "overview" },
+			search,
 		});
 	},
 });


### PR DESCRIPTION
## Summary

- **LocalOverviewCard**: branches on whether real deployments exist. Adds a "View executions" button and fixes the CLI hint to `kitaru deploy path/to/file.py:flow_name`.
- **Breadcrumbs**: preserve `search` on breadcrumb `Link`s so deployment version context persists across the flow detail hierarchy.
- **`/flows/$flowId` index redirect**: pass through `search` to `$tab` so clicking the flow breadcrumb keeps `version`.
- **Execution detail sidebar**: applies the same snapshot filter as the executions table (via `useSelectedVersion`), so the sidebar matches the table.
- **Executions table row link**: navigates with `version` derived from the row's `snapshotId` → that deployment's `versionNumber` (or `local`). Clicking an execution from the "All versions" scope now lands inside that execution's own deployment context.
- **Invocation success redirect**: passes `search: { version: deployment.versionNumber }` so the user stays in the invoked deployment's context.
- **Execution breadcrumb label**: `#0014` instead of `0014#`.

## Test plan

- [ ] On a flow with no deployments, the overview tab shows the "Running locally" card with the updated command and the "View executions" button navigates to the executions tab.
- [ ] On a flow with deployments, selecting "local" in the version switcher shows the "Viewing local runs" copy.
- [ ] With a non-default `version` selected, clicking breadcrumbs (flow name, executions tab) keeps the `version` in the URL.
- [ ] On the execution detail page, the sidebar executions list matches the flow executions table for the current version scope (including "All versions").
- [ ] From the executions table under "All versions", clicking an execution that belongs to a different deployment lands with `version=<that deployment>` in the URL.
- [ ] Invoking a deployment redirects to the resulting execution with `version=<invoked deployment>` in the URL.
- [ ] Execution breadcrumb displays `#0014` (hash before the number).