### PR TITLE
feat(executions): add View in panel button on checkpoint artifacts

### DIFF
--- a/src/modules/checkpoints/business-logic/use-checkpoint-panel-state.ts
+++ b/src/modules/checkpoints/business-logic/use-checkpoint-panel-state.ts
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { useThreePanelLayout } from "@/shared/ui/ThreePanelLayoutContext";
+import type {
+	ArtifactPanelTarget,
+	SelectedArtifact,
+} from "../domain/checkpoint";
+import type { PanelTab } from "../ui/CheckpointDetailPanelTabs";
+
+export function useCheckpointPanelState() {
+	const { expandRight } = useThreePanelLayout();
+
+	const [selectedCheckpointId, setSelectedCheckpointId] = useState<
+		string | undefined
+	>();
+	const [activeTab, setActiveTab] = useState<PanelTab>("logs");
+	const [selectedArtifact, setSelectedArtifact] =
+		useState<SelectedArtifact | null>(null);
+
+	const selectCheckpoint = (id: string) => {
+		if (id !== selectedCheckpointId) {
+			setSelectedArtifact(null);
+		}
+		setSelectedCheckpointId(id);
+	};
+
+	const viewArtifactInPanel = ({
+		checkpointId,
+		artifact,
+		direction,
+	}: ArtifactPanelTarget) => {
+		setSelectedCheckpointId(checkpointId);
+		setActiveTab("artifacts");
+		setSelectedArtifact({ artifact, direction });
+		expandRight();
+	};
+
+	return {
+		selectedCheckpointId,
+		activeTab,
+		setActiveTab,
+		selectedArtifact,
+		setSelectedArtifact,
+		selectCheckpoint,
+		viewArtifactInPanel,
+	};
+}

--- a/src/modules/checkpoints/domain/artifact.ts
+++ b/src/modules/checkpoints/domain/artifact.ts
@@ -7,7 +7,7 @@ export type ArtifactEntry = {
 	id: string;
 };
 
-type ArtifactDirection = "input" | "output";
+export type ArtifactDirection = "input" | "output";
 
 const visibleInputTypes = new Set<
 	components["schemas"]["StepRunInputArtifactType"]

--- a/src/modules/checkpoints/domain/checkpoint.ts
+++ b/src/modules/checkpoints/domain/checkpoint.ts
@@ -6,9 +6,18 @@ import {
 	extractInputArtifactEntries,
 	extractOutputArtifactEntries,
 } from "./artifact";
-import type { ArtifactEntry } from "./artifact";
+import type { ArtifactDirection, ArtifactEntry } from "./artifact";
 
-export type { ArtifactEntry };
+export type { ArtifactDirection, ArtifactEntry };
+
+export type SelectedArtifact = {
+	artifact: ArtifactEntry;
+	direction: ArtifactDirection;
+};
+
+export type ArtifactPanelTarget = SelectedArtifact & {
+	checkpointId: string;
+};
 
 export type Checkpoint = {
 	id: string;

--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -1,9 +1,9 @@
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import {
 	getCheckpointDetailsPollingInterval,
 	useCheckpointDetails,
 } from "../business-logic/use-checkpoint-details";
-import type { ArtifactEntry } from "../domain/checkpoint";
+import type { SelectedArtifact } from "../domain/checkpoint";
 import { CheckpointMemoryTabContainer } from "@/modules/memory/feature/CheckpointMemoryTabContainer";
 import { CheckpointDetailPanelArtifacts } from "../ui/CheckpointDetailPanelArtifacts";
 import { CheckpointDetailPanelHeader } from "../ui/CheckpointDetailPanelHeader";
@@ -20,12 +20,16 @@ type CheckpointDetailPanelContainerProps = {
 	checkpointId?: string;
 	activeTab: PanelTab;
 	onTabChange: (tab: PanelTab) => void;
+	selectedArtifact: SelectedArtifact | null;
+	onSelectArtifact: (artifact: SelectedArtifact | null) => void;
 };
 
 export function CheckpointDetailPanelContainer({
 	checkpointId,
 	activeTab,
 	onTabChange,
+	selectedArtifact,
+	onSelectArtifact,
 }: CheckpointDetailPanelContainerProps) {
 	if (!checkpointId) {
 		return <CheckpointDetailsEmptyView />;
@@ -37,6 +41,8 @@ export function CheckpointDetailPanelContainer({
 				checkpointId={checkpointId}
 				activeTab={activeTab}
 				onTabChange={onTabChange}
+				selectedArtifact={selectedArtifact}
+				onSelectArtifact={onSelectArtifact}
 			/>
 		</Suspense>
 	);
@@ -46,10 +52,14 @@ function CheckpointDetailPanelContentContainer({
 	checkpointId,
 	activeTab,
 	onTabChange,
+	selectedArtifact,
+	onSelectArtifact,
 }: {
 	checkpointId: string;
 	activeTab: PanelTab;
 	onTabChange: (tab: PanelTab) => void;
+	selectedArtifact: SelectedArtifact | null;
+	onSelectArtifact: (artifact: SelectedArtifact | null) => void;
 }) {
 	const { detailsData } = useCheckpointDetails(checkpointId, {
 		refetchInterval: getCheckpointDetailsPollingInterval,
@@ -58,17 +68,12 @@ function CheckpointDetailPanelContentContainer({
 	const inputs = detailsData?.inputs ?? [];
 	const outputs = detailsData?.outputs ?? [];
 
-	const [selectedArtifact, setSelectedArtifact] = useState<{
-		artifact: ArtifactEntry;
-		direction: "input" | "output";
-	} | null>(null);
-
 	function handleTabChange(tab: PanelTab) {
 		onTabChange(tab);
 		if (tab === "artifacts" && !selectedArtifact) {
 			const first = outputs[0] ?? inputs[0];
 			if (first) {
-				setSelectedArtifact({
+				onSelectArtifact({
 					artifact: first,
 					direction: outputs[0] ? "output" : "input",
 				});
@@ -95,7 +100,7 @@ function CheckpointDetailPanelContentContainer({
 						outputs={outputs}
 						selectedArtifact={selectedArtifact}
 						onSelectArtifact={(artifact, direction) =>
-							setSelectedArtifact({ artifact, direction })
+							onSelectArtifact({ artifact, direction })
 						}
 					/>
 				)}

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelArtifacts.tsx
@@ -3,16 +3,15 @@ import { ViewerFrameFullHeight } from "@/modules/executions/ui/traces/ViewerFram
 import { ChipBar } from "@/shared/ui/ChipBar";
 import { Separator } from "@/shared/ui/separator";
 import { TruncatedText } from "@/shared/ui/truncated-text";
-import type { ArtifactEntry } from "../domain/checkpoint";
+import type {
+	ArtifactDirection,
+	ArtifactEntry,
+	SelectedArtifact,
+} from "../domain/checkpoint";
 import { FullscreenArtifactButtonContainer } from "../feature/FullscreenArtifactButtonContainer";
 import { ArtifactVisualizationContainer } from "../feature/ArtifactVisualizationContainer";
 import { DownloadArtifactButtonContainer } from "../feature/DownloadArtifactButtonContainer";
 import { NoArtifactsMessage } from "./NoArtifactsMessage";
-
-type SelectedArtifact = {
-	artifact: ArtifactEntry;
-	direction: "input" | "output";
-};
 
 type CheckpointDetailPanelArtifactsProps = {
 	inputs: ArtifactEntry[];
@@ -20,7 +19,7 @@ type CheckpointDetailPanelArtifactsProps = {
 	selectedArtifact: SelectedArtifact | null;
 	onSelectArtifact: (
 		artifact: ArtifactEntry,
-		direction: "input" | "output"
+		direction: ArtifactDirection
 	) => void;
 };
 
@@ -86,7 +85,7 @@ type ArtifactsToolbarProps = {
 	selectedArtifact: SelectedArtifact | null;
 	onSelectArtifact: (
 		artifact: ArtifactEntry,
-		direction: "input" | "output"
+		direction: ArtifactDirection
 	) => void;
 };
 

--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -1,14 +1,9 @@
+import { useCheckpointPanelState } from "@/modules/checkpoints/business-logic/use-checkpoint-panel-state";
 import {
 	getCheckpointsPollingInterval,
 	useCheckpoints,
 } from "@/modules/checkpoints/business-logic/use-checkpoints";
-import type {
-	ArtifactPanelTarget,
-	SelectedArtifact,
-} from "@/modules/checkpoints/domain/checkpoint";
 import { CheckpointDetailPanelContainer } from "@/modules/checkpoints/feature/CheckpointDetailPanelContainer";
-import type { PanelTab } from "@/modules/checkpoints/ui/CheckpointDetailPanelTabs";
-import { useThreePanelLayout } from "@/shared/ui/ThreePanelLayoutContext";
 import { useSelectedVersion } from "@/modules/deployments/business-logic/use-selected-version";
 import { isLocalDeployment } from "@/modules/deployments/domain/local-deployment";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
@@ -16,7 +11,6 @@ import { RefreshButton } from "@/shared/ui/RefreshButton";
 import { ThreePanelLayout } from "@/shared/ui/ThreePanelLayout";
 import { ThreePanelLayoutProvider } from "@/shared/ui/ThreePanelLayoutContext";
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
-import { useState } from "react";
 import { useExecution } from "../business-logic/use-execution";
 import { useExecutions } from "../business-logic/use-executions";
 import { useSyncExecutionStatus } from "../business-logic/use-sync-execution-status";
@@ -110,33 +104,15 @@ function ExecutionContainerBody() {
 			]);
 		});
 
-	const [selectedCheckpointId, setSelectedCheckpointId] = useState<
-		string | undefined
-	>();
-	const [activeCheckpointTab, setActiveCheckpointTab] =
-		useState<PanelTab>("logs");
-	const [selectedArtifact, setSelectedArtifact] =
-		useState<SelectedArtifact | null>(null);
-
-	const { expandRight } = useThreePanelLayout();
-
-	const handleSelectCheckpoint = (id: string) => {
-		if (id !== selectedCheckpointId) {
-			setSelectedArtifact(null);
-		}
-		setSelectedCheckpointId(id);
-	};
-
-	const handleViewArtifactInPanel = ({
-		checkpointId,
-		artifact,
-		direction,
-	}: ArtifactPanelTarget) => {
-		setSelectedCheckpointId(checkpointId);
-		setActiveCheckpointTab("artifacts");
-		setSelectedArtifact({ artifact, direction });
-		expandRight();
-	};
+	const {
+		selectedCheckpointId,
+		activeTab: activeCheckpointTab,
+		setActiveTab: setActiveCheckpointTab,
+		selectedArtifact,
+		setSelectedArtifact,
+		selectCheckpoint,
+		viewArtifactInPanel,
+	} = useCheckpointPanelState();
 
 	const kitaruSnapshotIds = new Set(realDeployments.map((d) => d.id));
 	const displayedExecutions =
@@ -187,8 +163,8 @@ function ExecutionContainerBody() {
 							flowId={flowId}
 							execution={executionData}
 							checkpoints={checkpointsData.checkpoints}
-							onSelectCheckpoint={handleSelectCheckpoint}
-							onViewArtifactInPanel={handleViewArtifactInPanel}
+							onSelectCheckpoint={selectCheckpoint}
+							onViewArtifactInPanel={viewArtifactInPanel}
 						/>
 					)
 				}

--- a/src/modules/executions/feature/ExecutionContainer.tsx
+++ b/src/modules/executions/feature/ExecutionContainer.tsx
@@ -2,8 +2,13 @@ import {
 	getCheckpointsPollingInterval,
 	useCheckpoints,
 } from "@/modules/checkpoints/business-logic/use-checkpoints";
+import type {
+	ArtifactPanelTarget,
+	SelectedArtifact,
+} from "@/modules/checkpoints/domain/checkpoint";
 import { CheckpointDetailPanelContainer } from "@/modules/checkpoints/feature/CheckpointDetailPanelContainer";
 import type { PanelTab } from "@/modules/checkpoints/ui/CheckpointDetailPanelTabs";
+import { useThreePanelLayout } from "@/shared/ui/ThreePanelLayoutContext";
 import { useSelectedVersion } from "@/modules/deployments/business-logic/use-selected-version";
 import { isLocalDeployment } from "@/modules/deployments/domain/local-deployment";
 import { useManualRefresh } from "@/shared/business-logic/use-manual-refresh";
@@ -110,6 +115,28 @@ function ExecutionContainerBody() {
 	>();
 	const [activeCheckpointTab, setActiveCheckpointTab] =
 		useState<PanelTab>("logs");
+	const [selectedArtifact, setSelectedArtifact] =
+		useState<SelectedArtifact | null>(null);
+
+	const { expandRight } = useThreePanelLayout();
+
+	const handleSelectCheckpoint = (id: string) => {
+		if (id !== selectedCheckpointId) {
+			setSelectedArtifact(null);
+		}
+		setSelectedCheckpointId(id);
+	};
+
+	const handleViewArtifactInPanel = ({
+		checkpointId,
+		artifact,
+		direction,
+	}: ArtifactPanelTarget) => {
+		setSelectedCheckpointId(checkpointId);
+		setActiveCheckpointTab("artifacts");
+		setSelectedArtifact({ artifact, direction });
+		expandRight();
+	};
 
 	const kitaruSnapshotIds = new Set(realDeployments.map((d) => d.id));
 	const displayedExecutions =
@@ -160,7 +187,8 @@ function ExecutionContainerBody() {
 							flowId={flowId}
 							execution={executionData}
 							checkpoints={checkpointsData.checkpoints}
-							onSelectCheckpoint={setSelectedCheckpointId}
+							onSelectCheckpoint={handleSelectCheckpoint}
+							onViewArtifactInPanel={handleViewArtifactInPanel}
 						/>
 					)
 				}
@@ -171,6 +199,8 @@ function ExecutionContainerBody() {
 							checkpointId={selectedCheckpointId}
 							activeTab={activeCheckpointTab}
 							onTabChange={setActiveCheckpointTab}
+							selectedArtifact={selectedArtifact}
+							onSelectArtifact={setSelectedArtifact}
 						/>
 					)
 				}

--- a/src/modules/executions/feature/ExecutionTabContainer.tsx
+++ b/src/modules/executions/feature/ExecutionTabContainer.tsx
@@ -1,5 +1,8 @@
 import { checkpointsQueryKeys } from "@/modules/checkpoints/business-logic/checkpoints-queries";
-import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type {
+	ArtifactPanelTarget,
+	CheckpointEntry,
+} from "@/modules/checkpoints/domain/checkpoint";
 import { CopyCommand } from "@/shared/ui/CopyCommand";
 import { StatusDot } from "@/shared/ui/StatusDot";
 import { useThreePanelLayout } from "@/shared/ui/ThreePanelLayoutContext";
@@ -18,6 +21,7 @@ type ExecutionTabContainerProps = {
 	execution: Execution;
 	checkpoints: CheckpointEntry[];
 	onSelectCheckpoint: (id: string) => void;
+	onViewArtifactInPanel: (target: ArtifactPanelTarget) => void;
 };
 
 export function ExecutionTabContainer({
@@ -26,6 +30,7 @@ export function ExecutionTabContainer({
 	execution,
 	checkpoints,
 	onSelectCheckpoint,
+	onViewArtifactInPanel,
 }: ExecutionTabContainerProps) {
 	const { expandRight } = useThreePanelLayout();
 
@@ -90,6 +95,7 @@ export function ExecutionTabContainer({
 				onSelectCheckpoint(id);
 				expandRight();
 			}}
+			onViewArtifactInPanel={onViewArtifactInPanel}
 			waitCondition={waitConditionData}
 			onResolveWaitCondition={resolveWaitCondition}
 			resumeHint={resumeHint}

--- a/src/modules/executions/ui/ExecutionDetails.tsx
+++ b/src/modules/executions/ui/ExecutionDetails.tsx
@@ -1,4 +1,5 @@
 import { useScrollHighlight } from "@/shared/business-logic/use-scroll-highlight";
+import type { ArtifactPanelTarget } from "@/modules/checkpoints/domain/checkpoint";
 import type { WaitCondition } from "../domain/wait-condition";
 import type { ResolveWaitConditionParams } from "../domain/resolve-wait-condition";
 import type { TimelineEntry } from "../domain/waiting-block";
@@ -13,6 +14,7 @@ import {
 type ExecutionDetailsProps = {
 	timelineEntries: TimelineEntry[];
 	onSelectCheckpoint: (id: string) => void;
+	onViewArtifactInPanel: (target: ArtifactPanelTarget) => void;
 	waitCondition?: WaitCondition;
 	onResolveWaitCondition?: (params: ResolveWaitConditionParams) => void;
 	resumeHint?: React.ReactNode;
@@ -21,6 +23,7 @@ type ExecutionDetailsProps = {
 export function ExecutionDetails({
 	timelineEntries,
 	onSelectCheckpoint,
+	onViewArtifactInPanel,
 	waitCondition,
 	onResolveWaitCondition,
 	resumeHint,
@@ -57,6 +60,7 @@ export function ExecutionDetails({
 			<CheckpointThread
 				timelineEntries={timelineEntries}
 				onSelect={onSelectCheckpoint}
+				onViewArtifactInPanel={onViewArtifactInPanel}
 				highlightedId={scrollHighlight.highlightedId}
 			/>
 

--- a/src/modules/executions/ui/traces/CheckpointRow.tsx
+++ b/src/modules/executions/ui/traces/CheckpointRow.tsx
@@ -2,18 +2,24 @@ import { StatusDot } from "@/shared/ui/StatusDot";
 import { CheckpointTypeBadge } from "./CheckpointTypeBadge";
 import { CheckpointRowArtifacts } from "./CheckpointRowArtifacts";
 import { ExpandableRow } from "./ExpandableRow";
-import type { CheckpointEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type {
+	ArtifactPanelTarget,
+	CheckpointEntry,
+	SelectedArtifact,
+} from "@/modules/checkpoints/domain/checkpoint";
 import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
 import { TruncatedText } from "@/shared/ui/truncated-text";
 
 type CheckpointRowProps = {
 	checkpointEntry: CheckpointEntry;
 	onSelect: (id: string) => void;
+	onViewArtifactInPanel: (target: ArtifactPanelTarget) => void;
 };
 
 export function CheckpointRow({
 	checkpointEntry,
 	onSelect,
+	onViewArtifactInPanel,
 }: CheckpointRowProps) {
 	return (
 		<ExpandableRow
@@ -37,7 +43,15 @@ export function CheckpointRow({
 				</>
 			}
 		>
-			<CheckpointRowArtifacts checkpointId={checkpointEntry.id} />
+			<CheckpointRowArtifacts
+				checkpointId={checkpointEntry.id}
+				onViewArtifactInPanel={(selection: SelectedArtifact) =>
+					onViewArtifactInPanel({
+						checkpointId: checkpointEntry.id,
+						...selection,
+					})
+				}
+			/>
 		</ExpandableRow>
 	);
 }

--- a/src/modules/executions/ui/traces/CheckpointRowArtifacts.tsx
+++ b/src/modules/executions/ui/traces/CheckpointRowArtifacts.tsx
@@ -2,32 +2,34 @@ import {
 	getCheckpointDetailsPollingInterval,
 	useCheckpointDetails,
 } from "@/modules/checkpoints/business-logic/use-checkpoint-details";
-import type { ArtifactEntry } from "@/modules/checkpoints/domain/checkpoint";
+import type { SelectedArtifact } from "@/modules/checkpoints/domain/checkpoint";
 import { ArtifactVisualizationContainer } from "@/modules/checkpoints/feature/ArtifactVisualizationContainer";
 import { FullscreenArtifactButtonContainer } from "@/modules/checkpoints/feature/FullscreenArtifactButtonContainer";
 import { DownloadArtifactButtonContainer } from "@/modules/checkpoints/feature/DownloadArtifactButtonContainer";
 import { ArrowRight } from "lucide-react";
 import { Suspense, useState } from "react";
 import { NoArtifactsMessage } from "@/modules/checkpoints/ui/NoArtifactsMessage";
+import { Button } from "@/shared/ui/button";
 import { TruncatedText } from "@/shared/ui/truncated-text";
 import { ArtifactChip } from "./ArtifactChip";
 
+type CheckpointRowArtifactsProps = {
+	checkpointId: string;
+	onViewArtifactInPanel: (selection: SelectedArtifact) => void;
+};
+
 function CheckpointRowArtifactsContent({
 	checkpointId,
-}: {
-	checkpointId: string;
-}) {
+	onViewArtifactInPanel,
+}: CheckpointRowArtifactsProps) {
 	const { detailsData } = useCheckpointDetails(checkpointId, {
 		refetchInterval: getCheckpointDetailsPollingInterval,
 	});
 
 	const { inputs, outputs } = detailsData;
 
-	const [selected, setSelected] = useState<{
-		entry: ArtifactEntry;
-		direction: "input" | "output";
-	} | null>(() =>
-		outputs[0] ? { entry: outputs[0], direction: "output" } : null
+	const [selected, setSelected] = useState<SelectedArtifact | null>(() =>
+		outputs[0] ? { artifact: outputs[0], direction: "output" } : null
 	);
 
 	if (inputs.length === 0 && outputs.length === 0) {
@@ -48,10 +50,12 @@ function CheckpointRowArtifactsContent({
 									key={a.id}
 									name={a.name}
 									isSelected={
-										selected?.entry.id === a.id &&
+										selected?.artifact.id === a.id &&
 										selected.direction === "input"
 									}
-									onClick={() => setSelected({ entry: a, direction: "input" })}
+									onClick={() =>
+										setSelected({ artifact: a, direction: "input" })
+									}
 								/>
 							))}
 						</div>
@@ -73,10 +77,12 @@ function CheckpointRowArtifactsContent({
 									key={a.id}
 									name={a.name}
 									isSelected={
-										selected?.entry.id === a.id &&
+										selected?.artifact.id === a.id &&
 										selected.direction === "output"
 									}
-									onClick={() => setSelected({ entry: a, direction: "output" })}
+									onClick={() =>
+										setSelected({ artifact: a, direction: "output" })
+									}
 								/>
 							))}
 						</div>
@@ -88,21 +94,30 @@ function CheckpointRowArtifactsContent({
 				<div className="border-border overflow-hidden rounded-lg border">
 					<div className="bg-muted/50 border-border flex items-center justify-between border-b px-4 py-2">
 						<TruncatedText className="text-foreground text-xs font-semibold">
-							{selected.entry.name}
+							{selected.artifact.name}
 						</TruncatedText>
 						<div className="flex items-center gap-1">
 							<DownloadArtifactButtonContainer
-								artifactVersionId={selected.entry.id}
+								artifactVersionId={selected.artifact.id}
 							/>
 							<FullscreenArtifactButtonContainer
-								artifactVersionId={selected.entry.id}
-								name={selected.entry.name}
+								artifactVersionId={selected.artifact.id}
+								name={selected.artifact.name}
 							/>
+							<Button
+								variant="ghost"
+								size="xs"
+								className="text-muted-foreground text-2xs"
+								onClick={() => onViewArtifactInPanel(selected)}
+							>
+								View in panel
+								<ArrowRight />
+							</Button>
 						</div>
 					</div>
 					<div className="bg-background">
 						<ArtifactVisualizationContainer
-							artifactVersionId={selected.entry.id}
+							artifactVersionId={selected.artifact.id}
 						/>
 					</div>
 				</div>
@@ -113,16 +128,18 @@ function CheckpointRowArtifactsContent({
 
 export function CheckpointRowArtifacts({
 	checkpointId,
-}: {
-	checkpointId: string;
-}) {
+	onViewArtifactInPanel,
+}: CheckpointRowArtifactsProps) {
 	return (
 		<Suspense
 			fallback={
 				<p className="text-2xs text-muted-foreground px-4 py-3">Loading…</p>
 			}
 		>
-			<CheckpointRowArtifactsContent checkpointId={checkpointId} />
+			<CheckpointRowArtifactsContent
+				checkpointId={checkpointId}
+				onViewArtifactInPanel={onViewArtifactInPanel}
+			/>
 		</Suspense>
 	);
 }

--- a/src/modules/executions/ui/traces/CheckpointThread.tsx
+++ b/src/modules/executions/ui/traces/CheckpointThread.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { cn } from "@/shared/utils/styles";
 import { HIGHLIGHT_MS } from "@/shared/business-logic/use-scroll-highlight";
+import type { ArtifactPanelTarget } from "@/modules/checkpoints/domain/checkpoint";
 import { CheckpointRow } from "./CheckpointRow";
 import { WaitingBlockRow } from "./WaitingBlockRow";
 import type { TimelineEntry } from "../../domain/waiting-block";
@@ -8,12 +9,14 @@ import type { TimelineEntry } from "../../domain/waiting-block";
 type CheckpointThreadProps = {
 	timelineEntries: TimelineEntry[];
 	onSelect: (id: string) => void;
+	onViewArtifactInPanel: (target: ArtifactPanelTarget) => void;
 	highlightedId?: string;
 };
 
 export function CheckpointThread({
 	timelineEntries,
 	onSelect,
+	onViewArtifactInPanel,
 	highlightedId,
 }: CheckpointThreadProps) {
 	return (
@@ -29,7 +32,11 @@ export function CheckpointThread({
 					{entry.kind === "waiting" ? (
 						<WaitingBlockRow waitingBlock={entry.data} />
 					) : (
-						<CheckpointRow checkpointEntry={entry.data} onSelect={onSelect} />
+						<CheckpointRow
+							checkpointEntry={entry.data}
+							onSelect={onSelect}
+							onViewArtifactInPanel={onViewArtifactInPanel}
+						/>
 					)}
 				</RowHighlightedWrapper>
 			))}


### PR DESCRIPTION
## Summary
- Adds a **View in panel →** button to the artifact preview row inside an expanded checkpoint. Clicking it opens the right-side checkpoint detail panel, switches to the **Artifacts** tab, and selects the same artifact.
- Lifts `selectedArtifact` state from `CheckpointDetailPanelContainer` up to `ExecutionContainerBody` so the panel is now externally controllable. Selection resets when the active checkpoint changes to avoid stale references.
- Promotes `ArtifactDirection`, `SelectedArtifact`, and a new `ArtifactPanelTarget` into `modules/checkpoints/domain/`, and replaces the inline `"input" | "output"` literals duplicated across the executions tree.

## Test plan
- [ ] Expand a checkpoint with both inputs and outputs; the artifact preview row shows the new **View in panel →** button at the right of the header
- [ ] Clicking the button opens the right panel, switches to the **Artifacts** tab, and selects the same artifact (input or output)
- [ ] Clicking it on a different checkpoint correctly switches the panel to that checkpoint and selects the new artifact
- [ ] Selecting a different checkpoint via the timeline resets the panel's selected artifact (no stale state)
- [ ] Inline preview, Download, and Fullscreen buttons still work as before