### PR TITLE
fix(executions): preserve version param when switching tab/log scope

### DIFF
--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -52,7 +52,10 @@ function ExecutionContainerBody() {
 
 	const setActiveTab = (tab: ExecutionTab) => {
 		navigate({
-			search: () => (tab === "logs" ? { tab: "logs" } : {}),
+			search: (prev) =>
+				tab === "logs"
+					? { version: prev.version, tab: "logs" }
+					: { version: prev.version },
 			replace: true,
 		});
 	};
@@ -63,10 +66,14 @@ function ExecutionContainerBody() {
 
 	const setSelectedScope = (scope: ExecutionLogsScope) => {
 		navigate({
-			search: () =>
+			search: (prev) =>
 				scope.kind === "root"
-					? { tab: "logs" }
-					: { tab: "logs", scope: scope.checkpointId },
+					? { version: prev.version, tab: "logs" }
+					: {
+							version: prev.version,
+							tab: "logs",
+							scope: scope.checkpointId,
+						},
 			replace: true,
 		});
 	};


### PR DESCRIPTION
## Summary

Carries `prev.version` through `setActiveTab` and `setSelectedScope` on the execution detail page, so switching between the Execution and Logs tabs (and changing the log scope) no longer drops the deployment version from the URL.

Follow-up to #158 — that PR covered navigation into and out of the execution detail page; this one fixes navigation within it.

## Test plan

- [ ] Open an execution with `?version=<N>` set. Switch between Execution and Logs tabs — `version=<N>` remains in the URL.
- [ ] On the Logs tab, switch the scope between root and a checkpoint — `version=<N>` remains in the URL.
- [ ] The sidebar executions list continues to scope correctly to the preserved version.