### PR TITLE
test(e2e): add coverage for execution-level logs tab

### DIFF
--- a/e2e/fixtures/api/executions.ts
+++ b/e2e/fixtures/api/executions.ts
@@ -111,20 +111,19 @@ export function makeCheckpointNode(overrides: Partial<Node> = {}): Node {
 			type: "step",
 		},
 		...overrides,
-	} as Node;
+	};
 }
 
-type DagResponseApi = {
-	status: string;
-	nodes: Node[];
-};
+type DagResponse = components["schemas"]["PipelineRunDAG"];
 
 export function makeDagResponse(
-	overrides: Partial<DagResponseApi> = {}
-): DagResponseApi {
+	overrides: Partial<DagResponse> = {}
+): DagResponse {
 	return {
+		id: "22222222-2222-2222-2222-222222222222",
 		status: "completed",
 		nodes: [makeCheckpointNode()],
+		edges: [],
 		...overrides,
 	};
 }

--- a/e2e/fixtures/api/executions.ts
+++ b/e2e/fixtures/api/executions.ts
@@ -9,6 +9,10 @@ type LogsResponse = components["schemas"]["LogsResponse"];
 type LogsResponseBody = components["schemas"]["LogsResponseBody"];
 type LogEntry = components["schemas"]["LogEntry"];
 type Node = components["schemas"]["Node"];
+type StepRunResponse = components["schemas"]["StepRunResponse"];
+type StepRunResponseBody = components["schemas"]["StepRunResponseBody"];
+type StepRunResponseResources =
+	components["schemas"]["StepRunResponseResources"];
 
 type LogsResponseOverrides = Partial<Omit<LogsResponse, "body">> & {
 	body?: Partial<LogsResponseBody>;
@@ -20,6 +24,15 @@ type ExecutionOverrides = Partial<
 	body?: Partial<PipelineRunResponseBody>;
 	resources?: Partial<PipelineRunResponseResources>;
 };
+
+type CheckpointOverrides = Partial<
+	Omit<StepRunResponse, "body" | "resources">
+> & {
+	body?: Partial<StepRunResponseBody>;
+	resources?: Partial<StepRunResponseResources>;
+};
+
+const DEFAULT_CHECKPOINT_ID = "33333333-3333-3333-3333-333333333333";
 
 const DEFAULT_EXECUTION_ID = "11111111-1111-1111-1111-111111111111";
 const DEFAULT_EXECUTION_NAME = "demo-execution";
@@ -101,8 +114,8 @@ export function makeLogEntries(
 
 export function makeCheckpointNode(overrides: Partial<Node> = {}): Node {
 	return {
-		id: "33333333-3333-3333-3333-333333333333",
-		node_id: "33333333-3333-3333-3333-333333333333",
+		id: DEFAULT_CHECKPOINT_ID,
+		node_id: DEFAULT_CHECKPOINT_ID,
 		name: "load_data",
 		type: "step",
 		metadata: {
@@ -111,6 +124,34 @@ export function makeCheckpointNode(overrides: Partial<Node> = {}): Node {
 			type: "step",
 		},
 		...overrides,
+	};
+}
+
+export function makeCheckpoint(
+	overrides: CheckpointOverrides = {}
+): StepRunResponse {
+	const {
+		body: bodyOverrides,
+		resources: resourceOverrides,
+		...rest
+	} = overrides;
+	return {
+		id: DEFAULT_CHECKPOINT_ID,
+		name: "load_data",
+		body: {
+			created: "2024-01-01T00:00:00Z",
+			updated: "2024-01-01T00:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			status: "completed",
+			version: 1,
+			is_retriable: false,
+			...bodyOverrides,
+		},
+		resources: {
+			log_collection: [makeLogsResponse({ body: { source: "stdout" } })],
+			...resourceOverrides,
+		},
+		...rest,
 	};
 }
 

--- a/e2e/fixtures/api/executions.ts
+++ b/e2e/fixtures/api/executions.ts
@@ -1,0 +1,130 @@
+import type { components } from "@/shared/api/openapi";
+import { makeUser } from "./current-user";
+
+type PipelineRunResponse = components["schemas"]["PipelineRunResponse"];
+type PipelineRunResponseBody = components["schemas"]["PipelineRunResponseBody"];
+type PipelineRunResponseResources =
+	components["schemas"]["PipelineRunResponseResources"];
+type LogsResponse = components["schemas"]["LogsResponse"];
+type LogsResponseBody = components["schemas"]["LogsResponseBody"];
+type LogEntry = components["schemas"]["LogEntry"];
+type Node = components["schemas"]["Node"];
+
+type LogsResponseOverrides = Partial<Omit<LogsResponse, "body">> & {
+	body?: Partial<LogsResponseBody>;
+};
+
+type ExecutionOverrides = Partial<
+	Omit<PipelineRunResponse, "body" | "resources">
+> & {
+	body?: Partial<PipelineRunResponseBody>;
+	resources?: Partial<PipelineRunResponseResources>;
+};
+
+const DEFAULT_EXECUTION_ID = "11111111-1111-1111-1111-111111111111";
+const DEFAULT_EXECUTION_NAME = "demo-execution";
+
+export function makeLogsResponse(
+	overrides: LogsResponseOverrides = {}
+): LogsResponse {
+	const { body: bodyOverrides, ...rest } = overrides;
+	return {
+		id: "99999999-9999-9999-9999-999999999991",
+		body: {
+			created: "2024-01-01T00:00:00Z",
+			updated: "2024-01-01T00:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			source: "stdout",
+			...bodyOverrides,
+		},
+		...rest,
+	};
+}
+
+export function makeExecution(
+	overrides: ExecutionOverrides = {}
+): PipelineRunResponse {
+	const {
+		body: bodyOverrides,
+		resources: resourceOverrides,
+		...rest
+	} = overrides;
+	return {
+		id: DEFAULT_EXECUTION_ID,
+		name: DEFAULT_EXECUTION_NAME,
+		body: {
+			created: "2024-01-01T00:00:00Z",
+			updated: "2024-01-01T00:00:00Z",
+			project_id: "00000000-0000-0000-0000-000000000000",
+			status: "completed",
+			in_progress: false,
+			index: 0,
+			...bodyOverrides,
+		},
+		resources: {
+			tags: [],
+			log_collection: [
+				makeLogsResponse({ body: { source: "stdout" } }),
+				makeLogsResponse({
+					id: "99999999-9999-9999-9999-999999999992",
+					body: { source: "stderr" },
+				}),
+			],
+			user: makeUser(),
+			...resourceOverrides,
+		},
+		...rest,
+	};
+}
+
+export function makeLogEntry(overrides: Partial<LogEntry> = {}): LogEntry {
+	return {
+		timestamp: "2024-01-01T00:00:00Z",
+		level: 20, // INFO
+		message: "Log message",
+		...overrides,
+	};
+}
+
+export function makeLogEntries(
+	count: number,
+	overrides: Partial<LogEntry> = {}
+): LogEntry[] {
+	return Array.from({ length: count }, (_, i) =>
+		makeLogEntry({
+			timestamp: new Date(Date.UTC(2024, 0, 1, 0, 0, i)).toISOString(),
+			message: `Log line ${i + 1}`,
+			...overrides,
+		})
+	);
+}
+
+export function makeCheckpointNode(overrides: Partial<Node> = {}): Node {
+	return {
+		id: "33333333-3333-3333-3333-333333333333",
+		node_id: "33333333-3333-3333-3333-333333333333",
+		name: "load_data",
+		type: "step",
+		metadata: {
+			status: "completed",
+			duration: 5,
+			type: "step",
+		},
+		...overrides,
+	} as Node;
+}
+
+type DagResponseApi = {
+	status: string;
+	nodes: Node[];
+};
+
+export function makeDagResponse(
+	overrides: Partial<DagResponseApi> = {}
+): DagResponseApi {
+	return {
+		status: "completed",
+		nodes: [makeCheckpointNode()],
+		...overrides,
+	};
+}

--- a/e2e/fixtures/api/index.ts
+++ b/e2e/fixtures/api/index.ts
@@ -8,3 +8,11 @@ export {
 	makeServiceAccount,
 	makeServiceAccountPage,
 } from "./api-keys";
+export {
+	makeExecution,
+	makeLogsResponse,
+	makeLogEntry,
+	makeLogEntries,
+	makeCheckpointNode,
+	makeDagResponse,
+} from "./executions";

--- a/e2e/fixtures/api/index.ts
+++ b/e2e/fixtures/api/index.ts
@@ -14,5 +14,6 @@ export {
 	makeLogEntry,
 	makeLogEntries,
 	makeCheckpointNode,
+	makeCheckpoint,
 	makeDagResponse,
 } from "./executions";

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "../fixtures/test";
+import {
+	makeExecution,
+	makeLogEntries,
+	makeDagResponse,
+	makePipeline,
+} from "../fixtures/api";
+
+const EXECUTION_ID = "11111111-1111-1111-1111-111111111111";
+const FLOW_ID = "22222222-2222-2222-2222-222222222222";
+
+const logsUrl = `/flows/${FLOW_ID}/executions/${EXECUTION_ID}?tab=logs`;
+
+const emptyArtifactVersionsPage = {
+	index: 1,
+	max_size: 10000,
+	total_pages: 1,
+	total: 0,
+	items: [],
+};
+
+test.beforeEach(async ({ mockApi, authenticatedPage }) => {
+	void authenticatedPage;
+	await mockApi({
+		"/api/v1/pipelines/{pipeline_id}": {
+			get: makePipeline({ id: FLOW_ID, name: "demo-flow" }),
+		},
+		"/api/v1/runs": {
+			get: {
+				index: 1,
+				max_size: 1000,
+				total_pages: 1,
+				total: 1,
+				items: [makeExecution()],
+			},
+		},
+		"/api/v1/runs/{run_id}": { get: makeExecution() },
+		"/api/v1/runs/{run_id}/dag": { get: makeDagResponse() },
+		"/api/v1/runs/{run_id}/logs": { get: makeLogEntries(5) },
+		"/api/v1/artifact_versions": { get: emptyArtifactVersionsPage },
+	});
+});
+
+test("renders execution log entries", async ({ page }) => {
+	await page.goto(logsUrl);
+
+	await expect(page.getByText("Log line 1")).toBeVisible();
+	await expect(page.getByText("Log line 5")).toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -343,3 +343,35 @@ test("scope sidebar switches between execution and checkpoint logs", async ({
 	await expect(page.getByText("execution-level line")).toBeVisible();
 	await expect(page).not.toHaveURL(new RegExp(`scope=${CHECKPOINT_ID}`));
 });
+
+test("shows error state with retry when logs endpoint fails", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: { status: 500, body: { detail: "boom" } },
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	await expect(page.getByText("Failed to load logs")).toBeVisible();
+
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "after retry",
+				},
+			],
+		},
+	});
+
+	await page.getByRole("button", { name: "Retry" }).click();
+
+	await expect(page.getByText("after retry")).toBeVisible();
+	await expect(page.getByText("Failed to load logs")).not.toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -222,3 +222,30 @@ test("source selector switches visible log entries", async ({
 	await expect(page.getByText("stderr line 1")).toBeVisible();
 	await expect(page.getByText("stdout line 1")).not.toBeVisible();
 });
+
+test("copy button writes log entries to the clipboard", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "hello world",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	await page.getByRole("button", { name: "Copy all logs" }).click();
+
+	const clipboardText = await page.evaluate(() =>
+		navigator.clipboard.readText()
+	);
+	expect(clipboardText).toContain("hello world");
+	expect(clipboardText).toContain("INFO");
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -184,3 +184,41 @@ test("level filter hides entries below the selected level", async ({
 	await expect(page.getByText("info entry")).not.toBeVisible();
 	await expect(page.getByText("another info")).not.toBeVisible();
 });
+
+test("source selector switches visible log entries", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: ({ query }) => {
+				if (query.source === "stderr") {
+					return [
+						{
+							timestamp: "2024-01-01T00:00:00Z",
+							level: 40,
+							message: "stderr line 1",
+						},
+					];
+				}
+				return [
+					{
+						timestamp: "2024-01-01T00:00:00Z",
+						level: 20,
+						message: "stdout line 1",
+					},
+				];
+			},
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	await expect(page.getByText("stdout line 1")).toBeVisible();
+
+	await page.getByRole("combobox").filter({ hasText: "stdout" }).click();
+	await page.getByRole("option", { name: "stderr" }).click();
+
+	await expect(page.getByText("stderr line 1")).toBeVisible();
+	await expect(page.getByText("stdout line 1")).not.toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -375,3 +375,40 @@ test("shows error state with retry when logs endpoint fails", async ({
 	await expect(page.getByText("after retry")).toBeVisible();
 	await expect(page.getByText("Failed to load logs")).not.toBeVisible();
 });
+
+test("shows stale banner when polling fails after initial success", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}": {
+			get: makeExecution({ body: { status: "running" } }),
+		},
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "initial line",
+				},
+			],
+		},
+	});
+
+	await page.clock.install();
+
+	await page.goto(logsUrl);
+	await expect(page.getByText("initial line")).toBeVisible();
+
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: { status: 500, body: { detail: "polling broke" } },
+		},
+	});
+
+	await page.clock.fastForward(4000);
+
+	await expect(
+		page.getByText("Live updates paused — couldn't reach the server.")
+	).toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -275,3 +275,71 @@ test("download button offers a .log file with the execution id", async ({
 
 	expect(download.suggestedFilename()).toBe(`execution-${EXECUTION_ID}.log`);
 });
+
+test("scope sidebar switches between execution and checkpoint logs", async ({
+	page,
+	mockApi,
+}) => {
+	const CHECKPOINT_ID = "33333333-3333-3333-3333-333333333333";
+
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "execution-level line",
+				},
+			],
+		},
+		"/api/v1/steps/{step_id}": {
+			get: {
+				id: CHECKPOINT_ID,
+				name: "load_data",
+				body: {
+					created: "2024-01-01T00:00:00Z",
+					updated: "2024-01-01T00:00:00Z",
+					project_id: "00000000-0000-0000-0000-000000000000",
+					status: "completed",
+					pipeline_run_id: EXECUTION_ID,
+				},
+				resources: {
+					log_collection: [
+						{
+							id: "99999999-9999-9999-9999-999999999999",
+							body: {
+								created: "2024-01-01T00:00:00Z",
+								updated: "2024-01-01T00:00:00Z",
+								project_id: "00000000-0000-0000-0000-000000000000",
+								source: "stdout",
+							},
+						},
+					],
+				},
+			},
+		},
+		"/api/v1/steps/{step_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "checkpoint-level line",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+	await expect(page.getByText("execution-level line")).toBeVisible();
+
+	const scopeNav = page.getByRole("navigation", { name: "Log scope" });
+	await scopeNav.getByRole("button", { name: "load_data" }).click();
+
+	await expect(page.getByText("checkpoint-level line")).toBeVisible();
+	await expect(page).toHaveURL(new RegExp(`scope=${CHECKPOINT_ID}`));
+
+	await scopeNav.getByRole("button", { name: /^Execution #/ }).click();
+
+	await expect(page.getByText("execution-level line")).toBeVisible();
+	await expect(page).not.toHaveURL(new RegExp(`scope=${CHECKPOINT_ID}`));
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -244,7 +244,9 @@ test("copy button writes log entries to the clipboard", async ({
 	await page.getByRole("button", { name: "Copy all logs" }).click();
 
 	const clipboardText = await page.evaluate(() =>
-		navigator.clipboard.readText()
+		(
+			navigator as unknown as { clipboard: { readText: () => Promise<string> } }
+		).clipboard.readText()
 	);
 	expect(clipboardText).toContain("hello world");
 	expect(clipboardText).toContain("INFO");
@@ -301,7 +303,8 @@ test("scope sidebar switches between execution and checkpoint logs", async ({
 					updated: "2024-01-01T00:00:00Z",
 					project_id: "00000000-0000-0000-0000-000000000000",
 					status: "completed",
-					pipeline_run_id: EXECUTION_ID,
+					version: 1,
+					is_retriable: false,
 				},
 				resources: {
 					log_collection: [

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -249,3 +249,29 @@ test("copy button writes log entries to the clipboard", async ({
 	expect(clipboardText).toContain("hello world");
 	expect(clipboardText).toContain("INFO");
 });
+
+test("download button offers a .log file with the execution id", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "downloadable line",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	const [download] = await Promise.all([
+		page.waitForEvent("download"),
+		page.getByRole("button", { name: "Download logs" }).click(),
+	]);
+
+	expect(download.suggestedFilename()).toBe(`execution-${EXECUTION_ID}.log`);
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -99,3 +99,49 @@ test("search filters log entries to matching messages", async ({
 	await expect(page.getByText("Training model")).toBeVisible();
 	await expect(page.getByText("1 of 1")).toBeVisible();
 });
+
+test("search match navigation advances through matches", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "match one",
+				},
+				{
+					timestamp: "2024-01-01T00:00:01Z",
+					level: 20,
+					message: "no hit",
+				},
+				{
+					timestamp: "2024-01-01T00:00:02Z",
+					level: 20,
+					message: "match two",
+				},
+				{
+					timestamp: "2024-01-01T00:00:03Z",
+					level: 20,
+					message: "match three",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+	await page.getByPlaceholder("Search logs...").fill("match");
+
+	await expect(page.getByText("1 of 3")).toBeVisible();
+
+	await page.getByRole("button", { name: "Next match" }).click();
+	await expect(page.getByText("2 of 3")).toBeVisible();
+
+	await page.getByRole("button", { name: "Next match" }).click();
+	await expect(page.getByText("3 of 3")).toBeVisible();
+
+	await page.getByRole("button", { name: "Previous match" }).click();
+	await expect(page.getByText("2 of 3")).toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -47,3 +47,18 @@ test("renders execution log entries", async ({ page }) => {
 	await expect(page.getByText("Log line 1")).toBeVisible();
 	await expect(page.getByText("Log line 5")).toBeVisible();
 });
+
+test("shows empty state when no logs exist", async ({ page, mockApi }) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}": {
+			get: makeExecution({ resources: { log_collection: [] } }),
+		},
+		"/api/v1/runs/{run_id}/logs": { get: [] },
+	});
+
+	await page.goto(logsUrl);
+
+	await expect(
+		page.getByText("No logs are available for this execution yet.")
+	).toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -145,3 +145,42 @@ test("search match navigation advances through matches", async ({
 	await page.getByRole("button", { name: "Previous match" }).click();
 	await expect(page.getByText("2 of 3")).toBeVisible();
 });
+
+test("level filter hides entries below the selected level", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "info entry",
+				},
+				{
+					timestamp: "2024-01-01T00:00:01Z",
+					level: 20,
+					message: "another info",
+				},
+				{
+					timestamp: "2024-01-01T00:00:02Z",
+					level: 40,
+					message: "error entry",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	await expect(page.getByText("info entry")).toBeVisible();
+	await expect(page.getByText("error entry")).toBeVisible();
+
+	await page.getByRole("combobox").filter({ hasText: "All levels" }).click();
+	await page.getByRole("option", { name: "Error" }).click();
+
+	await expect(page.getByText("error entry")).toBeVisible();
+	await expect(page.getByText("info entry")).not.toBeVisible();
+	await expect(page.getByText("another info")).not.toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -12,7 +12,7 @@ const FLOW_ID = "22222222-2222-2222-2222-222222222222";
 
 const logsUrl = `/flows/${FLOW_ID}/executions/${EXECUTION_ID}?tab=logs`;
 
-const emptyArtifactVersionsPage = {
+const emptyPage = {
 	index: 1,
 	max_size: 10000,
 	total_pages: 1,
@@ -38,7 +38,8 @@ test.beforeEach(async ({ mockApi, authenticatedPage }) => {
 		"/api/v1/runs/{run_id}": { get: makeExecution() },
 		"/api/v1/runs/{run_id}/dag": { get: makeDagResponse() },
 		"/api/v1/runs/{run_id}/logs": { get: makeLogEntries(5) },
-		"/api/v1/artifact_versions": { get: emptyArtifactVersionsPage },
+		"/api/v1/artifact_versions": { get: emptyPage },
+		"/api/v1/pipeline_snapshots": { get: emptyPage },
 	});
 });
 

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -59,9 +59,7 @@ test("shows empty state when no logs exist", async ({ page, mockApi }) => {
 
 	await page.goto(logsUrl);
 
-	await expect(
-		page.getByText("No logs are available for this execution yet.")
-	).toBeVisible();
+	await expect(page.getByTestId("execution-logs-empty")).toBeVisible();
 });
 
 test("search filters log entries to matching messages", async ({
@@ -334,7 +332,7 @@ test("shows error state with retry when logs endpoint fails", async ({
 
 	await page.goto(logsUrl);
 
-	await expect(page.getByText("Failed to load logs")).toBeVisible();
+	await expect(page.getByTestId("execution-logs-error")).toBeVisible();
 
 	await mockApi({
 		"/api/v1/runs/{run_id}/logs": {
@@ -351,7 +349,7 @@ test("shows error state with retry when logs endpoint fails", async ({
 	await page.getByRole("button", { name: "Retry" }).click();
 
 	await expect(page.getByText("after retry")).toBeVisible();
-	await expect(page.getByText("Failed to load logs")).not.toBeVisible();
+	await expect(page.getByTestId("execution-logs-error")).not.toBeVisible();
 });
 
 test("shows stale banner when polling fails after initial success", async ({
@@ -386,7 +384,5 @@ test("shows stale banner when polling fails after initial success", async ({
 
 	await page.clock.fastForward(4000);
 
-	await expect(
-		page.getByText("Live updates paused — couldn't reach the server.")
-	).toBeVisible();
+	await expect(page.getByRole("status")).toBeVisible();
 });

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -62,3 +62,40 @@ test("shows empty state when no logs exist", async ({ page, mockApi }) => {
 		page.getByText("No logs are available for this execution yet.")
 	).toBeVisible();
 });
+
+test("search filters log entries to matching messages", async ({
+	page,
+	mockApi,
+}) => {
+	await mockApi({
+		"/api/v1/runs/{run_id}/logs": {
+			get: [
+				{
+					timestamp: "2024-01-01T00:00:00Z",
+					level: 20,
+					message: "Loading data",
+				},
+				{
+					timestamp: "2024-01-01T00:00:01Z",
+					level: 20,
+					message: "Training model",
+				},
+				{
+					timestamp: "2024-01-01T00:00:02Z",
+					level: 20,
+					message: "Saving output",
+				},
+			],
+		},
+	});
+
+	await page.goto(logsUrl);
+
+	await expect(page.getByText("Loading data")).toBeVisible();
+	await expect(page.getByText("Training model")).toBeVisible();
+
+	await page.getByPlaceholder("Search logs...").fill("Training");
+
+	await expect(page.getByText("Training model")).toBeVisible();
+	await expect(page.getByText("1 of 1")).toBeVisible();
+});

--- a/e2e/specs/execution-logs.spec.ts
+++ b/e2e/specs/execution-logs.spec.ts
@@ -3,6 +3,7 @@ import {
 	makeExecution,
 	makeLogEntries,
 	makeDagResponse,
+	makeCheckpoint,
 	makePipeline,
 } from "../fixtures/api";
 
@@ -244,9 +245,7 @@ test("copy button writes log entries to the clipboard", async ({
 	await page.getByRole("button", { name: "Copy all logs" }).click();
 
 	const clipboardText = await page.evaluate(() =>
-		(
-			navigator as unknown as { clipboard: { readText: () => Promise<string> } }
-		).clipboard.readText()
+		navigator.clipboard.readText()
 	);
 	expect(clipboardText).toContain("hello world");
 	expect(clipboardText).toContain("INFO");
@@ -295,31 +294,7 @@ test("scope sidebar switches between execution and checkpoint logs", async ({
 			],
 		},
 		"/api/v1/steps/{step_id}": {
-			get: {
-				id: CHECKPOINT_ID,
-				name: "load_data",
-				body: {
-					created: "2024-01-01T00:00:00Z",
-					updated: "2024-01-01T00:00:00Z",
-					project_id: "00000000-0000-0000-0000-000000000000",
-					status: "completed",
-					version: 1,
-					is_retriable: false,
-				},
-				resources: {
-					log_collection: [
-						{
-							id: "99999999-9999-9999-9999-999999999999",
-							body: {
-								created: "2024-01-01T00:00:00Z",
-								updated: "2024-01-01T00:00:00Z",
-								project_id: "00000000-0000-0000-0000-000000000000",
-								source: "stdout",
-							},
-						},
-					],
-				},
-			},
+			get: makeCheckpoint({ id: CHECKPOINT_ID }),
 		},
 		"/api/v1/steps/{step_id}/logs": {
 			get: [

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"target": "ES2022",
-		"lib": ["ES2022"],
+		"lib": ["ES2022", "DOM"],
 		"module": "ESNext",
 		"moduleResolution": "bundler",
 		"strict": true,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 		baseURL: E2E_BASE_URL,
 		trace: "retain-on-failure",
 		screenshot: "only-on-failure",
+		permissions: ["clipboard-read", "clipboard-write"],
 	},
 	projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
 	webServer: {

--- a/src/modules/executions/ui/ExecutionLogsEmptyState.tsx
+++ b/src/modules/executions/ui/ExecutionLogsEmptyState.tsx
@@ -12,7 +12,10 @@ export function ExecutionLogsEmptyState({
 	leading,
 }: ExecutionLogsEmptyStateProps) {
 	return (
-		<div className="flex h-full min-h-0 flex-col">
+		<div
+			data-testid="execution-logs-empty"
+			className="flex h-full min-h-0 flex-col"
+		>
 			<div className="border-border flex shrink-0 items-center gap-2 border-b p-2">
 				{leading}
 			</div>

--- a/src/modules/executions/ui/ExecutionLogsErrorState.tsx
+++ b/src/modules/executions/ui/ExecutionLogsErrorState.tsx
@@ -19,7 +19,7 @@ export function ExecutionLogsErrorState({
 }: ExecutionLogsErrorStateProps) {
 	const message = error instanceof Error ? error.message : "Unknown error";
 	return (
-		<Empty>
+		<Empty data-testid="execution-logs-error">
 			<EmptyHeader className="max-w-md">
 				<EmptyMedia
 					variant="icon"


### PR DESCRIPTION
## Summary

- Adds 11 Playwright E2E tests for the execution-level logs tab introduced in #136 (`/flows/{flowId}/executions/{executionId}?tab=logs`).
- Covers logs display, search + match navigation, level filter, source selector, copy/download export, scope sidebar (execution ↔ checkpoint), error state with retry, and the stale-update banner.
- Adds reusable fixture makers in `e2e/fixtures/api/executions.ts` (`makeExecution`, `makeLogEntry/Entries`, `makeLogsResponse`, `makeCheckpoint`, `makeCheckpointNode`, `makeDagResponse`).
- Grants clipboard permissions globally in `playwright.config.ts` and adds `DOM` to `e2e/tsconfig.json` lib so `navigator.clipboard` is typed without a cast.
- Adds `data-testid` to the empty/error chrome components so tests assert state instead of copy.

## Test plan

- [x] `pnpm check:types`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test:e2e e2e/specs/execution-logs.spec.ts` — 11/11 pass