### PR TITLE
Add Code tab to checkpoint detail panel

### DIFF
--- a/src/modules/checkpoints/domain/checkpoint.spec.ts
+++ b/src/modules/checkpoints/domain/checkpoint.spec.ts
@@ -351,6 +351,62 @@ describe("checkpointFromApiToDomain", () => {
 
 		expect(checkpointFromApiToDomain(checkpoint).type).toBe("memory_call");
 	});
+
+	it("extracts source.code and derives source.filePath from spec.source.module", () => {
+		const checkpoint = {
+			id: "checkpoint-id-source",
+			name: "data_loader",
+			body: { status: "completed" },
+			resources: { inputs: {}, outputs: {} },
+			metadata: {
+				source_code: "def data_loader():\n    pass\n",
+				spec: { source: { module: "src.flows.content_pipeline" } },
+			},
+		} as unknown as components["schemas"]["StepRunResponse"];
+
+		expect(checkpointFromApiToDomain(checkpoint).source).toEqual({
+			code: "def data_loader():\n    pass\n",
+			filePath: "src/flows/content_pipeline.py",
+		});
+	});
+
+	it("returns source with code but no filePath when spec.source.module is missing", () => {
+		const checkpoint = {
+			id: "checkpoint-id-source-no-spec",
+			name: "lonely_source",
+			body: { status: "completed" },
+			resources: { inputs: {}, outputs: {} },
+			metadata: { source_code: "def lonely_source():\n    pass\n" },
+		} as unknown as components["schemas"]["StepRunResponse"];
+
+		expect(checkpointFromApiToDomain(checkpoint).source).toEqual({
+			code: "def lonely_source():\n    pass\n",
+			filePath: undefined,
+		});
+	});
+
+	it("leaves source undefined when metadata is absent", () => {
+		const checkpoint = {
+			id: "checkpoint-id-no-metadata",
+			name: "no_metadata",
+			body: { status: "completed" },
+			resources: { inputs: {}, outputs: {} },
+		} as unknown as components["schemas"]["StepRunResponse"];
+
+		expect(checkpointFromApiToDomain(checkpoint).source).toBeUndefined();
+	});
+
+	it("leaves source undefined when only spec.source.module is set (no code)", () => {
+		const checkpoint = {
+			id: "checkpoint-id-spec-only",
+			name: "spec_only",
+			body: { status: "completed" },
+			resources: { inputs: {}, outputs: {} },
+			metadata: { spec: { source: { module: "src.flows.spec_only" } } },
+		} as unknown as components["schemas"]["StepRunResponse"];
+
+		expect(checkpointFromApiToDomain(checkpoint).source).toBeUndefined();
+	});
 });
 
 describe("checkpointEntryFromApiToDomain", () => {

--- a/src/modules/checkpoints/domain/checkpoint.ts
+++ b/src/modules/checkpoints/domain/checkpoint.ts
@@ -23,11 +23,14 @@ export type Checkpoint = {
 	outputs: ArtifactEntry[];
 	logSources: string[];
 	runMetadata?: Record<string, unknown>;
+	sourceCode?: string;
+	sourceFilePath?: string;
 };
 
 export function checkpointFromApiToDomain(
 	checkpoint: components["schemas"]["StepRunResponse"]
 ): Checkpoint {
+	const sourceModule = checkpoint.metadata?.spec?.source?.module;
 	return {
 		id: checkpoint.id,
 		name: checkpoint.name,
@@ -51,6 +54,10 @@ export function checkpointFromApiToDomain(
 			checkpoint.metadata?.run_metadata?.llm_usage?.cost_usd ?? undefined,
 		logSources: extractLogSources(checkpoint.resources?.log_collection),
 		runMetadata: checkpoint.metadata?.run_metadata,
+		sourceCode: checkpoint.metadata?.source_code ?? undefined,
+		sourceFilePath: sourceModule
+			? `${sourceModule.replace(/\./g, "/")}.py`
+			: undefined,
 	};
 }
 

--- a/src/modules/checkpoints/domain/checkpoint.ts
+++ b/src/modules/checkpoints/domain/checkpoint.ts
@@ -2,6 +2,7 @@ import type { components } from "@/shared/api/openapi";
 import type { ExecutionStatus } from "@/modules/executions/domain/execution";
 import { extractLogSources } from "@/modules/logs/domain/log-mapper";
 import { parseBackendTimestamp } from "@/shared/utils/time";
+import { pythonModuleToFilePath } from "../util/file-path";
 import {
 	extractInputArtifactEntries,
 	extractOutputArtifactEntries,
@@ -9,6 +10,11 @@ import {
 import type { ArtifactEntry } from "./artifact";
 
 export type { ArtifactEntry };
+
+export type CheckpointSource = {
+	code: string;
+	filePath?: string;
+};
 
 export type Checkpoint = {
 	id: string;
@@ -23,14 +29,22 @@ export type Checkpoint = {
 	outputs: ArtifactEntry[];
 	logSources: string[];
 	runMetadata?: Record<string, unknown>;
-	sourceCode?: string;
-	sourceFilePath?: string;
+	source?: CheckpointSource;
 };
 
 export function checkpointFromApiToDomain(
 	checkpoint: components["schemas"]["StepRunResponse"]
 ): Checkpoint {
+	const sourceCode = checkpoint.metadata?.source_code;
 	const sourceModule = checkpoint.metadata?.spec?.source?.module;
+	const source: CheckpointSource | undefined = sourceCode
+		? {
+				code: sourceCode,
+				filePath: sourceModule
+					? pythonModuleToFilePath(sourceModule)
+					: undefined,
+			}
+		: undefined;
 	return {
 		id: checkpoint.id,
 		name: checkpoint.name,
@@ -54,10 +68,7 @@ export function checkpointFromApiToDomain(
 			checkpoint.metadata?.run_metadata?.llm_usage?.cost_usd ?? undefined,
 		logSources: extractLogSources(checkpoint.resources?.log_collection),
 		runMetadata: checkpoint.metadata?.run_metadata,
-		sourceCode: checkpoint.metadata?.source_code ?? undefined,
-		sourceFilePath: sourceModule
-			? `${sourceModule.replace(/\./g, "/")}.py`
-			: undefined,
+		source,
 	};
 }
 

--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -6,6 +6,7 @@ import {
 import type { ArtifactEntry } from "../domain/checkpoint";
 import { CheckpointMemoryTabContainer } from "@/modules/memory/feature/CheckpointMemoryTabContainer";
 import { CheckpointDetailPanelArtifacts } from "../ui/CheckpointDetailPanelArtifacts";
+import { CheckpointDetailPanelSourceCode } from "../ui/CheckpointDetailPanelSourceCode";
 import { CheckpointDetailPanelHeader } from "../ui/CheckpointDetailPanelHeader";
 import { CheckpointDetailPanelInfo } from "../ui/CheckpointDetailPanelInfo";
 import {
@@ -88,6 +89,12 @@ function CheckpointDetailPanelContentContainer({
 			<div className="min-h-0 flex-1 overflow-y-auto">
 				{activeTab === "checkpoint" && (
 					<CheckpointDetailPanelInfo checkpoint={detailsData} />
+				)}
+				{activeTab === "code" && (
+					<CheckpointDetailPanelSourceCode
+						sourceCode={detailsData.sourceCode}
+						sourceFilePath={detailsData.sourceFilePath}
+					/>
 				)}
 				{activeTab === "artifacts" && (
 					<CheckpointDetailPanelArtifacts

--- a/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
+++ b/src/modules/checkpoints/feature/CheckpointDetailPanelContainer.tsx
@@ -91,10 +91,7 @@ function CheckpointDetailPanelContentContainer({
 					<CheckpointDetailPanelInfo checkpoint={detailsData} />
 				)}
 				{activeTab === "code" && (
-					<CheckpointDetailPanelSourceCode
-						sourceCode={detailsData.sourceCode}
-						sourceFilePath={detailsData.sourceFilePath}
-					/>
+					<CheckpointDetailPanelSourceCode source={detailsData.source} />
 				)}
 				{activeTab === "artifacts" && (
 					<CheckpointDetailPanelArtifacts

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelSourceCode.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelSourceCode.tsx
@@ -13,22 +13,19 @@ import {
 import { Separator } from "@/shared/ui/separator";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
 import { TruncatedText } from "@/shared/ui/truncated-text";
+import type { CheckpointSource } from "../domain/checkpoint";
+import { filePathToFileName } from "../util/file-path";
 
 interface CheckpointDetailPanelSourceCodeProps {
-	sourceCode?: string;
-	sourceFilePath?: string;
+	source?: CheckpointSource;
 }
 
 export function CheckpointDetailPanelSourceCode({
-	sourceCode,
-	sourceFilePath,
+	source,
 }: CheckpointDetailPanelSourceCodeProps) {
 	const { copied, copy } = useCopy();
-	const fileName = sourceFilePath
-		? (sourceFilePath.split("/").pop()?.replace(/\.py$/, "") ?? sourceFilePath)
-		: undefined;
 
-	if (!sourceCode) {
+	if (!source) {
 		return (
 			<div className="flex flex-1 flex-col items-center justify-center gap-1 p-4 text-center">
 				<p className="text-foreground text-xs font-medium">
@@ -41,6 +38,10 @@ export function CheckpointDetailPanelSourceCode({
 		);
 	}
 
+	const fileName = source.filePath
+		? filePathToFileName(source.filePath)
+		: undefined;
+
 	return (
 		<div className="flex h-full flex-col">
 			<Dialog>
@@ -52,9 +53,9 @@ export function CheckpointDetailPanelSourceCode({
 								{fileName}
 							</div>
 						)}
-						{sourceFilePath && (
+						{source.filePath && (
 							<div className="text-2xs text-muted-foreground truncate">
-								{sourceFilePath}
+								{source.filePath}
 							</div>
 						)}
 					</div>
@@ -65,7 +66,7 @@ export function CheckpointDetailPanelSourceCode({
 									<Button
 										variant="ghost"
 										size="icon-sm"
-										onClick={() => copy(sourceCode)}
+										onClick={() => copy(source.code)}
 										aria-label="Copy source code"
 									>
 										{copied ? (
@@ -99,7 +100,7 @@ export function CheckpointDetailPanelSourceCode({
 					</div>
 				</div>
 				<div className="min-h-0 flex-1 overflow-auto">
-					<CodeBlock code={sourceCode} language="python" />
+					<CodeBlock code={source.code} language="python" />
 				</div>
 				<DialogContent
 					showCloseButton={false}
@@ -107,13 +108,13 @@ export function CheckpointDetailPanelSourceCode({
 				>
 					<DialogHeader className="bg-muted/50 flex-row items-center justify-between gap-2 px-4 py-2">
 						<DialogTitle className="text-foreground min-w-0 flex-1 text-xs font-semibold">
-							<TruncatedText>{sourceFilePath ?? "Source code"}</TruncatedText>
+							<TruncatedText>{source.filePath ?? "Source code"}</TruncatedText>
 						</DialogTitle>
 						<div className="flex items-center gap-1">
 							<Button
 								variant="ghost"
 								size="icon-sm"
-								onClick={() => copy(sourceCode)}
+								onClick={() => copy(source.code)}
 								aria-label="Copy source code"
 							>
 								{copied ? (
@@ -134,7 +135,7 @@ export function CheckpointDetailPanelSourceCode({
 					</DialogHeader>
 					<Separator />
 					<div className="min-h-0 flex-1 overflow-auto">
-						<CodeBlock code={sourceCode} language="python" />
+						<CodeBlock code={source.code} language="python" />
 					</div>
 				</DialogContent>
 			</Dialog>

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelSourceCode.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelSourceCode.tsx
@@ -1,0 +1,143 @@
+import { Check, Copy, Expand, File, X } from "lucide-react";
+import { useCopy } from "@/shared/business-logic/use-copy";
+import { Button } from "@/shared/ui/button";
+import { CodeBlock } from "@/shared/ui/CodeBlock";
+import {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogTrigger,
+} from "@/shared/ui/dialog";
+import { Separator } from "@/shared/ui/separator";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/shared/ui/tooltip";
+import { TruncatedText } from "@/shared/ui/truncated-text";
+
+interface CheckpointDetailPanelSourceCodeProps {
+	sourceCode?: string;
+	sourceFilePath?: string;
+}
+
+export function CheckpointDetailPanelSourceCode({
+	sourceCode,
+	sourceFilePath,
+}: CheckpointDetailPanelSourceCodeProps) {
+	const { copied, copy } = useCopy();
+	const fileName = sourceFilePath
+		? (sourceFilePath.split("/").pop()?.replace(/\.py$/, "") ?? sourceFilePath)
+		: undefined;
+
+	if (!sourceCode) {
+		return (
+			<div className="flex flex-1 flex-col items-center justify-center gap-1 p-4 text-center">
+				<p className="text-foreground text-xs font-medium">
+					No source code available.
+				</p>
+				<p className="text-muted-foreground text-xs">
+					Source code is not recorded for this checkpoint.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			<Dialog>
+				<div className="border-border flex shrink-0 items-center gap-2.5 border-b px-4 py-3">
+					<File className="text-muted-foreground size-3.5 shrink-0" />
+					<div className="min-w-0 flex-1">
+						{fileName && (
+							<div className="text-foreground truncate font-mono text-xs font-semibold">
+								{fileName}
+							</div>
+						)}
+						{sourceFilePath && (
+							<div className="text-2xs text-muted-foreground truncate">
+								{sourceFilePath}
+							</div>
+						)}
+					</div>
+					<div className="flex shrink-0 items-center gap-0.5">
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										onClick={() => copy(sourceCode)}
+										aria-label="Copy source code"
+									>
+										{copied ? (
+											<Check className="text-success size-3.5" />
+										) : (
+											<Copy className="size-3.5" />
+										)}
+									</Button>
+								}
+							/>
+							<TooltipContent>{copied ? "Copied" : "Copy"}</TooltipContent>
+						</Tooltip>
+						<Tooltip>
+							<TooltipTrigger
+								render={
+									<DialogTrigger
+										render={
+											<Button
+												variant="ghost"
+												size="icon-sm"
+												aria-label="Open fullscreen"
+											>
+												<Expand className="size-3.5" />
+											</Button>
+										}
+									/>
+								}
+							/>
+							<TooltipContent>Fullscreen</TooltipContent>
+						</Tooltip>
+					</div>
+				</div>
+				<div className="min-h-0 flex-1 overflow-auto">
+					<CodeBlock code={sourceCode} language="python" />
+				</div>
+				<DialogContent
+					showCloseButton={false}
+					className="flex h-[90vh] w-[90vw] flex-col gap-0 p-0 sm:max-w-[90vw]"
+				>
+					<DialogHeader className="bg-muted/50 flex-row items-center justify-between gap-2 px-4 py-2">
+						<DialogTitle className="text-foreground min-w-0 flex-1 text-xs font-semibold">
+							<TruncatedText>{sourceFilePath ?? "Source code"}</TruncatedText>
+						</DialogTitle>
+						<div className="flex items-center gap-1">
+							<Button
+								variant="ghost"
+								size="icon-sm"
+								onClick={() => copy(sourceCode)}
+								aria-label="Copy source code"
+							>
+								{copied ? (
+									<Check className="text-success size-3.5" />
+								) : (
+									<Copy className="size-3.5" />
+								)}
+							</Button>
+							<DialogClose
+								render={
+									<Button variant="ghost" size="icon-sm">
+										<X className="text-foreground size-3.5" />
+										<span className="sr-only">Close</span>
+									</Button>
+								}
+							/>
+						</div>
+					</DialogHeader>
+					<Separator />
+					<div className="min-h-0 flex-1 overflow-auto">
+						<CodeBlock code={sourceCode} language="python" />
+					</div>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/shared/utils/styles";
 
-export type PanelTab = "checkpoint" | "code" | "artifacts" | "memory" | "logs";
-
 const TABS = ["logs", "checkpoint", "code", "artifacts", "memory"] as const;
+
+export type PanelTab = (typeof TABS)[number];
 
 interface CheckpointDetailPanelTabsProps {
 	activeTab: PanelTab;

--- a/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
+++ b/src/modules/checkpoints/ui/CheckpointDetailPanelTabs.tsx
@@ -1,8 +1,8 @@
 import { cn } from "@/shared/utils/styles";
 
-export type PanelTab = "checkpoint" | "artifacts" | "memory" | "logs";
+export type PanelTab = "checkpoint" | "code" | "artifacts" | "memory" | "logs";
 
-const TABS = ["logs", "checkpoint", "artifacts", "memory"] as const;
+const TABS = ["logs", "checkpoint", "code", "artifacts", "memory"] as const;
 
 interface CheckpointDetailPanelTabsProps {
 	activeTab: PanelTab;

--- a/src/modules/checkpoints/util/file-path.spec.ts
+++ b/src/modules/checkpoints/util/file-path.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { filePathToFileName, pythonModuleToFilePath } from "./file-path";
+
+describe("pythonModuleToFilePath", () => {
+	it("converts dotted module path to filesystem path with .py", () => {
+		expect(pythonModuleToFilePath("src.flows.content_pipeline")).toBe(
+			"src/flows/content_pipeline.py"
+		);
+	});
+
+	it("handles a single-segment module", () => {
+		expect(pythonModuleToFilePath("main")).toBe("main.py");
+	});
+});
+
+describe("filePathToFileName", () => {
+	it("returns the basename without the file extension", () => {
+		expect(filePathToFileName("src/flows/content_pipeline.py")).toBe(
+			"content_pipeline"
+		);
+	});
+
+	it("strips any single extension", () => {
+		expect(filePathToFileName("src/flows/notebook.ipynb")).toBe("notebook");
+	});
+
+	it("returns the basename when the path has no slashes", () => {
+		expect(filePathToFileName("main.py")).toBe("main");
+	});
+
+	it("returns the basename unchanged when there is no extension", () => {
+		expect(filePathToFileName("src/flows/main")).toBe("main");
+	});
+});

--- a/src/modules/checkpoints/util/file-path.ts
+++ b/src/modules/checkpoints/util/file-path.ts
@@ -1,0 +1,8 @@
+export function pythonModuleToFilePath(module: string): string {
+	return `${module.replace(/\./g, "/")}.py`;
+}
+
+export function filePathToFileName(filePath: string): string {
+	// Strip the directory prefix (everything up to the last "/"), then the file extension.
+	return filePath.replace(/^.*\//, "").replace(/\.[^./]+$/, "");
+}


### PR DESCRIPTION

<img width="1512" height="830" alt="image" src="https://github.com/user-attachments/assets/32b61c91-cda0-4dd3-8a89-a657b0ccdbcb" />


## Summary
- Adds a `Code` tab to the checkpoint detail panel that displays the step's source code via `metadata.source_code`.
- New `CheckpointDetailPanelSourceCode` component shows a flat header (file icon + bold filename + module path) with copy and fullscreen actions, matching the prototype layout.
- `Checkpoint` domain gains `sourceCode` and `sourceFilePath` (derived from `metadata.spec.source.module`).

## Test plan
- [ ] `pnpm check:types`
- [ ] `pnpm test:unit src/modules/checkpoints/domain/checkpoint.spec.ts`
- [ ] Open a checkpoint with a recorded source function → Code tab renders filename + path + syntax-highlighted Python.
- [ ] Click the copy icon → source copied to clipboard.
- [ ] Click the expand icon → fullscreen dialog opens with the same code; close via X.
- [ ] Open a checkpoint with no recorded source → Code tab shows the empty-state message.