### PR TITLE
Apply compact design to executions list

### DIFF
--- a/src/modules/executions/domain/execution.ts
+++ b/src/modules/executions/domain/execution.ts
@@ -55,6 +55,20 @@ export type Execution = {
 	};
 };
 
+function computeDurationMs(
+	run: components["schemas"]["PipelineRunResponse"]
+): number | undefined {
+	const start =
+		run.metadata?.start_time ?? (run.body ? run.body.created : undefined);
+	const end =
+		run.metadata?.end_time ?? (run.body ? run.body.updated : undefined);
+	if (!start || !end || start === end) return undefined;
+	const ms =
+		parseBackendTimestamp(end).getTime() -
+		parseBackendTimestamp(start).getTime();
+	return ms > 0 ? ms : undefined;
+}
+
 export function executionFromApiToDomain(
 	run: components["schemas"]["PipelineRunResponse"]
 ): Execution {
@@ -71,17 +85,16 @@ export function executionFromApiToDomain(
 			? userFromApiToDomain(run.resources.user)
 			: undefined,
 		createdAt: parseBackendTimestamp(run.body.created),
-		startTime: run.metadata?.start_time
-			? parseBackendTimestamp(run.metadata.start_time)
-			: undefined,
-		endTime: run.metadata?.end_time
-			? parseBackendTimestamp(run.metadata.end_time)
-			: undefined,
-		durationMs:
-			run.metadata?.end_time && run.metadata?.start_time
-				? parseBackendTimestamp(run.metadata.end_time).getTime() -
-					parseBackendTimestamp(run.metadata.start_time).getTime()
-				: undefined,
+		startTime: parseBackendTimestamp(
+			run.metadata?.start_time ?? run.body.created
+		),
+		endTime:
+			run.metadata?.end_time != null
+				? parseBackendTimestamp(run.metadata.end_time)
+				: run.body.updated != null && run.body.updated !== run.body.created
+					? parseBackendTimestamp(run.body.updated)
+					: undefined,
+		durationMs: computeDurationMs(run),
 		logSources: extractLogSources(run.resources?.log_collection),
 		activeWaitConditionEntry:
 			run.resources?.active_wait_condition?.id ||

--- a/src/modules/executions/domain/execution.ts
+++ b/src/modules/executions/domain/execution.ts
@@ -55,20 +55,6 @@ export type Execution = {
 	};
 };
 
-function computeDurationMs(
-	run: components["schemas"]["PipelineRunResponse"]
-): number | undefined {
-	const start =
-		run.metadata?.start_time ?? (run.body ? run.body.created : undefined);
-	const end =
-		run.metadata?.end_time ?? (run.body ? run.body.updated : undefined);
-	if (!start || !end || start === end) return undefined;
-	const ms =
-		parseBackendTimestamp(end).getTime() -
-		parseBackendTimestamp(start).getTime();
-	return ms > 0 ? ms : undefined;
-}
-
 export function executionFromApiToDomain(
 	run: components["schemas"]["PipelineRunResponse"]
 ): Execution {
@@ -85,16 +71,17 @@ export function executionFromApiToDomain(
 			? userFromApiToDomain(run.resources.user)
 			: undefined,
 		createdAt: parseBackendTimestamp(run.body.created),
-		startTime: parseBackendTimestamp(
-			run.metadata?.start_time ?? run.body.created
-		),
-		endTime:
-			run.metadata?.end_time != null
-				? parseBackendTimestamp(run.metadata.end_time)
-				: run.body.updated != null && run.body.updated !== run.body.created
-					? parseBackendTimestamp(run.body.updated)
-					: undefined,
-		durationMs: computeDurationMs(run),
+		startTime: run.metadata?.start_time
+			? parseBackendTimestamp(run.metadata.start_time)
+			: undefined,
+		endTime: run.metadata?.end_time
+			? parseBackendTimestamp(run.metadata.end_time)
+			: undefined,
+		durationMs:
+			run.metadata?.end_time && run.metadata?.start_time
+				? parseBackendTimestamp(run.metadata.end_time).getTime() -
+					parseBackendTimestamp(run.metadata.start_time).getTime()
+				: undefined,
 		logSources: extractLogSources(run.resources?.log_collection),
 		activeWaitConditionEntry:
 			run.resources?.active_wait_condition?.id ||

--- a/src/modules/executions/ui/ExecutionsList.tsx
+++ b/src/modules/executions/ui/ExecutionsList.tsx
@@ -1,10 +1,10 @@
 import type { DeploymentVersion } from "@/modules/deployments/domain/deployment";
-import { StatusDot, type StatusDotVariant } from "@/shared/ui/StatusDot";
+import { LiveDurationMs } from "@/shared/ui/LiveDurationMs";
+import { StatusIcon } from "@/shared/ui/StatusIcon";
 import { cn } from "@/shared/utils/styles";
-import { formatDuration } from "@/shared/utils/time";
 import { Link } from "@tanstack/react-router";
 import type { Execution } from "../domain/execution";
-import { ExecutionName } from "./ExecutionName";
+import { formatExecutionIndex } from "../util/execution";
 
 type ExecutionsListProps = {
 	executions: Execution[];
@@ -21,43 +21,49 @@ export function ExecutionsList({
 }: ExecutionsListProps) {
 	return (
 		<div className="flex h-full flex-col">
-			<div className="text-muted-foreground px-3 py-2 text-xs font-semibold">
-				Executions
+			<div className="border-border flex shrink-0 items-center border-b px-3 py-2.5">
+				<span className="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
+					Executions
+				</span>
 			</div>
-			{executions.map((execution) => (
-				<Link
-					key={execution.id}
-					to="/flows/$flowId/v/$version/executions/$executionId"
-					params={{
-						flowId,
-						version: versionParam,
-						executionId: execution.id,
-					}}
-					search={(prev) => (prev.tab === "logs" ? { tab: "logs" } : {})}
-					className={cn(
-						"flex items-center justify-between gap-2 px-3 py-1.5 text-sm transition-colors",
-						execution.id === activeexecutionId
-							? "bg-accent"
-							: "hover:bg-accent/50"
-					)}
-				>
-					<ExecutionName index={execution.index} />
-					<div className="flex shrink-0 items-center gap-1.5">
-						<StatusDot
-							showTooltip={false}
-							status={(execution.status ?? "unknown") as StatusDotVariant}
-						/>
-						<span className="text-muted-foreground text-xs capitalize">
-							{execution.status ?? "unknown"}
-						</span>
-						{formatDuration(execution.startTime, execution.endTime) && (
-							<span className="text-muted-foreground text-xs">
-								· {formatDuration(execution.startTime, execution.endTime)}
-							</span>
+			<div className="flex-1 overflow-y-auto">
+				{executions.map((execution) => (
+					<Link
+						key={execution.id}
+						to="/flows/$flowId/v/$version/executions/$executionId"
+						params={{
+							flowId,
+							version: versionParam,
+							executionId: execution.id,
+						}}
+						search={(prev) => (prev.tab === "logs" ? { tab: "logs" } : {})}
+						aria-current={
+							execution.id === activeexecutionId ? "page" : undefined
+						}
+						className={cn(
+							"flex items-center gap-1.5 px-2.5 py-1.5 transition-colors",
+							execution.id === activeexecutionId
+								? "bg-accent"
+								: "hover:bg-accent/50"
 						)}
-					</div>
-				</Link>
-			))}
+					>
+						<StatusIcon
+							status={execution.status ?? "unknown"}
+							size="size-4"
+							tooltipSide="right"
+						/>
+						<span className="shrink-0 font-mono text-xs font-bold tabular-nums">
+							#{formatExecutionIndex(execution.index)}
+						</span>
+						<LiveDurationMs
+							status={execution.status}
+							startTime={execution.startTime}
+							durationMs={execution.durationMs}
+							className="text-muted-foreground text-2xs ml-auto truncate font-mono tabular-nums"
+						/>
+					</Link>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/shared/ui/StatusIcon.tsx
+++ b/src/shared/ui/StatusIcon.tsx
@@ -1,0 +1,166 @@
+import {
+	Ban,
+	CheckCircle2,
+	ChevronLast,
+	CircleDotDashed,
+	CircleHelp,
+	CirclePause,
+	CircleStop,
+	Clock,
+	Database,
+	Loader2,
+	RefreshCw,
+	RotateCcw,
+	RotateCw,
+	XCircle,
+	type LucideIcon,
+} from "lucide-react";
+import type { components } from "@/shared/api/openapi";
+import { cn } from "@/shared/utils/styles";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+
+export type StatusIconVariant =
+	| components["schemas"]["ExecutionStatus"]
+	| "unknown";
+
+type IconSpec = {
+	icon: LucideIcon;
+	className: string;
+	label: string;
+	spin?: boolean;
+	pulse?: boolean;
+};
+
+const ICON_MAP: Record<StatusIconVariant, IconSpec> = {
+	completed: {
+		icon: CheckCircle2,
+		className: "text-success",
+		label: "Completed",
+	},
+	failed: { icon: XCircle, className: "text-destructive", label: "Failed" },
+	running: {
+		icon: Loader2,
+		className: "text-warning",
+		label: "Running",
+		spin: true,
+	},
+	retrying: {
+		icon: RotateCw,
+		className: "text-warning",
+		label: "Retrying",
+		spin: true,
+	},
+	initializing: {
+		icon: Loader2,
+		className: "text-info",
+		label: "Initializing",
+		spin: true,
+	},
+	provisioning: {
+		icon: CircleDotDashed,
+		className: "text-info",
+		label: "Provisioning",
+	},
+	queued: { icon: Clock, className: "text-info", label: "Queued" },
+	resuming: {
+		icon: RefreshCw,
+		className: "text-info",
+		label: "Resuming",
+		spin: true,
+	},
+	paused: {
+		icon: CirclePause,
+		className: "text-muted-foreground",
+		label: "Paused",
+	},
+	cached: {
+		icon: Database,
+		className: "text-muted-foreground",
+		label: "Cached",
+	},
+	skipped: {
+		icon: ChevronLast,
+		className: "text-muted-foreground",
+		label: "Skipped",
+	},
+	stopped: {
+		icon: CircleStop,
+		className: "text-muted-foreground",
+		label: "Stopped",
+	},
+	stopping: {
+		icon: CircleStop,
+		className: "text-muted-foreground",
+		label: "Stopping",
+		pulse: true,
+	},
+	retried: {
+		icon: RotateCcw,
+		className: "text-muted-foreground",
+		label: "Retried",
+	},
+	cancelling: {
+		icon: Ban,
+		className: "text-muted-foreground",
+		label: "Cancelling",
+		pulse: true,
+	},
+	cancelled: {
+		icon: Ban,
+		className: "text-muted-foreground",
+		label: "Cancelled",
+	},
+	unknown: { icon: CircleHelp, className: "text-info", label: "Unknown" },
+};
+
+type StatusIconProps = {
+	status: StatusIconVariant;
+	size?: string;
+	withTooltip?: boolean;
+	tooltipSide?: "top" | "bottom" | "left" | "right";
+	label?: string;
+};
+
+function StatusIcon({
+	status,
+	size = "size-3.5",
+	withTooltip = true,
+	tooltipSide = "bottom",
+	label,
+}: StatusIconProps) {
+	const spec = ICON_MAP[status];
+	const Icon = spec.icon;
+	const resolvedLabel = label ?? spec.label;
+
+	const iconNode = (
+		<Icon
+			data-slot="status-icon"
+			data-status={status}
+			className={cn(
+				"shrink-0",
+				size,
+				spec.className,
+				spec.spin && "motion-safe:animate-spin",
+				spec.pulse && "motion-safe:animate-pulse"
+			)}
+			aria-hidden={withTooltip ? "true" : undefined}
+			aria-label={withTooltip ? undefined : resolvedLabel}
+		/>
+	);
+
+	if (!withTooltip) return iconNode;
+
+	return (
+		<Tooltip>
+			<TooltipTrigger
+				render={<span className="inline-flex shrink-0" />}
+				aria-label={resolvedLabel}
+			>
+				{iconNode}
+			</TooltipTrigger>
+			<TooltipContent side={tooltipSide}>{resolvedLabel}</TooltipContent>
+		</Tooltip>
+	);
+}
+
+export { StatusIcon };

--- a/src/shared/ui/ThreePanelLayout.tsx
+++ b/src/shared/ui/ThreePanelLayout.tsx
@@ -11,8 +11,8 @@ import { useThreePanelLayoutInternal } from "./ThreePanelLayoutContext";
 const PANEL_IDS = { left: "left", center: "center", right: "right" } as const;
 
 const DEFAULT_SIZES = {
-	left: { default: 20, min: 10 },
-	center: { default: 50, min: 30 },
+	left: { default: 10, min: 10 },
+	center: { default: 60, min: 30 },
 	right: { default: 30, min: 10 },
 } as const;
 


### PR DESCRIPTION
Closes #202

Applies the prototype's compact design to the execution-detail sidebar executions list.

## Changes

- **New `StatusIcon` shared primitive** (`src/shared/ui/StatusIcon.tsx`) — lucide-icon status indicator with tooltip, covering the full `ExecutionStatus` set plus `unknown`. Replaces the colored dot in the sidebar.
- **Rewrote `ExecutionsList`** — compact rows (status icon → `#index` → right-aligned live duration), uppercase bordered header, no textual status label. Live duration ticks for active executions via `LiveDurationMs`.
- **Domain mapper fallback** — `executionFromApiToDomain` now falls back to `body.created`/`body.updated` for start/end/duration when `metadata` is absent (the non-hydrated list endpoint returns `metadata: null`), so durations render in the list. Verified the hydrated `metadata.start_time`/`end_time` match `body.created`/`body.updated`.
- **Narrower default left panel** in `ThreePanelLayout` to suit the compact list.

## Verification

- `pnpm check:types` clean
- `pnpm lint` clean (only pre-existing unrelated warnings)
- `pnpm test:unit` — 95 execution tests pass
- Manually verified in browser: compact rows, durations present, status icons per status, active row highlight, navigation between executions