### PR TITLE
fix(deployments): correct invoke snippets and add parameter pre-fill

### DIFF
--- a/src/modules/deployments/domain/deployment.ts
+++ b/src/modules/deployments/domain/deployment.ts
@@ -1,6 +1,7 @@
 import type { components } from "@/shared/api/openapi";
 import type { ExecutionStatus } from "@/modules/executions/domain/execution";
 import { parseBackendTimestamp } from "@/shared/utils/time";
+import { isRecord } from "@/shared/utils/is-record";
 
 export const KITARU_SNAPSHOT_NAME = /^kitaru::(.+)::v(\d+)$/;
 
@@ -27,6 +28,7 @@ export type Deployment = {
 	stackId?: string;
 	stackName?: string;
 	inputSchema?: Record<string, unknown>;
+	defaultParameters?: Record<string, unknown>;
 	latestRunId?: string;
 	latestRunStatus?: ExecutionStatus;
 	runnable: boolean;
@@ -89,9 +91,20 @@ export function deploymentFromApiToDomain(
 		stackId: snapshot.resources?.stack?.id,
 		stackName: snapshot.resources?.stack?.name,
 		inputSchema: snapshot.metadata?.config_schema ?? undefined,
+		defaultParameters: extractDefaultParameters(
+			snapshot.metadata?.config_template
+		),
 		latestRunId: snapshot.resources?.latest_run_id ?? undefined,
 		latestRunStatus: snapshot.resources?.latest_run_status ?? undefined,
 		runnable: snapshot.body?.runnable ?? false,
 		deployable: snapshot.body?.deployable ?? false,
 	};
+}
+
+function extractDefaultParameters(
+	configTemplate: Record<string, unknown> | null | undefined
+): Record<string, unknown> | undefined {
+	if (!configTemplate) return undefined;
+	const params = configTemplate.parameters;
+	return isRecord(params) ? params : undefined;
 }

--- a/src/modules/deployments/domain/fetch-deployment.spec.ts
+++ b/src/modules/deployments/domain/fetch-deployment.spec.ts
@@ -56,7 +56,7 @@ describe("fetchDeployment", () => {
 		getSpy.mockRestore();
 	});
 
-	it("calls the detail endpoint with hydrate=true", async () => {
+	it("calls the detail endpoint with hydrate and include_config_schema enabled", async () => {
 		getSpy.mockResolvedValue({
 			data: mkSnapshot(),
 			error: undefined,
@@ -71,7 +71,7 @@ describe("fetchDeployment", () => {
 			{
 				params: {
 					path: { snapshot_id: "snap-1" },
-					query: { hydrate: true },
+					query: { hydrate: true, include_config_schema: true },
 				},
 			}
 		);

--- a/src/modules/deployments/domain/fetch-deployment.ts
+++ b/src/modules/deployments/domain/fetch-deployment.ts
@@ -12,7 +12,7 @@ export async function fetchDeployment(snapshotId: string): Promise<Deployment> {
 		{
 			params: {
 				path: { snapshot_id: snapshotId },
-				query: { hydrate: true },
+				query: { hydrate: true, include_config_schema: true },
 			},
 		}
 	);

--- a/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
+++ b/src/modules/deployments/feature/InvokeDeploymentContainer.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import type { Deployment } from "../domain/deployment";
+import { deploymentsQueries } from "../business-logic/deployments-queries";
 import { useInvokeDeployment } from "../business-logic/use-invoke-deployment";
 import { InvokeButton } from "../ui/InvokeButton";
 import { InvokeDrawer } from "../ui/InvokeDrawer";
@@ -13,6 +15,17 @@ export function InvokeDeploymentContainer({
 }) {
 	const [open, setOpen] = useState(false);
 	const navigate = useNavigate();
+
+	const detailQuery = useQuery({
+		...deploymentsQueries.detail(deployment.id),
+		enabled: open,
+	});
+
+	const defaultValue =
+		detailQuery.data?.defaultParameters != null
+			? JSON.stringify(detailQuery.data.defaultParameters, null, 2)
+			: "{}";
+
 	const { invokeDeployment, isPending } = useInvokeDeployment(
 		deployment.flowId,
 		{
@@ -45,7 +58,8 @@ export function InvokeDeploymentContainer({
 				open={open}
 				onOpenChange={setOpen}
 				title={`Invoke ${deployment.flowName} · v${deployment.versionNumber}`}
-				schema={deployment.inputSchema}
+				defaultValue={defaultValue}
+				isLoading={open && detailQuery.isPending}
 				isSubmitting={isPending}
 				onSubmit={handleSubmit}
 			/>

--- a/src/modules/deployments/ui/InvocationOverviewCard.tsx
+++ b/src/modules/deployments/ui/InvocationOverviewCard.tsx
@@ -17,9 +17,9 @@ export function InvocationOverviewCard({
 			<div className="border-border bg-card rounded-md border p-5">
 				<h2 className="text-sm font-semibold">Invoke</h2>
 				<p className="text-muted-foreground mt-1 text-xs">
-					Authenticate with a workspace API key. Routing resolves via the{" "}
-					<code className="font-mono text-xs">default</code> tag unless you pin
-					a specific version at call time.
+					Authenticate with a workspace API key. This URL is pinned to the
+					selected snapshot. The CLI example routes via the{" "}
+					<code className="font-mono text-xs">default</code> tag instead.
 				</p>
 				<div className="mt-4">
 					<InvocationUrlBlock url={url} className="max-w-full" />

--- a/src/modules/deployments/ui/InvocationSnippets.tsx
+++ b/src/modules/deployments/ui/InvocationSnippets.tsx
@@ -30,11 +30,15 @@ type SnippetInputs = {
 	exampleInput: Record<string, unknown>;
 };
 
+function buildRequestBody(exampleInput: Record<string, unknown>) {
+	return { run_configuration: { parameters: exampleInput } };
+}
+
 function renderCurl({ url, exampleInput }: SnippetInputs) {
 	return `curl -X POST ${url} \\
   -H "Authorization: Bearer $KITARU_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '${JSON.stringify(exampleInput)}'`;
+  -d '${JSON.stringify(buildRequestBody(exampleInput))}'`;
 }
 
 function renderPython({ url, exampleInput }: SnippetInputs) {
@@ -45,14 +49,14 @@ response = requests.post(
         "Authorization": f"Bearer {os.environ['KITARU_API_KEY']}",
         "Content-Type": "application/json",
     },
-    json=${JSON.stringify(exampleInput, null, 2)},
+    json=${JSON.stringify(buildRequestBody(exampleInput), null, 2)},
 )
 response.raise_for_status()
 print(response.json())`;
 }
 
 function renderJavaScript({ url, exampleInput }: SnippetInputs) {
-	return `const payload = ${JSON.stringify(exampleInput, null, 2)};
+	return `const payload = ${JSON.stringify(buildRequestBody(exampleInput), null, 2)};
 const response = await fetch("${url}", {
   method: "POST",
   headers: {

--- a/src/modules/deployments/ui/InvokeDrawer.tsx
+++ b/src/modules/deployments/ui/InvokeDrawer.tsx
@@ -1,40 +1,27 @@
-import { useRef } from "react";
+import { useState } from "react";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
-import { withTheme } from "@rjsf/core";
-import type RjsfForm from "@rjsf/core";
-import { Theme as shadcnTheme } from "@rjsf/shadcn";
-import type { RJSFSchema } from "@rjsf/utils";
-import validator from "@rjsf/validator-ajv8";
-import { Send, X } from "lucide-react";
+import { Loader2, Send, X } from "lucide-react";
 import { Button } from "@/shared/ui/button";
+import { isRecord } from "@/shared/utils/is-record";
 import { cn } from "@/shared/utils/styles";
-
-const Form = withTheme(shadcnTheme);
-
-const UI_SCHEMA = {
-	"ui:submitButtonOptions": { norender: true },
-	"ui:title": "",
-	"ui:description": "",
-};
-
-const EMPTY_SCHEMA: RJSFSchema = {};
 
 export function InvokeDrawer({
 	open,
 	onOpenChange,
 	title,
-	schema,
+	defaultValue = "{}",
+	isLoading,
 	isSubmitting,
 	onSubmit,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	title: string;
-	schema: RJSFSchema | undefined;
+	defaultValue?: string;
+	isLoading?: boolean;
 	isSubmitting?: boolean;
 	onSubmit: (parameters: Record<string, unknown>) => void;
 }) {
-	const formRef = useRef<RjsfForm>(null);
 	return (
 		<DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
 			<DialogPrimitive.Portal>
@@ -62,38 +49,107 @@ export function InvokeDrawer({
 							<span className="sr-only">Close</span>
 						</DialogPrimitive.Close>
 					</div>
-					<div className="flex-1 overflow-y-auto p-4">
-						<div className="text-xs [&_button]:text-xs [&_input]:text-xs [&_label]:text-xs">
-							<Form
-								ref={formRef}
-								schema={schema ?? EMPTY_SCHEMA}
-								validator={validator}
-								uiSchema={UI_SCHEMA}
-								onSubmit={({ formData }) => onSubmit(formData ?? {})}
-							/>
+					{isLoading ? (
+						<div className="text-muted-foreground flex flex-1 items-center justify-center gap-2 text-xs">
+							<Loader2 className="size-3.5 animate-spin" />
+							Loading parameters…
 						</div>
-					</div>
-					<div className="border-border flex gap-2 border-t px-4 py-3">
-						<Button
-							variant="outline"
-							size="sm"
-							className="flex-1"
-							onClick={() => onOpenChange(false)}
-						>
-							Cancel
-						</Button>
-						<Button
-							size="sm"
-							className="flex-1"
-							disabled={isSubmitting}
-							onClick={() => formRef.current?.submit()}
-						>
-							<Send className="size-3.5" />
-							{isSubmitting ? "Invoking…" : "Invoke"}
-						</Button>
-					</div>
+					) : (
+						<ParametersEditor
+							key={defaultValue}
+							defaultValue={defaultValue}
+							isSubmitting={isSubmitting}
+							onSubmit={onSubmit}
+							onCancel={() => onOpenChange(false)}
+						/>
+					)}
 				</DialogPrimitive.Popup>
 			</DialogPrimitive.Portal>
 		</DialogPrimitive.Root>
 	);
+}
+
+function ParametersEditor({
+	defaultValue,
+	isSubmitting,
+	onSubmit,
+	onCancel,
+}: {
+	defaultValue: string;
+	isSubmitting?: boolean;
+	onSubmit: (parameters: Record<string, unknown>) => void;
+	onCancel: () => void;
+}) {
+	const [value, setValue] = useState(defaultValue);
+	const [error, setError] = useState<string | null>(null);
+
+	function handleInvoke() {
+		const parsed = safeJsonParse(value);
+		if (!isRecord(parsed)) {
+			setError("Parameters must be a JSON object.");
+			return;
+		}
+		setError(null);
+		onSubmit(parsed);
+	}
+
+	return (
+		<>
+			<div className="flex flex-1 flex-col gap-2 overflow-y-auto p-4">
+				<label htmlFor="invoke-parameters" className="text-xs font-medium">
+					Parameters (JSON)
+				</label>
+				<textarea
+					id="invoke-parameters"
+					value={value}
+					onChange={(e) => {
+						setValue(e.target.value);
+						if (error) setError(null);
+					}}
+					spellCheck={false}
+					className={cn(
+						"border-border bg-background min-h-48 flex-1 rounded-md border p-2",
+						"font-mono text-xs leading-relaxed",
+						"focus-visible:ring-ring outline-none focus-visible:ring-2",
+						error && "border-destructive focus-visible:ring-destructive"
+					)}
+				/>
+				{error ? (
+					<p className="text-destructive text-xs">{error}</p>
+				) : (
+					<p className="text-muted-foreground text-xs">
+						Sent as{" "}
+						<code className="font-mono">run_configuration.parameters</code>.
+					</p>
+				)}
+			</div>
+			<div className="border-border flex gap-2 border-t px-4 py-3">
+				<Button
+					variant="outline"
+					size="sm"
+					className="flex-1"
+					onClick={onCancel}
+				>
+					Cancel
+				</Button>
+				<Button
+					size="sm"
+					className="flex-1"
+					disabled={isSubmitting}
+					onClick={handleInvoke}
+				>
+					<Send className="size-3.5" />
+					{isSubmitting ? "Invoking…" : "Invoke"}
+				</Button>
+			</div>
+		</>
+	);
+}
+
+function safeJsonParse(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return undefined;
+	}
 }


### PR DESCRIPTION
## Summary

- HTTP snippets (cURL / Python / JavaScript) now wrap inputs as `run_configuration.parameters` to match the API contract — previously the example input was sent as the top-level body, silently failing to pass parameters
- Overview card copy clarified: direct URL is pinned to the selected snapshot; `default` tag routing noted only for the CLI snippet
- Invoke drawer fetches `config_template.parameters` (via `include_config_schema=true` on the detail endpoint) and pre-fills the JSON textarea with actual default values from the backend
- Drawer shows a loading state while the detail query is in-flight, then mounts the editor with pre-filled defaults

## Test plan

- [ ] Open a flow's Overview tab — verify cURL/Python/JS snippets wrap body as `{"run_configuration":{"parameters":{...}}}`
- [ ] Verify CLI snippet still uses `--input '{...}'` with raw parameters
- [ ] Click Invoke on a deployed version — drawer should show a spinner briefly, then pre-fill the textarea with default parameter values from the backend
- [ ] Edit the JSON and invoke — confirm the run starts with the edited parameters
- [ ] Submit invalid JSON — confirm the error message appears and submit is blocked