### PR TITLE
fix(memory): use versioned route id in CheckpointMemoryTabContainer

### DIFF
--- a/src/modules/memory/feature/CheckpointMemoryTabContainer.tsx
+++ b/src/modules/memory/feature/CheckpointMemoryTabContainer.tsx
@@ -15,7 +15,7 @@ export function CheckpointMemoryTabContainer({
 	checkpointStartTime,
 }: CheckpointMemoryTabContainerProps) {
 	const { flowId, executionId } = useParams({
-		from: "/_private/_navbar/flows/$flowId/executions/$executionId",
+		from: "/_private/_navbar/flows/$flowId/v/$version/executions/$executionId",
 	});
 
 	const { flowData } = useFlow(flowId);


### PR DESCRIPTION
The memory tab was reading params from the redirect-only route id (.../executions/$executionId), which is never an active match — its loader just throw redirects to the versioned form. This caused "Could not find an active match" when opening the tab. Switch to the versioned route id used by the rest of the execution detail page.